### PR TITLE
In 148172759 hide copy button on ie

### DIFF
--- a/app/assets/javascripts/components/screenings/HistoryCard.jsx
+++ b/app/assets/javascripts/components/screenings/HistoryCard.jsx
@@ -5,6 +5,7 @@ import HistoryCardScreening from 'components/screenings/HistoryCardScreening'
 import PropTypes from 'prop-types'
 import React from 'react'
 import clipboard from 'clipboard-js'
+import {jsClipboardSupported} from 'config'
 
 export default class HistoryCard extends React.Component {
   constructor(props, context) {
@@ -78,16 +79,21 @@ export default class HistoryCard extends React.Component {
           { !emptyInvolvements &&
             <div className='row'>
               <div className='centered'>
-                <button
-                  onClick={() =>
-                    this.historyTable && clipboard.copy({
-                      'text/plain': this.historyTable.innerText,
-                      'text/html': this.historyTable.outerHTML,
-                    })}
-                  className='btn btn-primary'
-                >
-                  Copy
-                </button>
+                { jsClipboardSupported() &&
+                  <button
+                    onClick={() =>
+                      this.historyTable && clipboard.copy({
+                        'text/plain': this.historyTable.innerText,
+                        'text/html': this.historyTable.outerHTML,
+                      })}
+                    className='btn btn-primary'
+                  >
+                    Copy
+                  </button>
+                }
+                { !jsClipboardSupported() &&
+                  <p>To copy the history to your clipboard, select the above history table, click the right button of your mouse and select "Copy".</p>
+                }
               </div>
             </div>
           }

--- a/app/assets/javascripts/config.js
+++ b/app/assets/javascripts/config.js
@@ -9,3 +9,7 @@ export function isFeatureActive(feature) {
 export function isFeatureInactive(feature) {
   return !isFeatureActive(feature)
 }
+
+export function jsClipboardSupported() {
+  return window.clipboardData === undefined
+}

--- a/spec/javascripts/components/screenings/history/HistoryCardSpec.jsx
+++ b/spec/javascripts/components/screenings/history/HistoryCardSpec.jsx
@@ -4,6 +4,7 @@ import HistoryCard from 'components/screenings/HistoryCard'
 import React from 'react'
 import clipboard from 'clipboard-js'
 import {shallow, mount} from 'enzyme'
+import * as config from 'config'
 
 describe('HistoryCard', () => {
   const requiredProps = {
@@ -188,6 +189,14 @@ describe('HistoryCard', () => {
 
       describe('copy button', () => {
         const involvements = Immutable.fromJS({screenings: [Immutable.fromJS({id: 1})]})
+        it('shows help text instead of copybutton', () => {
+          spyOn(config, 'jsClipboardSupported').and.returnValue(false)
+          const component = shallow(<HistoryCard {...requiredProps} involvements={involvements} />)
+          expect(component.find('button[children="Copy"]').length).toEqual(0)
+          expect(component.text()).toContain(
+            'To copy the history to your clipboard, select the above history table, click the right button of your mouse and select "Copy".'
+          )
+        })
         it('does not render if there are no involvements', () => {
           const component = shallow(<HistoryCard {...requiredProps} />)
           expect(component.find('button[children="Copy"]').length).toEqual(0)
@@ -202,6 +211,9 @@ describe('HistoryCard', () => {
           const wrapper = mount(<HistoryCard {...requiredProps} involvements={involvements} />)
           const resultsTable = wrapper.find('table').node
           wrapper.find('button[children="Copy"]').simulate('click')
+          expect(wrapper.text()).not.toContain(
+            'To copy the history to your clipboard, select the above history table, click the right button of your mouse and select "Copy".'
+          )
           expect(copySpy).toHaveBeenCalledWith({
             'text/plain': resultsTable.innerText,
             'text/html': resultsTable.outerHTML,

--- a/spec/javascripts/configSpec.js
+++ b/spec/javascripts/configSpec.js
@@ -1,4 +1,4 @@
-import {isFeatureActive, isFeatureInactive, config} from 'config'
+import {isFeatureActive, isFeatureInactive, config, jsClipboardSupported} from 'config'
 
 describe('intake config', () => {
   let windowOrg
@@ -12,6 +12,17 @@ describe('intake config', () => {
 
     it('references window org intake config', () => {
       expect(config()).toEqual({test_config: true})
+    })
+  })
+
+  describe('.jsClipboardSupported', () => {
+    it('true when clipboardData (IE specific) is absent', () => {
+      window.clipboardData = {} // We can only spyOn methods that already exist
+      expect(jsClipboardSupported()).toEqual(false)
+      delete window.clipboardData
+    })
+    it('is true when clipboardData is missing', () => {
+      expect(jsClipboardSupported()).toEqual(true)
     })
   })
 

--- a/spec/support/helpers/datetime_helpers.rb
+++ b/spec/support/helpers/datetime_helpers.rb
@@ -5,7 +5,7 @@ module DateTimeHelpers
     zero_indexed_month = date.month - 1
     within locator do
       find('.rw-btn-calendar').click
-      find("[id$='cal_calendar__month_#{zero_indexed_month}-#{date.day}']").click
+      find("[id$='cal_calendar__month_#{zero_indexed_month}-#{date.day}']", visible: true).click
     end
   end
 


### PR DESCRIPTION
Hide copy button for IE11.

Also fixing a spec helper that was flaking due to visibility / timing issues.