### PR TITLE
Allow apostrophe in Screening Name field

### DIFF
--- a/app/javascript/screenings/ScreeningInformationEditView.jsx
+++ b/app/javascript/screenings/ScreeningInformationEditView.jsx
@@ -9,7 +9,7 @@ const ScreeningInformationEditView = ({screening, onCancel, onChange, onSave, va
   <div className='card-body'>
     <div className='row'>
       <InputField
-        allowCharacters={/[a-zA-Z\s-]/}
+        allowCharacters={/[a-zA-Z\s'’-]/}
         gridClassName='col-md-6'
         id='name'
         label='Title/Name of Screening'

--- a/spec/features/screening/screening_information_spec.rb
+++ b/spec/features/screening/screening_information_spec.rb
@@ -16,7 +16,7 @@ feature 'screening information card' do
     )
   end
 
-  let(:character_buffet) { 'C am-ron1234567890!@#$%^&*(),./;"[]' }
+  let(:character_buffet) { 'C am-r\'o’n1234567890!@#$%^&*(),./;"[]' }
 
   before(:each) do
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
@@ -29,7 +29,7 @@ feature 'screening information card' do
     within '#screening-information-card.edit' do
       fill_in 'Title/Name of Screening', with: character_buffet
       fill_in 'Assigned Social Worker', with: character_buffet
-      expect(page).to have_field('Title/Name of Screening', with: 'C am-ron')
+      expect(page).to have_field('Title/Name of Screening', with: "C am-r'o’n")
       expect(page).to have_field('Assigned Social Worker', with: 'C amron')
     end
   end

--- a/spec/javascripts/components/screenings/screeningInformation/ScreeningInformationEditViewSpec.jsx
+++ b/spec/javascripts/components/screenings/screeningInformation/ScreeningInformationEditViewSpec.jsx
@@ -37,8 +37,8 @@ describe('ScreeningInformationEditView', () => {
       const titleField = component.find('InputField[label="Title/Name of Screening"]')
       expect(titleField.props().value).toEqual('The Rocky Horror Picture Show')
       expect(titleField.props().maxLength).toEqual('64')
-      // Allows alpha, space, and hyphen
-      expect(titleField.props().allowCharacters).toEqual(/[a-zA-Z\s-]/)
+      // Allows alpha, space, hyphen, and apostrophe
+      expect(titleField.props().allowCharacters).toEqual(/[a-zA-Z\s'’-]/)
     })
 
     it('renders the assigned social worker field', () => {


### PR DESCRIPTION
- Allowing actual apostrophe (’)
- Allowing single quote (i) which is also commonly used as an apostrophe
[#151423584]

### Pivotal Story

- [**HOTLINE: ** Title/Name of Screening should allow for an apostrophe #151423584](https://www.pivotaltracker.com/story/show/151423584)