### PR TITLE
In 133203085 add notify on ci failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,6 +2,7 @@ node {
     checkout scm
     def branch = env.BRANCH_NAME ?: 'master'
     def curStage = 'Start'
+    def emailList = EMAIL_NOTIFICATION_LIST ?: 'thomas.ramirez@osi.ca.gov'
 
     try {
         stage('Test') {
@@ -44,9 +45,9 @@ node {
     }
     catch (e) {
         emailext (
-            to: "${EMAIL_NOTIFICATION_LIST}",
+            to: emailList,
             subject: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' in stage ${curStage}",
-            body: """<p>FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' in stage ${curStage}, branch ${branch}:</p>
+            body: """<p>FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' in stage '${curStage}' for branch '${branch}':</p>
                 <p>Check console output at &QUOT;<a href='${env.BUILD_URL}'>${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>&QUOT;</p>"""
         )
         throw e

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,22 +1,27 @@
 node {
     checkout scm
     def branch = env.BRANCH_NAME ?: 'master'
+    def curStage = 'Start'
 
     try {
         stage('Test') {
+            curStage = 'Test'
             sh 'make test'
         }
 
         if (branch == 'master') {
           stage('Build') {
+              curStage = 'Build'
               sh 'make build'
           }
 
           stage('Release') {
+              curStage = 'Release'
               sh 'make release'
           }
 
           stage('Publish') {
+              curStage = 'Publish'
               sh "make tag latest \$(git rev-parse --short HEAD)"
               withEnv(["DOCKER_USER=${DOCKER_USER}",
                        "DOCKER_PASSWORD=${DOCKER_PASSWORD}"]) {
@@ -26,6 +31,7 @@ node {
           }
 
           stage('Deploy') {
+              curStage = 'Deploy'
               sh "printf \$(git rev-parse --short HEAD) > tag.tmp"
               def imageTag = readFile 'tag.tmp'
               build job: DEPLOY_JOB, parameters: [[
@@ -35,6 +41,15 @@ node {
               ]]
           }
         }
+    }
+    catch (e) {
+        emailext (
+            to: "${EMAIL_NOTIFICATION_LIST}",
+            subject: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' in stage ${curStage}",
+            body: """<p>FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' in stage ${curStage}, branch ${branch}:</p>
+                <p>Check console output at &QUOT;<a href='${env.BUILD_URL}'>${env.JOB_NAME} [${env.BUILD_NUMBER}]</a>&QUOT;</p>"""
+        )
+        throw e
     }
     finally {
         stage ('Reports') {


### PR DESCRIPTION
@pemaOSI I'm waiting for my Slack token to be approved but would like you to take a look at the changes before I apply them to the API prototype side.  The current code generates emails that have a clickable link to the job that failed and look like this:

<img width="540" alt="screen shot 2016-10-31 at 4 41 27 pm" src="https://cloud.githubusercontent.com/assets/22504156/19875312/07e67a18-9f89-11e6-952a-21a80389eee9.png">
