### PR TITLE
In 150719135 Prep for Contacts Validator

### DIFF
--- a/app/javascript/common/CheckboxField.jsx
+++ b/app/javascript/common/CheckboxField.jsx
@@ -31,7 +31,7 @@ const CheckboxField = ({
 CheckboxField.propTypes = {
   checked: PropTypes.bool,
   disabled: PropTypes.bool,
-  errors: PropTypes.object,
+  errors: PropTypes.array,
   id: PropTypes.string.isRequired,
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,

--- a/app/javascript/common/DateField.jsx
+++ b/app/javascript/common/DateField.jsx
@@ -85,7 +85,7 @@ DateField.defaultProps = {
 }
 
 DateField.propTypes = {
-  errors: PropTypes.object,
+  errors: PropTypes.array,
   gridClassName: PropTypes.string,
   hasCalendar: PropTypes.bool,
   hasTime: PropTypes.bool,

--- a/app/javascript/common/ErrorMessages.jsx
+++ b/app/javascript/common/ErrorMessages.jsx
@@ -12,7 +12,7 @@ const ErrorMessages = ({id, errors}) => (
 )
 
 ErrorMessages.propTypes = {
-  errors: PropTypes.object,
+  errors: PropTypes.array,
   id: PropTypes.string,
 }
 export default ErrorMessages

--- a/app/javascript/common/FormField.jsx
+++ b/app/javascript/common/FormField.jsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 const FormField = ({children, errors, gridClassName, labelClassName, id, label, required}) => {
-  const hasErrors = errors && !errors.isEmpty()
+  const emptyArrayLength = 0
+  const hasErrors = errors && errors.length > emptyArrayLength
   const gridClassNames = ClassNames(gridClassName, {'input-error': hasErrors})
   const labelClassNames =
     ClassNames(labelClassName, {'input-error-label': hasErrors}, {required: required})
@@ -24,7 +25,7 @@ FormField.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.node,
   ]).isRequired,
-  errors: PropTypes.object,
+  errors: PropTypes.array,
   gridClassName: PropTypes.string,
   id: PropTypes.string,
   label: PropTypes.string.isRequired,

--- a/app/javascript/common/InputField.jsx
+++ b/app/javascript/common/InputField.jsx
@@ -58,7 +58,7 @@ InputField.defaultProps = {
 InputField.propTypes = {
   allowCharacters: PropTypes.instanceOf(RegExp),
   disabled: PropTypes.bool,
-  errors: PropTypes.object,
+  errors: PropTypes.array,
   gridClassName: PropTypes.string,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,

--- a/app/javascript/common/MaskedInputField.jsx
+++ b/app/javascript/common/MaskedInputField.jsx
@@ -41,7 +41,7 @@ MaskedInputField.defaultProps = {
 }
 
 MaskedInputField.propTypes = {
-  errors: PropTypes.object,
+  errors: PropTypes.array,
   gridClassName: PropTypes.string,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,

--- a/app/javascript/common/SelectField.jsx
+++ b/app/javascript/common/SelectField.jsx
@@ -19,7 +19,7 @@ SelectField.propTypes = {
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.object,
   ]).isRequired,
-  errors: PropTypes.object,
+  errors: PropTypes.array,
   gridClassName: PropTypes.string,
   id: PropTypes.string.isRequired,
   label: PropTypes.string.isRequired,

--- a/app/javascript/common/ShowField.jsx
+++ b/app/javascript/common/ShowField.jsx
@@ -16,7 +16,7 @@ ShowField.propTypes = {
     PropTypes.number,
     PropTypes.element,
   ]),
-  errors: PropTypes.object,
+  errors: PropTypes.array,
   gridClassName: PropTypes.string,
   label: PropTypes.string.isRequired,
   labelClassName: PropTypes.string,

--- a/app/javascript/screenings/CrossReportEditView.jsx
+++ b/app/javascript/screenings/CrossReportEditView.jsx
@@ -59,6 +59,7 @@ export default class CrossReportEditView extends React.Component {
   }
 
   renderCrossReport(crossReportOptions) {
+    const {errors} = this.props
     return (
       <div className='col-md-6'>
         <ul className='unstyled-list'>
@@ -72,7 +73,7 @@ export default class CrossReportEditView extends React.Component {
                     <CheckboxField
                       id={`type-${typeId}`}
                       checked={selected}
-                      errors={this.props.errors.getIn([agencyType, 'agency_type'])}
+                      errors={errors.getIn([agencyType, 'agency_type']) && errors.getIn([agencyType, 'agency_type']).toJS()}
                       onBlur={(event) =>
                         this.props.onBlur(
                           this.updatedCrossReports(agencyType, 'agency_type', event.target.checked),
@@ -91,7 +92,7 @@ export default class CrossReportEditView extends React.Component {
                     {
                       selected &&
                           <InputField
-                            errors={this.props.errors.getIn([agencyType, 'agency_name'])}
+                            errors={errors.getIn([agencyType, 'agency_name']) && errors.getIn([agencyType, 'agency_name']).toJS()}
                             id={`${typeId}-agency-name`}
                             label={`${agencyType} agency name`}
                             maxLength='128'
@@ -131,8 +132,8 @@ export default class CrossReportEditView extends React.Component {
     // reported_on is a single value, but stored on >1 cross reports.
     // In theory, all values will either be the same or undefined so flatMap
     // is just an alternative to picking an arbitrary item to retrieve from.
-    const reportedOnErrors = this.props.errors.toSet().flatMap((item) => item.get('reported_on'))
-    const communicationErrors = this.props.errors.toSet().flatMap((item) => item.get('communication_method'))
+    const reportedOnErrors = this.props.errors.toSet().flatMap((item) => item.get('reported_on')).toJS()
+    const communicationErrors = this.props.errors.toSet().flatMap((item) => item.get('communication_method')).toJS()
 
     return (
       <div className='card-body no-pad-top'>
@@ -170,7 +171,7 @@ export default class CrossReportEditView extends React.Component {
                   value={this.state.reportedOn}
                 />
                 <SelectField
-                  errors={communicationErrors.toList()}
+                  errors={communicationErrors}
                   gridClassName='col-md-6'
                   id='cross_report_communication_method'
                   label='Communication Method'

--- a/app/javascript/screenings/CrossReportShowView.jsx
+++ b/app/javascript/screenings/CrossReportShowView.jsx
@@ -14,9 +14,9 @@ export default class CrossReportShowView extends React.Component {
   render() {
     const crossReports = this.props.crossReports.toJS()
     const hasCrossReports = !_.isEmpty(crossReports)
-    const agencyTypeErrors = this.props.errors.toSet().flatMap((item) => item.get('agency_type'))
-    const reportedOnErrors = this.props.errors.toSet().flatMap((item) => item.get('reported_on'))
-    const communicationErrors = this.props.errors.toSet().flatMap((item) => item.get('communication_method'))
+    const agencyTypeErrors = this.props.errors.toSet().flatMap((item) => item.get('agency_type')).toJS()
+    const reportedOnErrors = this.props.errors.toSet().flatMap((item) => item.get('reported_on')).toJS()
+    const communicationErrors = this.props.errors.toSet().flatMap((item) => item.get('communication_method')).toJS()
     let reportedOn
     let communicationMethod
     const [firstCrossReport] = crossReports
@@ -38,7 +38,9 @@ export default class CrossReportShowView extends React.Component {
                       return (
                         <div key={index}>
                           <li>{agencyTypeAndName}</li>
-                          <ErrorMessages errors={this.props.errors.getIn([agency_type, 'agency_name'])}/>
+                          <ErrorMessages
+                            errors={this.props.errors.getIn([agency_type, 'agency_name']) && this.props.errors.getIn([agency_type, 'agency_name']).toJS()}
+                          />
                         </div>
                       )
                     })
@@ -51,7 +53,7 @@ export default class CrossReportShowView extends React.Component {
           firstCrossReport &&
             <div className='row'>
               <ShowField
-                errors={reportedOnErrors.toList()}
+                errors={reportedOnErrors}
                 gridClassName='col-md-6'
                 label='Cross Reported on Date'
                 required={hasCrossReports}
@@ -59,7 +61,7 @@ export default class CrossReportShowView extends React.Component {
                 {reportedOn}
               </ShowField>
               <ShowField
-                errors={communicationErrors.toList()}
+                errors={communicationErrors}
                 gridClassName='col-md-6'
                 label='Communication Method'
                 required={hasCrossReports}

--- a/app/javascript/screenings/DecisionCardView.jsx
+++ b/app/javascript/screenings/DecisionCardView.jsx
@@ -58,7 +58,7 @@ export default class DecisionCardView extends React.Component {
   filteredErrors() {
     return this.props.errors.filter((_value, key) => (
       this.state.displayErrorsFor.includes(key)
-    ))
+    )).toJS()
   }
 
   render() {

--- a/app/javascript/screenings/DecisionEditView.jsx
+++ b/app/javascript/screenings/DecisionEditView.jsx
@@ -28,7 +28,7 @@ const DecisionEditView = ({errors, screening, onCancel, onSave, onChange, onBlur
           <SelectField
             id='screening_decision'
             label= 'Screening Decision'
-            errors={errors.get('screening_decision')}
+            errors={errors.screening_decision}
             required
             value={screening.get('screening_decision')}
             onChange={(event) => onChangeDecision(event)}
@@ -41,7 +41,7 @@ const DecisionEditView = ({errors, screening, onCancel, onSave, onChange, onBlur
             <SelectField
               id='decisionDetail'
               label={decisionLabel}
-              errors={errors.get('screening_decision_detail')}
+              errors={errors.screening_decision_detail}
               required={isRequired}
               value={screening.getIn(['screening_decision_detail'])}
               onChange={(event) => onChange(['screening_decision_detail'], event.target.value || null)}
@@ -57,7 +57,7 @@ const DecisionEditView = ({errors, screening, onCancel, onSave, onChange, onBlur
               <InputField
                 id='decisionDetail'
                 label={decisionLabel}
-                errors={errors.get('screening_decision_detail')}
+                errors={errors.screening_decision_detail}
                 required={isRequired}
                 value={screening.getIn(['screening_decision_detail']) || ''}
                 onChange={(event) => onChange(['screening_decision_detail'], event.target.value || null)}

--- a/app/javascript/screenings/DecisionShowView.jsx
+++ b/app/javascript/screenings/DecisionShowView.jsx
@@ -27,13 +27,13 @@ const DecisionShowView = ({screening, errors}) => {
     <div className='card-body'>
       <div className='row'>
         <div className='col-md-6'>
-          <ShowField label='Screening Decision' errors={errors.get('screening_decision')} required>
+          <ShowField label='Screening Decision' errors={errors.screening_decision} required>
             {screening.get('screening_decision') && SCREENING_DECISION[screening.get('screening_decision')] || ''}
           </ShowField>
           <ShowField
             label={decisionDetailLabel}
             required={decisionDetailLabel === 'Response time'}
-            errors={errors.get('screening_decision_detail')}
+            errors={errors.screening_decision_detail}
           >
             {decisionDetailText}
           </ShowField>

--- a/app/javascript/screenings/IncidentInformationCardView.jsx
+++ b/app/javascript/screenings/IncidentInformationCardView.jsx
@@ -56,7 +56,7 @@ export default class IncidentInformationCardView extends React.Component {
   filteredErrors() {
     return this.props.errors.filter((_value, key) => (
       this.state.displayErrorsFor.includes(key)
-    ))
+    )).toJS()
   }
 
   render() {

--- a/app/javascript/screenings/IncidentInformationEditView.jsx
+++ b/app/javascript/screenings/IncidentInformationEditView.jsx
@@ -15,7 +15,7 @@ const IncidentInformationEditView = ({screening, onBlur, onCancel, onSave, onCha
         id='incident_date'
         label='Incident Date'
         value={screening.get('incident_date')}
-        errors={errors.get('incident_date')}
+        errors={errors.incident_date}
         onChange={(value) => onChange(['incident_date'], value)}
         onBlur={() => onBlur('incident_date')}
         hasTime={false}

--- a/app/javascript/screenings/IncidentInformationShowView.jsx
+++ b/app/javascript/screenings/IncidentInformationShowView.jsx
@@ -12,7 +12,7 @@ const IncidentInformationShowView = ({screening, errors}) => {
   return (
     <div className='card-body'>
       <div className='row'>
-        <ShowField gridClassName='col-md-6' label='Incident Date' errors={errors.get('incident_date')}>
+        <ShowField gridClassName='col-md-6' label='Incident Date' errors={errors.incident_date}>
           {incidentDate}
         </ShowField>
       </div>

--- a/app/javascript/screenings/NarrativeCardView.jsx
+++ b/app/javascript/screenings/NarrativeCardView.jsx
@@ -80,7 +80,7 @@ export default class NarrativeCardView extends React.Component {
     const {errors, mode} = this.state
     const allProps = {
       edit: {
-        errors: errors,
+        errors: errors.toJS(),
         screening: this.props.screening,
         onBlur: this.onBlur,
         onCancel: this.onCancel,
@@ -88,7 +88,7 @@ export default class NarrativeCardView extends React.Component {
         onSave: this.onSave,
       },
       show: {
-        errors: errors,
+        errors: errors.toJS(),
         screening: this.props.screening,
         onEdit: this.onEdit,
       },

--- a/app/javascript/screenings/NarrativeEditView.jsx
+++ b/app/javascript/screenings/NarrativeEditView.jsx
@@ -6,7 +6,7 @@ const NarrativeEditView = ({errors, screening, onBlur, onCancel, onChange, onSav
   <div className='card-body'>
     <div className='row'>
       <FormField
-        errors={errors.get('report_narrative')}
+        errors={errors.report_narrative}
         gridClassName='col-md-12'
         id='report_narrative'
         label='Report Narrative'

--- a/app/javascript/screenings/NarrativeShowView.jsx
+++ b/app/javascript/screenings/NarrativeShowView.jsx
@@ -5,7 +5,7 @@ import ShowField from 'common/ShowField'
 const NarrativeShowView = ({errors, screening}) => (
   <div className='card-body'>
     <div className='row'>
-      <ShowField gridClassName='col-md-12' label='Report Narrative' errors={errors.get('report_narrative')} required>
+      <ShowField gridClassName='col-md-12' label='Report Narrative' errors={errors.report_narrative} required>
         {screening.get('report_narrative')}
       </ShowField>
     </div>

--- a/app/javascript/screenings/ScreeningInformationCardView.jsx
+++ b/app/javascript/screenings/ScreeningInformationCardView.jsx
@@ -88,7 +88,7 @@ export default class ScreeningInformationCardView extends React.Component {
     const {errors, mode} = this.state
     const allprops = {
       edit: {
-        errors: errors,
+        errors: errors.toJS(),
         validateOnChange: this.validateOnChange,
         validateField: this.validateField,
         onCancel: this.onCancel,
@@ -99,7 +99,7 @@ export default class ScreeningInformationCardView extends React.Component {
       show: {
         onEdit: this.onEdit,
         screening: this.props.screening,
-        errors: errors,
+        errors: errors.toJS(),
       },
     }
     const ScreeningInformationView = (mode === 'edit') ? ScreeningInformationEditView : ScreeningInformationShowView

--- a/app/javascript/screenings/ScreeningInformationEditView.jsx
+++ b/app/javascript/screenings/ScreeningInformationEditView.jsx
@@ -21,7 +21,7 @@ const ScreeningInformationEditView = ({screening, onCancel, onChange, onSave, va
       <InputField
         allowCharacters={/[a-zA-Z\s]/}
         disabled={Boolean(screening.get('staff_id'))}
-        errors={errors.get('assignee')}
+        errors={errors.assignee}
         gridClassName='col-md-6'
         id='assignee'
         label='Assigned Social Worker'
@@ -42,7 +42,7 @@ const ScreeningInformationEditView = ({screening, onCancel, onChange, onSave, va
         value={screening.get('started_at')}
         onChange={(value) => validateOnChange('started_at', value)}
         onBlur={(value) => validateField('started_at', value)}
-        errors={errors.get('started_at')}
+        errors={errors.started_at}
       />
       <DateField
         gridClassName='col-md-6'
@@ -51,7 +51,7 @@ const ScreeningInformationEditView = ({screening, onCancel, onChange, onSave, va
         value={screening.get('ended_at')}
         onChange={(value) => validateOnChange('ended_at', value)}
         onBlur={(value) => validateField('ended_at', value)}
-        errors={errors.get('ended_at')}
+        errors={errors.ended_at}
       />
     </div>
     <div className='row'>
@@ -63,7 +63,7 @@ const ScreeningInformationEditView = ({screening, onCancel, onChange, onSave, va
         value={screening.get('communication_method')}
         onChange={(event) => validateOnChange('communication_method', event.target.value || null)}
         onBlur={(event) => validateField('communication_method', event.target.value)}
-        errors={errors.get('communication_method')}
+        errors={errors.communication_method}
       >
         <option key='' />
         {Object.keys(COMMUNICATION_METHOD).map((item) => <option key={item} value={item}>{COMMUNICATION_METHOD[item]}</option>)}

--- a/app/javascript/screenings/ScreeningInformationShowView.jsx
+++ b/app/javascript/screenings/ScreeningInformationShowView.jsx
@@ -11,22 +11,22 @@ const ScreeningInformationShowView = ({errors, screening}) => (
         {screening.get('name')}
       </ShowField>
       <ShowField gridClassName='col-md-6' label='Assigned Social Worker'
-        errors={errors.get('assignee')} required
+        errors={errors.assignee} required
       >
         {screening.get('assignee')}
       </ShowField>
     </div>
     <div className='row double-gap-top'>
-      <ShowField gridClassName='col-md-6' label='Screening Start Date/Time' errors={errors.get('started_at')} required>
+      <ShowField gridClassName='col-md-6' label='Screening Start Date/Time' errors={errors.started_at} required>
         {dateTimeFormatter(screening.get('started_at'))}
       </ShowField>
-      <ShowField gridClassName='col-md-6' label='Screening End Date/Time' errors={errors.get('ended_at')}>
+      <ShowField gridClassName='col-md-6' label='Screening End Date/Time' errors={errors.ended_at}>
         {dateTimeFormatter(screening.get('ended_at'))}
       </ShowField>
     </div>
     <div className='row double-gap-top'>
       <ShowField gridClassName='col-md-6' label='Communication Method'
-        errors={errors.get('communication_method')} required
+        errors={errors.communication_method} required
       >
         {COMMUNICATION_METHOD[screening.get('communication_method')]}
       </ShowField>

--- a/spec/javascripts/components/common/CheckboxFieldSpec.jsx
+++ b/spec/javascripts/components/common/CheckboxFieldSpec.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Immutable from 'immutable'
 import {shallow} from 'enzyme'
 import CheckboxField from 'common/CheckboxField'
 
@@ -8,7 +7,7 @@ describe('CheckboxField', () => {
   let onBlur
   let component
   const props = {
-    errors: Immutable.Map(),
+    errors: [],
     id: 'myCheckboxFieldId',
     value: 'this-is-my-value',
   }
@@ -25,7 +24,7 @@ describe('CheckboxField', () => {
   })
 
   it('passes errors to the ErrorMessages', () => {
-    expect(component.find('ErrorMessages').props().errors).toEqual(Immutable.Map())
+    expect(component.find('ErrorMessages').props().errors).toEqual([])
   })
 
   describe('with no flags set', () => {

--- a/spec/javascripts/components/common/DateFieldSpec.jsx
+++ b/spec/javascripts/components/common/DateFieldSpec.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import {shallow, mount} from 'enzyme'
 import DateField from 'common/DateField'
 import moment from 'moment'
-import Immutable from 'immutable'
 
 describe('DateField', () => {
   let component
@@ -123,10 +122,10 @@ describe('DateField', () => {
 
   describe('when errors exist', () => {
     it('sends the errors to FormField', () => {
-      const errors = Immutable.List(['Error 1', 'Error 2'])
+      const errors = ['Error 1', 'Error 2']
       component = shallow(<DateField {...props} errors={errors} />)
       expect(component.find('FormField').props().errors)
-        .toEqual(Immutable.List(['Error 1', 'Error 2']))
+        .toEqual(['Error 1', 'Error 2'])
     })
   })
 

--- a/spec/javascripts/components/common/ErrorMessagesSpec.jsx
+++ b/spec/javascripts/components/common/ErrorMessagesSpec.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Immutable from 'immutable'
 import {shallow} from 'enzyme'
 import ErrorMessages from 'common/ErrorMessages'
 
@@ -20,8 +19,8 @@ describe('ErrorMessages', () => {
     })
   })
 
-  describe('when an empty list is passed for errors', () => {
-    const props = {id: 'myInputFieldId', errors: Immutable.List()}
+  describe('when errors is an empty array', () => {
+    const props = {id: 'myInputFieldId', errors: []}
 
     it('does not render error messages', () => {
       component = shallow(<ErrorMessages {...props}/>)
@@ -30,7 +29,7 @@ describe('ErrorMessages', () => {
   })
 
   describe('when there are errors', () => {
-    const errors = Immutable.fromJS(['You have failed this city', 'Stick to the plan!'])
+    const errors = ['You have failed this city', 'Stick to the plan!']
     describe('when id is passed', () => {
       beforeEach(() => {
         const props = {id: 'myInputFieldId', errors}

--- a/spec/javascripts/components/common/FormFieldSpec.jsx
+++ b/spec/javascripts/components/common/FormFieldSpec.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Immutable from 'immutable'
 import {shallow} from 'enzyme'
 import FormField from 'common/FormField'
 
@@ -56,7 +55,7 @@ describe('FormField', () => {
       label: 'Do not judge a component by its label',
       gridClassName: 'working-class object-oriented-class',
       labelClassName: 'trouble-maker',
-      errors: Immutable.List(['Please choose wisely.', 'Stick to the plan!']),
+      errors: ['Please choose wisely.', 'Stick to the plan!'],
     }
 
     it('renders label and its wrapper with error classes', () => {
@@ -68,7 +67,7 @@ describe('FormField', () => {
     it('renders ErrorMessages and passes it errors', () => {
       component = shallow(<FormField {...props}/>)
       expect(component.find('ErrorMessages').props().errors)
-        .toEqual(Immutable.List(['Please choose wisely.', 'Stick to the plan!']))
+        .toEqual(['Please choose wisely.', 'Stick to the plan!'])
     })
 
     describe('when required', () => {

--- a/spec/javascripts/components/common/InputFieldSpec.jsx
+++ b/spec/javascripts/components/common/InputFieldSpec.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Immutable from 'immutable'
 import {shallow} from 'enzyme'
 import InputField from 'common/InputField'
 
@@ -11,7 +10,7 @@ describe('InputField', () => {
 
   const props = {
     disabled: false,
-    errors: Immutable.Map(),
+    errors: [],
     gridClassName: 'myWrapperTest',
     id: 'myInputFieldId',
     label: 'this is my label',
@@ -38,7 +37,7 @@ describe('InputField', () => {
       expect(formField.props().gridClassName).toEqual('myWrapperTest')
       expect(formField.props().id).toEqual('myInputFieldId')
       expect(formField.props().label).toEqual('this is my label')
-      expect(formField.props().errors).toEqual(Immutable.Map())
+      expect(formField.props().errors).toEqual([])
       expect(formField.props().required).toEqual(false)
       expect(formField.childAt(0).node.type).toEqual('input')
       expect(formField.props().disabled).toEqual(false)

--- a/spec/javascripts/components/common/MaskedInputFieldSpec.jsx
+++ b/spec/javascripts/components/common/MaskedInputFieldSpec.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import Immutable from 'immutable'
 import {shallow} from 'enzyme'
 import MaskedInputField from 'common/MaskedInputField'
 
@@ -23,7 +22,7 @@ describe('MaskedInputField', () => {
       onBlur: onBlur,
       value: 'this is my field value',
       mask: '111-11-1111',
-      errors: Immutable.Map(),
+      errors: [],
       required: false,
     }
   })
@@ -40,7 +39,7 @@ describe('MaskedInputField', () => {
       expect(formField.props().gridClassName).toEqual('myWrapperTest')
       expect(formField.props().id).toEqual('myInputFieldId')
       expect(formField.props().label).toEqual('this is my label')
-      expect(formField.props().errors).toEqual(Immutable.Map())
+      expect(formField.props().errors).toEqual([])
       expect(formField.props().required).toEqual(false)
       expect(maskedInput.exists()).toEqual(true)
     })

--- a/spec/javascripts/components/common/ShowFieldSpec.jsx
+++ b/spec/javascripts/components/common/ShowFieldSpec.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {shallow} from 'enzyme'
 import ShowField from 'common/ShowField'
-import Immutable from 'immutable'
 
 describe('ShowField', () => {
   let component
@@ -37,12 +36,12 @@ describe('when field is required and has errors', () => {
     const props = {
       label: 'this is my label',
       required: true,
-      errors: Immutable.List(['Error 1', 'Error 2']),
+      errors: ['Error 1', 'Error 2'],
     }
     const component = shallow(<ShowField {...props} >show field value</ShowField>)
     const formField = component.find('FormField')
     expect(formField.props().required).toEqual(true)
-    expect(formField.props().errors).toEqual(Immutable.List(['Error 1', 'Error 2']))
+    expect(formField.props().errors).toEqual(['Error 1', 'Error 2'])
   })
 })
 

--- a/spec/javascripts/components/screenings/crossReports/CrossReportShowViewSpec.jsx
+++ b/spec/javascripts/components/screenings/crossReports/CrossReportShowViewSpec.jsx
@@ -67,12 +67,12 @@ describe('CrossReportShowView', () => {
 
     it('renders an error for communication_method', () => {
       const field = component.find('ShowField[label="Communication Method"]')
-      expect(field.props().errors).toEqual(Immutable.List(['Error 2']))
+      expect(field.props().errors).toEqual(['Error 2'])
     })
 
     it('renders an error for reported_on', () => {
       const field = component.find('ShowField[label="Cross Reported on Date"]')
-      expect(field.props().errors).toEqual(Immutable.List(['Error 3']))
+      expect(field.props().errors).toEqual(['Error 3'])
     })
   })
 

--- a/spec/javascripts/components/screenings/decision/DecisionCardViewSpec.jsx
+++ b/spec/javascripts/components/screenings/decision/DecisionCardViewSpec.jsx
@@ -108,7 +108,7 @@ describe('DecisionCardView', () => {
     })
 
     it('passes errors from the state', () => {
-      expect(component.find('DecisionShowView').props().errors).toEqual(Immutable.Map())
+      expect(component.find('DecisionShowView').props().errors).toEqual({})
     })
   })
 
@@ -126,8 +126,7 @@ describe('DecisionCardView', () => {
       const component = shallow(<DecisionCardView {...props} mode={'edit'} errors={errorProps}/>)
       component.setState({displayErrorsFor: Immutable.List(['foo'])})
       const errors = component.instance().filteredErrors()
-      expect(errors.toJS()).toEqual({foo: ['foo error']})
-      expect(Immutable.is(errors, Immutable.fromJS({foo: ['foo error']}))).toEqual(true)
+      expect(errors).toEqual({foo: ['foo error']})
     })
   })
 })

--- a/spec/javascripts/components/screenings/decision/DecisionEditViewSpec.jsx
+++ b/spec/javascripts/components/screenings/decision/DecisionEditViewSpec.jsx
@@ -116,7 +116,7 @@ describe('conditional decision options', () => {
 describe('DecisionEditView', () => {
   let component
   let props
-  const errors = Immutable.fromJS({screening_decision: [], screening_decision_detail: []})
+  const errors = {screening_decision: [], screening_decision_detail: []}
 
   beforeEach(() => {
     const sdmPath = 'https://ca.sdmdata.org'
@@ -137,11 +137,11 @@ describe('DecisionEditView', () => {
   })
 
   it('renders errors for screening_decision', () => {
-    expect(component.find('#screening_decision').props().errors).toEqual(Immutable.List())
+    expect(component.find('#screening_decision').props().errors).toEqual([])
   })
 
   it('renders errors for screening_decision_detail', () => {
-    expect(component.find('#decisionDetail').props().errors).toEqual(Immutable.List())
+    expect(component.find('#decisionDetail').props().errors).toEqual([])
   })
 
   it('calls onBlur with the proper field name for screening decision', () => {
@@ -186,7 +186,7 @@ describe('DecisionEditView', () => {
     const selectField = component.find('SelectField[label="Category"]')
     selectField.simulate('blur')
     expect(props.onBlur).toHaveBeenCalledWith('screening_decision_detail')
-    expect(selectField.props().errors).toEqual(Immutable.List())
+    expect(selectField.props().errors).toEqual([])
     expect(selectField.length).toEqual(1)
     expect(component.find('InputField[label="Service name"]').length).toEqual(0)
   })

--- a/spec/javascripts/components/screenings/decision/DecisionShowViewSpec.jsx
+++ b/spec/javascripts/components/screenings/decision/DecisionShowViewSpec.jsx
@@ -7,7 +7,7 @@ import {shallow} from 'enzyme'
 describe('DecisionShowView', () => {
   let component
   let onEdit
-  const errors = Immutable.fromJS({screening_decision: []})
+  const errors = {screening_decision: []}
 
   beforeEach(() => {
     const sdmPath = 'https://ca.sdmdata.org'
@@ -36,7 +36,7 @@ describe('DecisionShowView', () => {
   })
 
   it('renders errors passed for screening decision', () => {
-    expect(component.find('ShowField[label="Screening Decision"]').props().errors).toEqual(Immutable.List())
+    expect(component.find('ShowField[label="Screening Decision"]').props().errors).toEqual([])
   })
 
   it('renders the show fields with text input decision_detail', () => {

--- a/spec/javascripts/components/screenings/incidentInformation/IncidentInformationCardViewSpec.jsx
+++ b/spec/javascripts/components/screenings/incidentInformation/IncidentInformationCardViewSpec.jsx
@@ -18,7 +18,7 @@ describe('IncidentInformationCardView', () => {
       },
       location_type: 'Juvenile Detention',
     }),
-    errors: Immutable.List(),
+    errors: Immutable.Map(),
     editable: true,
   }
 
@@ -52,7 +52,7 @@ describe('IncidentInformationCardView', () => {
       })
 
       it('passes errors to the edit view', () => {
-        expect(component.find('IncidentInformationEditView').props().errors).toEqual(Immutable.List())
+        expect(component.find('IncidentInformationEditView').props().errors).toEqual({})
       })
 
       describe('when a user clicks Cancel', () => {
@@ -96,7 +96,7 @@ describe('IncidentInformationCardView', () => {
       })
 
       it('passes errors to the edit view', () => {
-        expect(component.find('IncidentInformationShowView').props().errors).toEqual(Immutable.List())
+        expect(component.find('IncidentInformationShowView').props().errors).toEqual({})
       })
     })
   })
@@ -115,8 +115,7 @@ describe('IncidentInformationCardView', () => {
       const component = shallow(<IncidentInformationCardView {...props} mode={'edit'} errors={errorProps}/>)
       component.setState({displayErrorsFor: Immutable.List(['foo'])})
       const errors = component.instance().filteredErrors()
-      expect(errors.toJS()).toEqual({foo: ['foo error']})
-      expect(Immutable.is(errors, Immutable.fromJS({foo: ['foo error']}))).toEqual(true)
+      expect(errors).toEqual({foo: ['foo error']})
     })
   })
 })

--- a/spec/javascripts/components/screenings/incidentInformation/IncidentInformationEditViewSpec.jsx
+++ b/spec/javascripts/components/screenings/incidentInformation/IncidentInformationEditViewSpec.jsx
@@ -24,7 +24,7 @@ describe('IncidentInformationEditView', () => {
         },
         location_type: 'Juvenile Detention',
       }),
-      errors: Immutable.fromJS({incident_date: []}),
+      errors: {incident_date: []},
     }
     component = shallow(<IncidentInformationEditView {...props} />)
   })
@@ -71,7 +71,7 @@ describe('IncidentInformationEditView', () => {
 
   it('passes errors to incident date', () => {
     const incidentDate = component.find('DateField[label="Incident Date"]')
-    expect(incidentDate.props().errors).toEqual(Immutable.List())
+    expect(incidentDate.props().errors).toEqual([])
   })
 
   it('calls onBlur with the proper field name when incident date is blurred', () => {

--- a/spec/javascripts/components/screenings/incidentInformation/IncidentInformationShowViewSpec.jsx
+++ b/spec/javascripts/components/screenings/incidentInformation/IncidentInformationShowViewSpec.jsx
@@ -13,13 +13,13 @@ describe('IncidentInformationShowView', () => {
       <IncidentInformationShowView
         screening={Immutable.fromJS({})}
         onEdit={onEdit}
-        errors={Immutable.fromJS({incident_date: []})}
+        errors={{incident_date: []}}
       />
     )
   })
 
   it('renders errors passed for incident date', () => {
-    expect(component.find('ShowField[label="Incident Date"]').props().errors).toEqual(Immutable.List())
+    expect(component.find('ShowField[label="Incident Date"]').props().errors).toEqual([])
   })
 
   it('render the show fields', () => {
@@ -39,7 +39,7 @@ describe('IncidentInformationShowView', () => {
       <IncidentInformationShowView
         screening={screening}
         onEdit={onEdit}
-        errors={Immutable.List()}
+        errors={{}}
       />
     )
     expect(component.find('ShowField').length).toEqual(7)
@@ -75,7 +75,7 @@ describe('IncidentInformationShowView', () => {
       <IncidentInformationShowView
         screening={screening}
         onEdit={onEdit}
-        errors={Immutable.List()}
+        errors={{}}
       />
     )
     expect(component.find('ShowField').length).toEqual(7)

--- a/spec/javascripts/components/screenings/narrative/NarrativeCardViewSpec.jsx
+++ b/spec/javascripts/components/screenings/narrative/NarrativeCardViewSpec.jsx
@@ -86,7 +86,7 @@ describe('NarrativeCardView', () => {
             })
 
             it('validates the field', () => {
-              expect(component.update().find('NarrativeShowView').props().errors.get('report_narrative').toJS()).toContain('Please enter a narrative.')
+              expect(component.update().find('NarrativeShowView').props().errors.report_narrative).toContain('Please enter a narrative.')
             })
           })
         })
@@ -97,12 +97,12 @@ describe('NarrativeCardView', () => {
           const oldErrors = Immutable.fromJS({report_narrative: ['The rules of gravity have begun to apply!']})
           component.setState({errors: oldErrors})
           component.find('textarea').simulate('blur', {target: {value: '   '}})
-          expect(component.update().find('NarrativeEditView').props().errors.get('report_narrative').toJS()).toContain('Please enter a narrative.')
+          expect(component.update().find('NarrativeEditView').props().errors.report_narrative).toContain('Please enter a narrative.')
         })
 
         it('does not validate if there are no errors on the field', () => {
           component.find('textarea').simulate('blur', {target: {value: ''}})
-          expect(component.update().find('NarrativeEditView').props().errors.get('report_narrative').toJS()).toContain('Please enter a narrative.')
+          expect(component.update().find('NarrativeEditView').props().errors.report_narrative).toContain('Please enter a narrative.')
         })
       })
 
@@ -111,13 +111,13 @@ describe('NarrativeCardView', () => {
           const oldErrors = Immutable.fromJS({report_narrative: ['The rules of gravity have begun to apply!']})
           component.setState({errors: oldErrors})
           component.find('textarea').simulate('change', {target: {value: '   '}})
-          expect(component.update().find('NarrativeEditView').props().errors.get('report_narrative').toJS()).toContain('Please enter a narrative.')
+          expect(component.update().find('NarrativeEditView').props().errors.report_narrative).toContain('Please enter a narrative.')
           expect(props.onChange).toHaveBeenCalledWith(['report_narrative'], '   ', undefined)
         })
 
         it('does not validate if there are no errors on the field', () => {
           component.find('textarea').simulate('change', {target: {value: ''}})
-          expect(component.update().find('NarrativeEditView').props().errors.get('report_narrative')).toEqual(undefined)
+          expect(component.update().find('NarrativeEditView').props().errors.report_narrative).toEqual(undefined)
           expect(props.onChange).toHaveBeenCalledWith(['report_narrative'], null, undefined)
         })
       })
@@ -135,7 +135,7 @@ describe('NarrativeCardView', () => {
           })
 
           it('no error on initial load', () => {
-            expect(component.find('NarrativeEditView').props().errors.get('report_narrative')).toEqual(undefined)
+            expect(component.find('NarrativeEditView').props().errors.report_narrative).toEqual(undefined)
           })
         })
       })
@@ -160,7 +160,7 @@ describe('NarrativeCardView', () => {
         })
 
         it('the error is passed down', () => {
-          expect(component.find('NarrativeShowView').props().errors.get('report_narrative').toJS()).toContain('Please enter a narrative.')
+          expect(component.find('NarrativeShowView').props().errors.report_narrative).toContain('Please enter a narrative.')
         })
       })
     })

--- a/spec/javascripts/components/screenings/narrative/NarrativeEditViewSpec.jsx
+++ b/spec/javascripts/components/screenings/narrative/NarrativeEditViewSpec.jsx
@@ -22,7 +22,7 @@ describe('NarrativeEditView', () => {
       onChange = jasmine.createSpy('onChange')
       component = mount(
         <NarrativeEditView
-          errors={Immutable.Map()}
+          errors={{}}
           onBlur={onBlur}
           onCancel={onCancel}
           onChange={onChange}
@@ -77,7 +77,7 @@ describe('NarrativeEditView', () => {
   describe('with INVALID data', () => {
     let errors
     beforeEach(() => {
-      errors = Immutable.fromJS({report_narrative: ['Please enter a narrative.']})
+      errors = {report_narrative: ['Please enter a narrative.']}
       screening = Immutable.fromJS({
         report_narrative: '',
       })
@@ -98,7 +98,7 @@ describe('NarrativeEditView', () => {
     })
 
     it('passes the error props correctly', () => {
-      expect(component.find('FormField').props().errors).toEqual(errors.get('report_narrative'))
+      expect(component.find('FormField').props().errors).toEqual(errors.report_narrative)
     })
 
     it('renders the narrative error', () => {

--- a/spec/javascripts/components/screenings/narrative/NarrativeShowViewSpec.jsx
+++ b/spec/javascripts/components/screenings/narrative/NarrativeShowViewSpec.jsx
@@ -14,7 +14,7 @@ describe('NarrativeShowView', () => {
         report_narrative: 'some narrative',
       })
       onEdit = jasmine.createSpy()
-      component = shallow(<NarrativeShowView screening={screening} errors={Immutable.Map()} onEdit={onEdit} />)
+      component = shallow(<NarrativeShowView screening={screening} errors={{}} onEdit={onEdit} />)
     })
 
     it('renders the report narrative label as required', () => {
@@ -30,7 +30,7 @@ describe('NarrativeShowView', () => {
   })
 
   describe('with INVALID data', () => {
-    const errors = Immutable.fromJS({report_narrative: ['That is not a report narrative, this is a report narrative']})
+    const errors = {report_narrative: ['That is not a report narrative, this is a report narrative']}
     beforeEach(() => {
       screening = Immutable.fromJS({
         report_narrative: 'some narrative',
@@ -40,7 +40,7 @@ describe('NarrativeShowView', () => {
     })
 
     it('renders the narrative show field', () => {
-      expect(component.find('ShowField').html()).toContain(errors.get('report_narrative').first())
+      expect(component.find('ShowField').html()).toContain(errors.report_narrative[0])
     })
   })
 })

--- a/spec/javascripts/components/screenings/screeningInformation/ScreeningInformationCardViewSpec.jsx
+++ b/spec/javascripts/components/screenings/screeningInformation/ScreeningInformationCardViewSpec.jsx
@@ -67,24 +67,21 @@ describe('ScreeningInformationCardView', () => {
       component.instance().validateField('communication_method', '')
       const errorProps = component.update().find('ScreeningInformationEditView').props().errors
       const expectedErrors = {communication_method: ['Please select a communication method.']}
-      expect(Immutable.is(errorProps, Immutable.fromJS(expectedErrors))).toEqual(true)
-      expect(errorProps.toJS()).toEqual(expectedErrors)
+      expect(errorProps).toEqual(expectedErrors)
     })
 
     it('adds errors for assigned social worker being required', () => {
       component.instance().validateField('assignee', '')
       const errorProps = component.update().find('ScreeningInformationEditView').props().errors
       const expectedErrors = {assignee: ['Please enter an assigned worker.']}
-      expect(Immutable.is(errorProps, Immutable.fromJS(expectedErrors))).toEqual(true)
-      expect(errorProps.toJS()).toEqual(expectedErrors)
+      expect(errorProps).toEqual(expectedErrors)
     })
 
     it('adds errors for start date/time being required', () => {
       component.instance().validateField('started_at', null)
       const errorProps = component.update().find('ScreeningInformationEditView').props().errors
       const expectedErrors = {started_at: ['Please enter a screening start date.']}
-      expect(Immutable.is(errorProps, Immutable.fromJS(expectedErrors))).toEqual(true)
-      expect(errorProps.toJS()).toEqual(expectedErrors)
+      expect(errorProps).toEqual(expectedErrors)
     })
 
     it('adds errors for end date/time being in the future', () => {
@@ -92,8 +89,7 @@ describe('ScreeningInformationCardView', () => {
       component.instance().validateField('ended_at', futureDate)
       const errorProps = component.update().find('ScreeningInformationEditView').props().errors
       const expectedErrors = {ended_at: ['The end date and time cannot be in the future.']}
-      expect(Immutable.is(errorProps, Immutable.fromJS(expectedErrors))).toEqual(true)
-      expect(errorProps.toJS()).toEqual(expectedErrors)
+      expect(errorProps).toEqual(expectedErrors)
     })
 
     describe('when start date is in the future, but before the end date', () => {
@@ -110,8 +106,7 @@ describe('ScreeningInformationCardView', () => {
         component.instance().validateField('started_at', date)
         const errorProps = component.update().find('ScreeningInformationEditView').props().errors
         const expectedErrors = {started_at: ['The start date and time cannot be in the future.']}
-        expect(Immutable.is(errorProps, Immutable.fromJS(expectedErrors))).toEqual(true)
-        expect(errorProps.toJS()).toEqual(expectedErrors)
+        expect(errorProps).toEqual(expectedErrors)
       })
     })
 
@@ -129,8 +124,7 @@ describe('ScreeningInformationCardView', () => {
         component.instance().validateField('started_at', date)
         const errorProps = component.update().find('ScreeningInformationEditView').props().errors
         const expectedErrors = {started_at: ['The start date and time must be before the end date and time.']}
-        expect(Immutable.is(errorProps, Immutable.fromJS(expectedErrors))).toEqual(true)
-        expect(errorProps.toJS()).toEqual(expectedErrors)
+        expect(errorProps).toEqual(expectedErrors)
       })
     })
   })
@@ -141,7 +135,7 @@ describe('ScreeningInformationCardView', () => {
     })
 
     it('does not have errors when all values are valid', () => {
-      expect(component.find('ScreeningInformationEditView').props().errors).toEqual(Immutable.Map())
+      expect(component.find('ScreeningInformationEditView').props().errors).toEqual({})
     })
 
     it('renders the edit card', () => {
@@ -154,7 +148,7 @@ describe('ScreeningInformationCardView', () => {
     })
 
     it('passes errors from the state', () => {
-      expect(component.find('ScreeningInformationEditView').props().errors).toEqual(Immutable.Map())
+      expect(component.find('ScreeningInformationEditView').props().errors).toEqual({})
     })
 
     it('renders the save and cancel button', () => {
@@ -244,7 +238,7 @@ describe('ScreeningInformationCardView', () => {
       })
 
       it('passes errors from the state', () => {
-        expect(component.find('ScreeningInformationShowView').props().errors.toJS())
+        expect(component.find('ScreeningInformationShowView').props().errors)
           .toEqual({
             assignee: [],
             communication_method: [],
@@ -267,7 +261,7 @@ describe('ScreeningInformationCardView', () => {
         }
         component = mount(<ScreeningInformationCardView {...props} mode='show' />)
         const errors = component.find('ScreeningInformationShowView').props().errors
-        expect(errors.get('started_at').toJS()).toContain('The start date and time cannot be in the future.')
+        expect(errors.started_at).toContain('The start date and time cannot be in the future.')
       })
 
       it('validates that end date/time cannot be in the future', () => {
@@ -283,7 +277,7 @@ describe('ScreeningInformationCardView', () => {
         }
         component = mount(<ScreeningInformationCardView {...props} mode='show' />)
         const errors = component.find('ScreeningInformationShowView').props().errors
-        expect(errors.get('ended_at').toJS()).toContain('The end date and time cannot be in the future.')
+        expect(errors.ended_at).toContain('The end date and time cannot be in the future.')
       })
 
       it('validates that start date/time cannot be after end date/time', () => {
@@ -299,7 +293,7 @@ describe('ScreeningInformationCardView', () => {
         }
         component = mount(<ScreeningInformationCardView {...props} mode='show' />)
         const errors = component.find('ScreeningInformationShowView').props().errors
-        expect(errors.get('started_at').toJS()).toContain('The start date and time must be before the end date and time.')
+        expect(errors.started_at).toContain('The start date and time must be before the end date and time.')
       })
     })
 
@@ -320,15 +314,15 @@ describe('ScreeningInformationCardView', () => {
       })
 
       it('validates the presence of the assigned social worker field', () => {
-        expect(errors.get('assignee').toJS()).toContain('Please enter an assigned worker.')
+        expect(errors.assignee).toContain('Please enter an assigned worker.')
       })
 
       it('validates the presence of the communication method field', () => {
-        expect(errors.get('communication_method').toJS()).toContain('Please select a communication method.')
+        expect(errors.communication_method).toContain('Please select a communication method.')
       })
 
       it('validates the presence of the start date field', () => {
-        expect(errors.get('started_at').toJS()).toContain('Please enter a screening start date.')
+        expect(errors.started_at).toContain('Please enter a screening start date.')
       })
     })
   })

--- a/spec/javascripts/components/screenings/screeningInformation/ScreeningInformationEditViewSpec.jsx
+++ b/spec/javascripts/components/screenings/screeningInformation/ScreeningInformationEditViewSpec.jsx
@@ -7,7 +7,7 @@ describe('ScreeningInformationEditView', () => {
   let component
 
   const requiredProps = {
-    errors: Immutable.Map(),
+    errors: {},
     screening: Immutable.fromJS({
       name: 'The Rocky Horror Picture Show',
       assignee: 'Michael Bluth',
@@ -137,13 +137,13 @@ describe('ScreeningInformationEditView', () => {
       const props = {
         ...requiredProps,
         validateField: validateFieldSpy,
-        errors: Immutable.fromJS({
+        errors: {
           assignee: ['First error', 'Second error'],
           communication_method: ['Stick to the plan!', 'An error occured while displaying the previous error'],
           started_at: ['My error', 'My other error'],
           ended_at: ['More errors'],
           name: [],
-        }),
+        },
       }
       component = shallow(<ScreeningInformationEditView {...props} />)
     })
@@ -185,13 +185,13 @@ describe('ScreeningInformationEditView', () => {
       const props = {
         ...requiredProps,
         validateOnChange: validateOnChangeSpy,
-        errors: Immutable.fromJS({
+        errors: {
           assignee: ['First error', 'Second error'],
           communication_method: ['Stick to the plan!', 'An error occured while displaying the previous error'],
           started_at: ['My error', 'My other error'],
           ended_at: ['More errors'],
           name: [],
-        }),
+        },
       }
       component = shallow(<ScreeningInformationEditView {...props} />)
     })
@@ -229,22 +229,22 @@ describe('ScreeningInformationEditView', () => {
     it('passes the appropriate errors to the fields', () => {
       const props = {
         ...requiredProps,
-        errors: Immutable.fromJS({
+        errors: {
           assignee: ['First error', 'Second error'],
           communication_method: ['Stick to the plan!', 'An error occured while displaying the previous error'],
           started_at: ['My error', 'My other error'],
           ended_at: ['More errors'],
           name: [],
-        }),
+        },
       }
       component = shallow(<ScreeningInformationEditView {...props} />)
-      expect(component.find('InputField[id="assignee"]').props().errors.toJS())
+      expect(component.find('InputField[id="assignee"]').props().errors)
         .toEqual(['First error', 'Second error'])
-      expect(component.find('SelectField[id="communication_method"]').props().errors.toJS())
+      expect(component.find('SelectField[id="communication_method"]').props().errors)
         .toEqual(['Stick to the plan!', 'An error occured while displaying the previous error'])
-      expect(component.find('DateField[label="Screening Start Date/Time"]').props().errors.toJS())
+      expect(component.find('DateField[label="Screening Start Date/Time"]').props().errors)
         .toEqual(['My error', 'My other error'])
-      expect(component.find('DateField[label="Screening End Date/Time"]').props().errors.toJS())
+      expect(component.find('DateField[label="Screening End Date/Time"]').props().errors)
         .toEqual(['More errors'])
     })
   })

--- a/spec/javascripts/components/screenings/screeningInformation/ScreeningInformationShowViewSpec.jsx
+++ b/spec/javascripts/components/screenings/screeningInformation/ScreeningInformationShowViewSpec.jsx
@@ -9,7 +9,7 @@ describe('ScreeningInformationShowView', () => {
   const requiredProps = {
     onEdit: jasmine.createSpy(),
     screening: Immutable.fromJS({}),
-    errors: Immutable.Map(),
+    errors: {},
   }
 
   describe('when the screening values are null', () => {
@@ -25,12 +25,12 @@ describe('ScreeningInformationShowView', () => {
       const props = {
         ...requiredProps,
         screening,
-        errors: Immutable.fromJS({
+        errors: {
           assignee: ['Error 1', 'Error 2'],
           started_at: ['Error 3', 'Error 4'],
           communication_method: ['My Spider-Sense is tingling.'],
           ended_at: ['Never give up', 'Never surrender'],
-        }),
+        },
       }
 
       component = shallow(<ScreeningInformationShowView {...props} />)


### PR DESCRIPTION
### Purpose of this PR
Convert our form objects to use a JS array for errors instead of an Immutable List

### Background
For investigations, one of the paradigms we are adopting is that view logic will only take vanilla JS objects, not Immutable ones. There are many benefits to this including:
- PropTypes will be stricter at checking to make sure the prop is in the proper format. Both Immutable Map and Immutable List satisfy PropTypes.object, but a JS object cannot be a JS array, and vice versa.
- Reduce the dependency on Immutable, which increases reusability for us and other service teams
- Helps force complicated logic to elsewhere in the app, not shoved into the view
- Immutability is import at the data layer, but the views shouldn't be changing the data directly. Thus, there is no inherent need for ImmutableJS.

### Notes
The Cross Report card is not as clean as I would like it to be, but it's the only card that was doing more complicated logic for the errors. Where possible, I tired to do the conversion from Immutable to JS in the card view, and pass that to both the show and edit cards. This was not possible for cross reports, since it is manipulating the errors at the view level. Added story [#151074426](https://www.pivotaltracker.com/story/show/151074426) to cover that.