### PR TITLE
In 143818717 docker watch

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -159,6 +159,6 @@ gulp.task('version-assets', function () {
   .pipe(gulp.dest('public/assets'))
 })
 
-gulp.task('watch', ['default', 'server'], function() {
+gulp.task('watch', ['default'], function() {
   gulp.watch(['app/assets/javascripts/**/*'], ['default'])
 })

--- a/bin/docker_start
+++ b/bin/docker_start
@@ -4,4 +4,4 @@ bundle check || bundle install
 npm install
 bin/gulp
 
-while true; do bin/gulp watch; done & bundle exec puma
+bin/gulp server & bundle exec puma

--- a/spec/support/assets_gulp.rb
+++ b/spec/support/assets_gulp.rb
@@ -1,20 +1,6 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
-  did_gen_assets = false
-  build_already_failed = false
-
-  config.around(:example, type: :feature) do |example|
-    if !build_already_failed && !did_gen_assets
-      build_success = system 'bin/gulp'
-      if build_success
-        did_gen_assets = true
-      else
-        build_already_failed = true
-      end
-    end
-
-    raise 'Failed to build modular JS assets!' if build_already_failed
-
-    example.run
+  config.before(:suite) do |example|
+    raise 'Failed to build modular JS assets!' unless system 'bin/gulp'
   end
 end

--- a/spec/support/assets_gulp.rb
+++ b/spec/support/assets_gulp.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 RSpec.configure do |config|
-  config.before(:suite) do |example|
+  config.before(:suite) do |_example|
     raise 'Failed to build modular JS assets!' unless system 'bin/gulp'
   end
 end


### PR DESCRIPTION
Fixes Gulp/Docker on Dev machines. Docker for Mac's filesystem handling of change events is unreliable and leads to a proliferation of change events, triggering many async gulp processes that step on each other and break tests.

Also refactored the login feature spec after investigating new failures.