### PR TITLE
Include app config at the version route

### DIFF
--- a/app/controllers/version_controller.rb
+++ b/app/controllers/version_controller.rb
@@ -5,7 +5,9 @@
 class VersionController < ApplicationController
   def index
     current_sha = `git rev-parse HEAD`.strip
-    message = current_sha.present? ? current_sha : 'Git not found'
-    render plain: message
+    message = { version: current_sha.present? ? current_sha : 'Git not found' }
+              .merge(Rails.configuration.intake)
+              .merge(active_features: Feature.active_features)
+    render json: JSON.pretty_generate(message)
   end
 end

--- a/spec/controllers/version_controller_spec.rb
+++ b/spec/controllers/version_controller_spec.rb
@@ -7,17 +7,36 @@ describe VersionController do
     let(:sha) { SecureRandom.hex(36) }
 
     it 'gets the sha of the latest git commit' do
-      allow(subject).to receive(:`).and_return sha
+      expect(subject).to receive(:`).and_return sha
       process :index, method: :get
       assert_response :success
-      expect(response.body).to eq(sha)
+      expect(JSON.parse(response.body)['version']).to eq(sha)
     end
 
     it 'does not break if git is not installed on system' do
-      allow(subject).to receive(:`).and_return `(exit 127)`
+      expect(subject).to receive(:`).and_return `(exit 127)`
       process :index, method: :get
       assert_response :success
-      expect(response.body).to eq('Git not found')
+      expect(JSON.parse(response.body)['version']).to eq('Git not found')
+    end
+
+    it 'includes the values included in intake config' do
+      expect(Rails.configuration).to receive(:intake).and_return(foo: 'bar')
+      process :index, method: :get
+      assert_response :success
+      expect(JSON.parse(response.body)['foo']).to eq('bar')
+    end
+
+    it 'includes active features' do
+      expect(Feature).to receive(:active_features).and_return(%w[foo bar])
+      process :index, method: :get
+      assert_response :success
+      expect(JSON.parse(response.body)['active_features']).to eq(%w[foo bar])
+    end
+
+    it 'converts the information to pretty json' do
+      expect(JSON).to receive(:pretty_generate)
+      process :index, method: :get
     end
   end
 end


### PR DESCRIPTION
### Pivotal Story
 
 - [User can see application settings 150894103](https://www.pivotaltracker.com/story/show/150894103)
 
 ### Purpose
 Allow devs to quickly determine the settings for any given environment to help with debugging, etc.
 
 ### Notes for Reviewer
 The ENV variables being output are limited to those that we specifically set in the application configuration, so I don't think this is exposing anything secret. We're already outputting that information into the javascript console, so we have bigger issues if that hash contains private information,
 
 ### Testing Notes
 Head on over to `/version` to check it out!