### PR TITLE
Tag app with timestamp and commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ node('Slave') {
 
             stage('Publish') {
                 curStage = 'Publish'
-                sh "make tag latest \$(git rev-parse --short HEAD)"
+                sh "make tag.default"
                 withEnv(["DOCKER_USER=${DOCKER_USER}",
                          "DOCKER_PASSWORD=${DOCKER_PASSWORD}"]) {
                     sh "make login"

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,6 @@ REPO_NAME ?= intake
 # DOCKER_LOGIN_EXPRESSION := eval $$(aws ecr get-login --registry-ids $(AWS_ACCOUNT_ID))
 
 export HTTP_PORT ?= 81
-export APP_VERSION ?= 1.$(GIT_HASH)
 
 include Makefile.settings
 
@@ -74,7 +73,7 @@ tag:
 	${INFO} "Tagging complete"
 
 tag%default:
-	@ make tag latest $(APP_VERSION) $(GIT_TAG)
+	@ make tag latest $(APP_VERSION) $(GIT_TAG) $(GIT_HASH)
 
 login:
 	${INFO} "Logging in to Docker registry $$DOCKER_REGISTRY..."


### PR DESCRIPTION
Tags docker images with latest, commit, timestamp.commit, git tag.
Changes Jenkinsfile to use 'make tag.default' instead of 'make.tag'
Fixes APP_VERSION to be timestamp.commit