### PR TITLE
Replace search_url with dora and ferb urls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,8 @@ services:
     environment:
       AUTHENTICATION_URL: 'https://perry.preint.cwds.io/perry'
       AUTHENTICATION: ${AUTHENTICATION:-true}
-      SEARCH_URL: 'https://ferbapi.preint.cwds.io'
+      DORA_URL: 'https://dora.preint.cwds.io/'
+      FERB_URL: 'https://ferbapi.preint.cwds.io'
     tty: true
     stdin_open: true
   db:


### PR DESCRIPTION
[#151073242]

### Pivotal Story

- [**HOTLINE: E2E** Change references to search using DORA instead of FERB dora](https://www.pivotaltracker.com/story/show/151073242)

### Purpose
Support the separation of Dora and Ferb in dev mode

