### PR TITLE
Redirect logs to Standard Output in line with Docker.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,7 @@ module CaIntake # :nodoc:
   # CA Intake configurations are set here.
   class Application < Rails::Application # :nodoc:
     config.autoload_paths << Rails.root.join('lib')
+    config.logger = Logger.new(STDOUT)
+    config.log_level = :debug
   end
 end


### PR DESCRIPTION
Logs redirected to STDOUT goes into docker logs which is being used to import/export logs.