### PR TITLE
Fix merge behavior of nested objects when editing a screening

### DIFF
--- a/app/assets/javascripts/components/screenings/ScreeningEditPage.jsx
+++ b/app/assets/javascripts/components/screenings/ScreeningEditPage.jsx
@@ -35,6 +35,7 @@ export class ScreeningEditPage extends React.Component {
       'setField',
       'setParticipantField',
       'saveParticipant',
+      'mergeScreeningWithEdits',
     ]
     methods.forEach((method) => {
       this[method] = this[method].bind(this)
@@ -66,7 +67,7 @@ export class ScreeningEditPage extends React.Component {
     const changes = this.state.screeningEdits.filter((value, key) =>
       fieldList.includes(key) && value !== undefined
     )
-    const screening = this.state.screening.merge(changes)
+    const screening = this.mergeScreeningWithEdits(changes)
     return this.props.actions.saveScreening(screening.toJS())
   }
 
@@ -95,6 +96,15 @@ export class ScreeningEditPage extends React.Component {
       .then(() => {
         this.props.actions.fetchScreening(this.props.params.id)
       })
+  }
+
+  mergeScreeningWithEdits(changes) {
+    const crossReportEdits = changes.get('cross_reports')
+    if (crossReportEdits) {
+      return this.state.screening.set('cross_reports', crossReportEdits).mergeDeep(changes)
+    } else {
+      return this.state.screening.mergeDeep(changes)
+    }
   }
 
   participants() {
@@ -152,7 +162,7 @@ export class ScreeningEditPage extends React.Component {
 
   render() {
     const {screening, loaded} = this.state
-    const mergedScreening = screening.merge(this.state.screeningEdits)
+    const mergedScreening = this.mergeScreeningWithEdits(this.state.screeningEdits)
     return (
       <div>
         <h1>{`Edit Screening #${mergedScreening.get('reference')}`}</h1>

--- a/app/assets/javascripts/components/screenings/ScreeningShowPage.jsx
+++ b/app/assets/javascripts/components/screenings/ScreeningShowPage.jsx
@@ -32,6 +32,7 @@ export class ScreeningShowPage extends React.Component {
     this.saveParticipant = this.saveParticipant.bind(this)
     this.setParticipantField = this.setParticipantField.bind(this)
     this.cancelParticipantEdit = this.cancelParticipantEdit.bind(this)
+    this.mergeScreeningWithEdits = this.mergeScreeningWithEdits.bind(this)
   }
 
   componentDidMount() {
@@ -54,7 +55,7 @@ export class ScreeningShowPage extends React.Component {
     const changes = this.state.screeningEdits.filter((value, key) =>
       fieldList.includes(key) && value !== undefined
     )
-    const screening = this.state.screening.merge(changes)
+    const screening = this.mergeScreeningWithEdits(changes)
     return this.props.actions.saveScreening(screening.toJS())
   }
 
@@ -82,6 +83,15 @@ export class ScreeningShowPage extends React.Component {
       .then(() => {
         this.props.actions.fetchScreening(this.props.params.id)
       })
+  }
+
+  mergeScreeningWithEdits(changes) {
+    const crossReportEdits = changes.get('cross_reports')
+    if (crossReportEdits) {
+      return this.state.screening.set('cross_reports', crossReportEdits).mergeDeep(changes)
+    } else {
+      return this.state.screening.mergeDeep(changes)
+    }
   }
 
   participants() {
@@ -122,7 +132,7 @@ export class ScreeningShowPage extends React.Component {
   render() {
     const {params} = this.props
     const {loaded, screening} = this.state
-    const mergedScreening = screening.merge(this.state.screeningEdits)
+    const mergedScreening = this.mergeScreeningWithEdits(this.state.screeningEdits)
     return (
       <div>
         <h1>{`Screening #${mergedScreening.get('reference')}`}</h1>

--- a/spec/features/screening/edit_screening_spec.rb
+++ b/spec/features/screening/edit_screening_spec.rb
@@ -251,6 +251,13 @@ feature 'individual card save' do
 
   scenario 'Incident information saves and cancels in isolation' do
     within '#incident-information-card', text: 'INCIDENT INFORMATION' do
+      existing_screening.address.assign_attributes(
+        street_address: '33 Whatever Rd',
+        city: 'Modesto',
+        state: 'TX',
+        zip: '57575',
+        type: nil
+      )
       existing_screening.incident_date = '1996-02-12'
 
       stub_request(:put, api_screening_path(existing_screening.id))
@@ -258,6 +265,10 @@ feature 'individual card save' do
         .and_return(json_body(existing_screening.to_json))
 
       fill_in 'Incident Date', with: '1996-02-12'
+      fill_in 'Address', with: '33 Whatever Rd'
+      fill_in 'City', with: 'Modesto'
+      select 'Texas', from: 'State'
+      fill_in 'Zip', with: '57575'
       click_button 'Save'
 
       expect(

--- a/spec/features/screening/incident_information_spec.rb
+++ b/spec/features/screening/incident_information_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 require 'support/factory_girl'
 
 feature 'screening incident information card' do
-  scenario 'user edits incident card from screening edit page and saves' do
-    existing_screening = FactoryGirl.create(
+  let(:existing_screening) do
+    FactoryGirl.create(
       :screening,
       incident_county: 'colusa',
       incident_date: '2016-08-11',
@@ -20,11 +20,33 @@ feature 'screening incident information card' do
       location_type: "Child's Home",
       report_narrative: 'Some kind of narrative'
     )
+  end
+
+  before(:each) do
     stub_request(:get, api_screening_path(existing_screening.id))
       .and_return(json_body(existing_screening.to_json))
-
     visit edit_screening_path(id: existing_screening.id)
+  end
 
+  scenario 'screening<->address edit merging should not override unchanged values' do
+    existing_screening.address.assign_attributes(
+      street_address: '33 Whatever'
+    )
+    stub_request(:put, api_screening_path(existing_screening.id))
+      .with(json_body(as_json_without_root_id(existing_screening)))
+      .and_return(json_body(existing_screening.to_json))
+    within '#incident-information-card.edit' do
+      fill_in 'Address', with: '33 Whatever Rd'
+      find_field('street_address').send_keys [:backspace, :backspace, :backspace]
+      click_button 'Save'
+      expect(
+        a_request(:put, api_screening_path(existing_screening.id))
+        .with(json_body(as_json_without_root_id(existing_screening)))
+      ).to have_been_made
+    end
+  end
+
+  scenario 'user edits incident card from screening edit page and saves' do
     within '#incident-information-card.edit' do
       expect(page).to have_field('Incident Date', with: '2016-08-11')
       expect(page).to have_field('Incident County', with: 'colusa')


### PR DESCRIPTION
- set cross_reports instead of merging (merging array issue)
- change merge logic back to mergeDeep (fix address field overrides)
- revert spec deletions and ensure specs were correct

[#142882533]