### PR TITLE
In 151271333 exclude snapshot screenings from search

### DIFF
--- a/app/models/screening.rb
+++ b/app/models/screening.rb
@@ -24,7 +24,9 @@ class Screening # :nodoc:
   attribute :restrictions_rationale
   attribute :staff_id
   attribute :started_at
-
+  attribute :indexable, Boolean, default: lambda { |_screening, _attribute|
+    Feature.inactive?(:release_two)
+  }
   attribute :address, Address
   attribute :assignee, String
   attribute :cross_reports, Array[CrossReport]

--- a/spec/controllers/api/v1/screenings_controller_spec.rb
+++ b/spec/controllers/api/v1/screenings_controller_spec.rb
@@ -12,6 +12,23 @@ describe Api::V1::ScreeningsController do
     }
   end
 
+  describe 'permitted attributes' do
+    describe '#create' do
+      before do
+        allow(LUID).to receive(:generate).and_return(['123ABC'])
+      end
+      it 'does not set indexable' do
+        screening_params = { indexable: [true, false].sample }
+        expect(Screening).to receive(:new)
+          .with(
+            hash_not_including(:indexable)
+          ).and_call_original
+        allow(ScreeningRepository).to receive(:create)
+        process :create, method: :post, session: session, params: screening_params
+      end
+    end
+  end
+
   describe '#create' do
     let(:created_screening) { double(:screening, id: '1') }
     let(:blank_screening) { double(:screening) }

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -15,6 +15,7 @@ feature 'Create Screening' do
       allow(LUID).to receive(:generate).and_return(['DQJIYK'])
       new_screening = FactoryGirl.create(
         :screening,
+        indexable: true,
         reference: 'DQJIYK',
         safety_alerts: [],
         safety_information: nil,

--- a/spec/models/screening_spec.rb
+++ b/spec/models/screening_spec.rb
@@ -1,12 +1,33 @@
 # frozen_string_literal: true
 
 require 'rails_helper'
+require 'feature/testing'
 
 describe Screening do
   describe 'new screening object' do
     let(:screening) { described_class.new }
     it ' does not have default cross report values' do
       expect(screening.cross_reports).to be_empty
+    end
+    describe '#indexable' do
+      around do |example|
+        Feature.run_with_deactivated(:release_two) do
+          example.run
+        end
+      end
+      it 'sets indexable to true' do
+        expect(screening.indexable).to be true
+      end
+    end
+    describe 'release_two enabled' do
+      around do |example|
+        Feature.run_with_activated(:release_two) do
+          example.run
+        end
+      end
+      it 'sets indexable to false' do
+        expect(screening.indexable).to be false
+      end
     end
   end
 
@@ -19,6 +40,7 @@ describe Screening do
         id: '2',
         incident_county: 'sacramento',
         incident_date: '2016-08-11',
+        indexable: false,
         location_type: nil,
         name: 'Little Shop Of Horrors',
         reference: 'My Bad!',
@@ -87,6 +109,7 @@ describe Screening do
         id: '2',
         incident_county: 'sacramento',
         incident_date: '2016-08-11',
+        indexable: false,
         location_type: nil,
         name: 'Little Shop Of Horrors',
         reference: 'My Bad!',


### PR DESCRIPTION
### Pivotal Story

- https://www.pivotaltracker.com/story/show/151271333

### Purpose

Set the new`is_snapshot` flag to true for screenings created in release two environment ("temporal screenings"). 