### PR TITLE
In 150856008 investigations feature flag

### DIFF
--- a/app/javascript/screenings/ScreeningRow.jsx
+++ b/app/javascript/screenings/ScreeningRow.jsx
@@ -4,6 +4,7 @@ import SCREENING_DECISION from '../enums/ScreeningDecision'
 import SCREENING_DECISION_OPTIONS from '../enums/ScreeningDecisionOptions'
 import moment from 'moment'
 import {Link} from 'react-router'
+import {isFeatureActive} from 'common/config'
 
 const ScreeningRow = ({id, name, decision, decisionDetail, assignee, startedAt, referralId}) => {
   const screeningStatus = (decision, decisionDetail) => {
@@ -24,7 +25,7 @@ const ScreeningRow = ({id, name, decision, decisionDetail, assignee, startedAt, 
     }
   }
   const linkPath = (id, referralId) => {
-    if (referralId) {
+    if (referralId && isFeatureActive('investigations')) {
       return `/investigations/${referralId}`
     } else {
       return `/screenings/${id}`

--- a/config/feature.yml
+++ b/config/feature.yml
@@ -6,6 +6,7 @@ development:
     authentication: <%= ENV.fetch('AUTHENTICATION', false) %>
     centralized_sessions: true
     referral_submit: <%= ENV.fetch('REFERRAL_SUBMIT', false) %>
+    investigations: true
 
 test:
   features:
@@ -14,6 +15,7 @@ test:
     authentication: false
     centralized_sessions: true
     referral_submit: false
+    investigations: true
 
 production:
   features:
@@ -22,3 +24,4 @@ production:
     authentication: <%= ENV.fetch('AUTHENTICATION', false) %>
     centralized_sessions: <%= ENV.fetch('CENTRALIZED_SESSIONS', false) %>
     referral_submit: <%= ENV.fetch('REFERRAL_SUBMIT', false) %>
+    investigations: <%= ENV.fetch('INVESTIGATIONS', true) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ require File.join(File.dirname(__FILE__), 'routes/inactive_release_one_constrain
 require File.join(File.dirname(__FILE__), 'routes/inactive_release_two_constraint')
 require File.join(File.dirname(__FILE__), 'routes/inactive_release_one_and_two_constraint')
 require File.join(File.dirname(__FILE__), 'routes/active_referral_submit_constraint')
+require File.join(File.dirname(__FILE__), 'routes/active_investigations_constraint')
 
 Rails.application.routes.draw do
   root 'home#index'
@@ -18,7 +19,9 @@ Rails.application.routes.draw do
     constraints: Routes::InactiveReleaseOneAndTwoConstraint do
   end
 
-  resources :investigations, only: [:show] do
+  resources :investigations,
+    only: [:show],
+    constraints: Routes::ActiveInvestigationsConstraint do
     resources :contacts, only: [:new]
   end
 
@@ -56,7 +59,9 @@ Rails.application.routes.draw do
         end
       end
 
-      resources :investigations, only: [:screening] do
+      resources :investigations,
+        only: [:screening],
+        constraints: Routes::ActiveInvestigationsConstraint do
         member do
           get :screening
         end

--- a/config/routes/active_investigations_constraint.rb
+++ b/config/routes/active_investigations_constraint.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Routes
+  # InactiveReleaseOneAndTwoConstraint provides a feature constraint
+  # for available routes while release_one and release two are inactive
+  class ActiveInvestigationsConstraint
+    def self.matches?(_request)
+      Feature.active?(:investigations)
+    end
+  end
+end

--- a/spec/features/show_investigation_spec.rb
+++ b/spec/features/show_investigation_spec.rb
@@ -1,61 +1,91 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'feature/testing'
 
 feature 'Show Investigation' do
-  scenario 'user navigates to the investigation show page' do
-    investigation_id = '12345'
-    screening_summary = {
-      id: '222',
-      name: 'My Screening',
-      decision_detail: 'immediate',
-      additional_information: 'There was considerable evidence abuse',
-      allegations: [{
-        victim_id: '2',
-        perpetrator_id: '3',
-        allegation_types: ['Severe neglect']
-      }, {
-        victim_id: '2',
-        perpetrator_id: '4',
-        allegation_types: ['Severe neglect', 'Sexual abuse']
-      }],
-      safety_alerts: [
-        'Dangerous Animal on Premises',
-        'Firearms in Home',
-        'Hostile, Aggressive Client',
-        'Remote or Isolated Location'
-      ],
-      safety_information: 'Animal is a tiger'
-    }
-    stub_request(
-      :get, ferb_api_url(ExternalRoutes.ferb_api_investigations_screening(investigation_id))
-    ).and_return(json_body(screening_summary.to_json, status: 200))
-    visit investigation_path(id: investigation_id)
-    within '.card.show', text: 'Screening Summary' do
-      within '.card-body' do
-        within :xpath, ".//div[@class='row'][1]" do
-          expect(page).to have_link 'My Screening', href: screening_path(id: '222')
-          expect(page).to have_content 'Immediate'
-          expect(page).to have_content 'Severe neglect', count: 1
-          expect(page).to have_content 'Sexual abuse'
-        end
-        within :xpath, ".//div[@class='row'][2]" do
-          expect(page).to have_content 'Dangerous Animal on Premises'
-          expect(page).to have_content 'Firearms in Home'
-          expect(page).to have_content 'Hostile, Aggressive Client'
-          expect(page).to have_content 'Remote or Isolated Location'
-          expect(page).to have_content 'Animal is a tiger'
-        end
-        within :xpath, ".//div[@class='row'][3]" do
-          expect(page).to have_content 'There was considerable evidence abuse'
-        end
+  context 'when investigations is enabled' do
+    around do |example|
+      Feature.run_with_activated(:investigations) do
+        example.run
       end
     end
 
-    within '.card.show', text: 'Contact Log' do
-      contact_url = new_investigation_contact_path(investigation_id: investigation_id)
-      expect(page).to have_link 'Create New Contact', href: contact_url
-      expect(page.find_link('Create New Contact')[:target]).to eq '_blank'
+    scenario 'user navigates to the investigation show page' do
+      investigation_id = '12345'
+      screening_summary = {
+        id: '222',
+        name: 'My Screening',
+        decision_detail: 'immediate',
+        additional_information: 'There was considerable evidence abuse',
+        allegations: [{
+          victim_id: '2',
+          perpetrator_id: '3',
+          allegation_types: ['Severe neglect']
+        }, {
+          victim_id: '2',
+          perpetrator_id: '4',
+          allegation_types: ['Severe neglect', 'Sexual abuse']
+        }],
+        safety_alerts: [
+          'Dangerous Animal on Premises',
+          'Firearms in Home',
+          'Hostile, Aggressive Client',
+          'Remote or Isolated Location'
+        ],
+        safety_information: 'Animal is a tiger'
+      }
+      stub_request(
+        :get, ferb_api_url(ExternalRoutes.ferb_api_investigations_screening(investigation_id))
+      ).and_return(json_body(screening_summary.to_json, status: 200))
+      stub_system_codes
+      visit investigation_path(id: investigation_id)
+      within '.card.show', text: 'Screening Summary' do
+        within '.card-body' do
+          within :xpath, ".//div[@class='row'][1]" do
+            expect(page).to have_link 'My Screening', href: screening_path(id: '222')
+            expect(page).to have_content 'Immediate'
+            expect(page).to have_content 'Severe neglect', count: 1
+            expect(page).to have_content 'Sexual abuse'
+          end
+          within :xpath, ".//div[@class='row'][2]" do
+            expect(page).to have_content 'Dangerous Animal on Premises'
+            expect(page).to have_content 'Firearms in Home'
+            expect(page).to have_content 'Hostile, Aggressive Client'
+            expect(page).to have_content 'Remote or Isolated Location'
+            expect(page).to have_content 'Animal is a tiger'
+          end
+          within :xpath, ".//div[@class='row'][3]" do
+            expect(page).to have_content 'There was considerable evidence abuse'
+          end
+        end
+      end
+
+      within '.card.show', text: 'Contact Log' do
+        contact_url = new_investigation_contact_path(investigation_id: investigation_id)
+        expect(page).to have_link 'Create New Contact', href: contact_url
+        expect(page.find_link('Create New Contact')[:target]).to eq '_blank'
+      end
+    end
+  end
+
+  context 'when investigations is disabled' do
+    around do |example|
+      Feature.run_with_deactivated(:investigations) do
+        example.run
+      end
+    end
+
+    scenario 'view an existing screening returns 404', js: true do
+      investigation_id = '12345'
+      visit investigation_path(id: investigation_id)
+      expect(
+        a_request(
+          :get,
+          intake_api_url(ExternalRoutes.ferb_api_investigations_screening(investigation_id))
+        )
+      ).to_not have_been_made
+      expect(page.status_code).to_not eq 200
     end
   end
 end

--- a/spec/javascripts/components/screenings/ScreeningRowSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningRowSpec.jsx
@@ -2,85 +2,116 @@ import React from 'react'
 import ScreeningRow from 'screenings/ScreeningRow'
 import moment from 'moment'
 import {shallow} from 'enzyme'
+import * as IntakeConfig from 'common/config'
 
 describe('ScreeningRow', () => {
-  describe('when referral id is not present', () => {
-    it('renders link to screening with name', () => {
-      const props = {id: '1', name: 'My Screening Name'}
-      const view = shallow(<ScreeningRow {...props} />)
-      const link = view.find('Link')
-      expect(link.props().to).toEqual('/screenings/1')
-      expect(link.html()).toEqual('<a>My Screening Name</a>')
+  describe('with investigations enabled', () => {
+    beforeEach(() => {
+      spyOn(IntakeConfig, 'isFeatureActive').and.returnValue(true)
     })
 
-    it('renders link to screening with ID when name is not present', () => {
-      const props = {id: '123', name: null}
+    describe('when referral id is not present', () => {
+      it('renders link to screening with name', () => {
+        const props = {id: '1', name: 'My Screening Name'}
+        const view = shallow(<ScreeningRow {...props} />)
+        const link = view.find('Link')
+        expect(link.props().to).toEqual('/screenings/1')
+        expect(link.html()).toEqual('<a>My Screening Name</a>')
+      })
+
+      it('renders link to screening with ID when name is not present', () => {
+        const props = {id: '123', name: null}
+        const view = shallow(<ScreeningRow {...props} />)
+        const link = view.find('Link')
+        expect(link.props().to).toEqual('/screenings/123')
+        expect(link.html()).toEqual('<a>123</a>')
+      })
+    })
+
+    describe('when referral id is present', () => {
+      it('renders link to investigation with name', () => {
+        const props = {id: '1', referralId: '456', name: 'My Screening Name'}
+        const view = shallow(<ScreeningRow {...props} />)
+        const link = view.find('Link')
+        expect(link.props().to).toEqual('/investigations/456')
+        expect(link.html()).toEqual('<a>My Screening Name</a>')
+      })
+
+      it('renders link to investigation with referral id when name is not present', () => {
+        const props = {id: '1', referralId: '456', name: null}
+        const view = shallow(<ScreeningRow {...props} />)
+        const link = view.find('Link')
+        expect(link.props().to).toEqual('/investigations/456')
+        expect(link.html()).toEqual('<a>456</a>')
+      })
+    })
+
+    it('renders decision', () => {
+      const props = {id: '1', name: null, decision: 'differential_response'}
       const view = shallow(<ScreeningRow {...props} />)
-      const link = view.find('Link')
-      expect(link.props().to).toEqual('/screenings/123')
-      expect(link.html()).toEqual('<a>123</a>')
+      const tr = view.find('tr')
+      expect(tr.text()).toContain('Differential response')
+    })
+
+    it('renders response time if decision is promote to referral', () => {
+      const props = {id: '1', decision: 'promote_to_referral', decisionDetail: 'immediate'}
+      const view = shallow(<ScreeningRow {...props} />)
+      const tr = view.find('tr')
+      expect(tr.text()).not.toContain('Promote to referral')
+      expect(tr.text()).toContain('Immediate')
+    })
+
+    it('renders category if decision is screen out', () => {
+      const props = {id: '1', decision: 'screen_out', decisionDetail: 'evaluate_out'}
+      const view = shallow(<ScreeningRow {...props} />)
+      const tr = view.find('tr')
+      expect(tr.text()).not.toContain('Screen out')
+      expect(tr.text()).toContain('Evaluate out')
+    })
+
+    it('renders assignee', () => {
+      const props = {id: '1', assignee: 'Bad Wolf'}
+      const view = shallow(<ScreeningRow {...props} />)
+      const tr = view.find('tr')
+      expect(tr.text()).toContain('Bad Wolf')
+    })
+
+    it('renders report date and time', () => {
+      const props = {id: '1', startedAt: '2016-09-21T14:26:58.042Z'}
+      const view = shallow(<ScreeningRow {...props} />)
+      const tr = view.find('tr')
+      expect(tr.text()).toContain('09/21/2016 7:26 AM')
+    })
+
+    it('renders time from now', () => {
+      const props = {id: '1', startedAt: moment().subtract(1, 'year').format()}
+      const view = shallow(<ScreeningRow {...props} />)
+      const tr = view.find('tr')
+      expect(tr.text()).toContain('(a year ago)')
     })
   })
 
-  describe('when referral id is present', () => {
-    it('renders link to investigation with name', () => {
-      const props = {id: '1', referralId: '456', name: 'My Screening Name'}
-      const view = shallow(<ScreeningRow {...props} />)
-      const link = view.find('Link')
-      expect(link.props().to).toEqual('/investigations/456')
-      expect(link.html()).toEqual('<a>My Screening Name</a>')
+  describe('with investigations feature disabled', () => {
+    beforeEach(() => {
+      spyOn(IntakeConfig, 'isFeatureActive').and.returnValue(false)
     })
 
-    it('renders link to investigation with referral id when name is not present', () => {
-      const props = {id: '1', referralId: '456', name: null}
-      const view = shallow(<ScreeningRow {...props} />)
-      const link = view.find('Link')
-      expect(link.props().to).toEqual('/investigations/456')
-      expect(link.html()).toEqual('<a>456</a>')
+    describe('when referral id is present', () => {
+      it('renders link to screening with name', () => {
+        const props = {id: '1', referralId: '456', name: 'My Screening Name'}
+        const view = shallow(<ScreeningRow {...props} />)
+        const link = view.find('Link')
+        expect(link.props().to).toEqual('/screenings/1')
+        expect(link.html()).toEqual('<a>My Screening Name</a>')
+      })
+
+      it('renders link to screening with screening id when name is not present', () => {
+        const props = {id: '1', referralId: '456', name: null}
+        const view = shallow(<ScreeningRow {...props} />)
+        const link = view.find('Link')
+        expect(link.props().to).toEqual('/screenings/1')
+        expect(link.html()).toEqual('<a>456</a>')
+      })
     })
-  })
-
-  it('renders decision', () => {
-    const props = {id: '1', name: null, decision: 'differential_response'}
-    const view = shallow(<ScreeningRow {...props} />)
-    const tr = view.find('tr')
-    expect(tr.text()).toContain('Differential response')
-  })
-
-  it('renders response time if decision is promote to referral', () => {
-    const props = {id: '1', decision: 'promote_to_referral', decisionDetail: 'immediate'}
-    const view = shallow(<ScreeningRow {...props} />)
-    const tr = view.find('tr')
-    expect(tr.text()).not.toContain('Promote to referral')
-    expect(tr.text()).toContain('Immediate')
-  })
-
-  it('renders category if decision is screen out', () => {
-    const props = {id: '1', decision: 'screen_out', decisionDetail: 'evaluate_out'}
-    const view = shallow(<ScreeningRow {...props} />)
-    const tr = view.find('tr')
-    expect(tr.text()).not.toContain('Screen out')
-    expect(tr.text()).toContain('Evaluate out')
-  })
-
-  it('renders assignee', () => {
-    const props = {id: '1', assignee: 'Bad Wolf'}
-    const view = shallow(<ScreeningRow {...props} />)
-    const tr = view.find('tr')
-    expect(tr.text()).toContain('Bad Wolf')
-  })
-
-  it('renders report date and time', () => {
-    const props = {id: '1', startedAt: '2016-09-21T14:26:58.042Z'}
-    const view = shallow(<ScreeningRow {...props} />)
-    const tr = view.find('tr')
-    expect(tr.text()).toContain('09/21/2016 7:26 AM')
-  })
-
-  it('renders time from now', () => {
-    const props = {id: '1', startedAt: moment().subtract(1, 'year').format()}
-    const view = shallow(<ScreeningRow {...props} />)
-    const tr = view.find('tr')
-    expect(tr.text()).toContain('(a year ago)')
   })
 })


### PR DESCRIPTION
### Pivotal Story

- [Can push all code base to new environments with unfinished investigations code inactive 150856008](https://www.pivotaltracker.com/story/show/150856008)

### Purpose
Add feature flag for investigations.

### Background
We want to make sure we can turn investigations off in certain environments without harming availability of the screenings code.

### Questions for Reviewer
None. We've been here before. Pretty boring stuff.

### Testing Notes
We'll need to find a good place to test this, since the environments will default to having the feature on unless we explicitly turn it off.
