### PR TITLE
Rename intake_api_prototype to intake_api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     stdin_open: true
   api:
     extends:
-      file: ../intake_api_prototype/docker-compose.common.yml
+      file: ../intake_api/docker-compose.common.yml
       service: api
     links:
       - db
@@ -43,7 +43,7 @@ services:
     stdin_open: true
   db:
     extends:
-      file: ../intake_api_prototype/docker-compose.common.yml
+      file: ../intake_api/docker-compose.common.yml
       service: db
   redis:
     image: 'redis:3.0'


### PR DESCRIPTION
### Pivotal Story

- [**RENAME** intake_api_prototype to intake_api](https://www.pivotaltracker.com/story/show/151232084)

### Purpose
Currently intake docker-compose file references intake_api as intake_api_prototype,
This should be changed to reflect the accurate name of the repository.

### Background


### Questions for Reviewer


### Notes for Reviewer


### Testing Notes

