### PR TITLE
Force update of participant as part of save

### DIFF
--- a/app/javascript/screenings/ParticipantCardView.jsx
+++ b/app/javascript/screenings/ParticipantCardView.jsx
@@ -52,13 +52,14 @@ export default class ParticipantCardView extends React.Component {
 
   onDobBlur(value) {
     if (value) {
-      const participant = this.stripApproximateAge(this.props.participant)
-      this.props.onChange(this.props.participant.get('id'), participant)
+      this.stripApproximateAge(this.props.participant)
     }
   }
 
   stripApproximateAge(participant) {
-    return participant.set('approximate_age', null).set('approximate_age_units', null)
+    const cleanedParticipant = participant.set('approximate_age', null).set('approximate_age_units', null)
+    this.props.onChange(cleanedParticipant.get('id'), cleanedParticipant)
+    return cleanedParticipant
   }
 
   render() {

--- a/spec/javascripts/components/screenings/participants/ParticipantCardViewSpec.jsx
+++ b/spec/javascripts/components/screenings/participants/ParticipantCardViewSpec.jsx
@@ -65,6 +65,7 @@ describe('Participant card view', () => {
       describe('#onSave', () => {
         let instance
         let onSave
+        let onChange
         const phoneNumberOne = {number: '(123)345-8899'}
         const phoneNumberTwo = {number: '1112223333'}
         const participant = Immutable.fromJS({
@@ -76,7 +77,8 @@ describe('Participant card view', () => {
         })
         beforeEach(() => {
           onSave = jasmine.createSpy('onSave')
-          const component = shallow(<ParticipantCardView {...{participant, onSave, mode: 'edit', editable: true}} />)
+          onChange = jasmine.createSpy('onChange')
+          const component = shallow(<ParticipantCardView {...{participant, onSave, onChange, mode: 'edit', editable: true}} />)
           instance = component.instance()
           instance.onSave()
         })
@@ -87,6 +89,10 @@ describe('Participant card view', () => {
 
         it('calls onSave', () => {
           expect(onSave).toHaveBeenCalled()
+        })
+
+        it('calls onChange', () => {
+          expect(onChange).toHaveBeenCalled()
         })
 
         it('sanitizes participants phone numbers and approximate age', () => {


### PR DESCRIPTION
- IE not clearing approximate age fields without this step

[#140105657]

### Pivotal Story

- [**HOTLINE: ** Create Approximate Age field for a Person](https://www.pivotaltracker.com/story/show/140105657)

### Purpose
Fix issue where IE does not fully clear approximate age fields when blur of DOB field does not happen

### Testing Notes
Test in IE 11
