### PR TITLE
In 150411707 include selected people in contact post

### DIFF
--- a/app/controllers/api/v1/investigations/contacts_controller.rb
+++ b/app/controllers/api/v1/investigations/contacts_controller.rb
@@ -15,7 +15,7 @@ module Api
           :note,
           :communication_method,
           :location,
-          people: []
+          people: %i[legacy_id legacy_table_name]
         ].freeze
 
         def create

--- a/app/controllers/api/v1/investigations/contacts_controller.rb
+++ b/app/controllers/api/v1/investigations/contacts_controller.rb
@@ -15,7 +15,7 @@ module Api
           :note,
           :communication_method,
           :location,
-          people: %i[legacy_id legacy_table_name]
+          people: [legacy_descriptor: %i[legacy_id legacy_table_name]]
         ].freeze
 
         def create

--- a/app/javascript/actions/contactFormActions.js
+++ b/app/javascript/actions/contactFormActions.js
@@ -5,6 +5,7 @@ export const SET_CONTACT_FIELD = 'SET_CONTACT_FIELD'
 export const TOUCH_CONTACT_FIELD = 'TOUCH_CONTACT_FIELD'
 export const TOUCH_ALL_CONTACT_FIELDS = 'TOUCH_ALL_CONTACT_FIELDS'
 export const SELECT_CONTACT_PERSON = 'SELECT_CONTACT_PERSON'
+export const DESELECT_CONTACT_PERSON = 'DESELECT_CONTACT_PERSON'
 export function build({investigation_id}) {
   return {type: BUILD_CONTACT, investigation_id}
 }
@@ -19,6 +20,9 @@ export function setField(field, value) {
 }
 export function selectPerson(index) {
   return {type: SELECT_CONTACT_PERSON, index}
+}
+export function deselectPerson(index) {
+  return {type: DESELECT_CONTACT_PERSON, index}
 }
 export function touchField(field) {
   return {type: TOUCH_CONTACT_FIELD, field}

--- a/app/javascript/actions/contactFormActions.js
+++ b/app/javascript/actions/contactFormActions.js
@@ -7,8 +7,8 @@ export const TOUCH_ALL_CONTACT_FIELDS = 'TOUCH_ALL_CONTACT_FIELDS'
 export function build({investigation_id}) {
   return {type: BUILD_CONTACT, investigation_id}
 }
-export function buildSuccess({investigation_id, investigation_started_at}) {
-  return {type: BUILD_CONTACT_SUCCESS, investigation_id, investigation_started_at}
+export function buildSuccess({investigation_id, investigation_started_at, people}) {
+  return {type: BUILD_CONTACT_SUCCESS, investigation_id, investigation_started_at, people}
 }
 export function buildFailure(error) {
   return {type: BUILD_CONTACT_FAILURE, error}

--- a/app/javascript/actions/contactFormActions.js
+++ b/app/javascript/actions/contactFormActions.js
@@ -4,6 +4,7 @@ export const BUILD_CONTACT_FAILURE = 'BUILD_CONTACT_FAILURE'
 export const SET_CONTACT_FIELD = 'SET_CONTACT_FIELD'
 export const TOUCH_CONTACT_FIELD = 'TOUCH_CONTACT_FIELD'
 export const TOUCH_ALL_CONTACT_FIELDS = 'TOUCH_ALL_CONTACT_FIELDS'
+export const SELECT_CONTACT_PERSON = 'SELECT_CONTACT_PERSON'
 export function build({investigation_id}) {
   return {type: BUILD_CONTACT, investigation_id}
 }
@@ -15,6 +16,9 @@ export function buildFailure(error) {
 }
 export function setField(field, value) {
   return {type: SET_CONTACT_FIELD, field, value}
+}
+export function selectPerson(index) {
+  return {type: SELECT_CONTACT_PERSON, index}
 }
 export function touchField(field) {
   return {type: TOUCH_CONTACT_FIELD, field}

--- a/app/javascript/common/routes.jsx
+++ b/app/javascript/common/routes.jsx
@@ -5,7 +5,7 @@ import HomePage from 'home/HomePage'
 import ScreeningPage from 'screenings/ScreeningPage'
 import ScreeningSummaryContainer from 'investigations/ScreeningSummaryContainer'
 import ContactLogContainer from 'investigations/ContactLogContainer'
-import ContactContainer from 'investigations/ContactContainer'
+import ContactFormContainer from 'investigations/ContactFormContainer'
 import ContactShowContainer from 'investigations/ContactShowContainer'
 import {store} from 'store/configureStore'
 import {Provider} from 'react-redux'
@@ -29,7 +29,7 @@ export default (
         <Route path='screenings/:id' component={ScreeningPage}/>
         <Route path='screenings/:id/:mode' component={ScreeningPage} />
         <Route path='investigations/:id' component={InvestigationPage} />
-        <Route path='investigations/:investigation_id/contacts/new' component={ContactContainer} />
+        <Route path='investigations/:investigation_id/contacts/new' component={ContactFormContainer} />
         <Route path='investigations/:investigation_id/contacts/:id' component={ContactShowContainer} />
       </Route>
     </Router>

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import DateField from 'common/DateField'
-import nameFormatter from 'utils/nameFormatter'
 import SelectField from 'common/SelectField'
 import FormField from 'common/FormField'
 
@@ -107,7 +106,7 @@ class ContactForm extends React.Component {
                 <div className='row'>
                   <FormField gridClassName='col-md-12' label='People Present' id='people'>
                     { <ul>
-                      {people.map((person, i) => <li key={i}>{nameFormatter(person)}</li>)}
+                      {people.map((person, i) => <li key={i}>{person.name}</li>)}
                     </ul>
                     }
                   </FormField>

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import DateField from 'common/DateField'
 import SelectField from 'common/SelectField'
+import CheckboxField from 'common/CheckboxField'
 import FormField from 'common/FormField'
 
 class ContactForm extends React.Component {
@@ -105,10 +106,14 @@ class ContactForm extends React.Component {
                 }
                 <div className='row'>
                   <FormField gridClassName='col-md-12' label='People Present' id='people'>
-                    { <ul>
-                      {people.map((person, i) => <li key={i}>{person.name}</li>)}
-                    </ul>
-                    }
+                    { people.map((person, index) =>
+                      <CheckboxField
+                        key={`person_${index}`}
+                        id={`person_${index}`}
+                        value={person.name}
+                        checked={person.selected}
+                      />
+                    )}
                   </FormField>
                 </div>
                 <div className='row'>
@@ -184,6 +189,7 @@ ContactForm.propTypes = {
 
 ContactForm.defaultProps = {
   errors: {},
+  people: [],
 }
 
 export default ContactForm

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -29,6 +29,7 @@ class ContactForm extends React.Component {
       officeLocationCode,
       people,
       valid,
+      selectedPeopleIds,
     } = this.props
     const onSubmit = (event) => {
       event.preventDefault()
@@ -41,7 +42,7 @@ class ContactForm extends React.Component {
           status,
           note,
           purpose,
-          people: [],
+          people: selectedPeopleIds,
         })
       } else {
         touchAllFields()
@@ -188,6 +189,7 @@ ContactForm.propTypes = {
   people: PropTypes.array.isRequired,
   purpose: PropTypes.string,
   purposes: PropTypes.array.isRequired,
+  selectedPeopleIds: PropTypes.array,
   startedAt: PropTypes.string,
   status: PropTypes.string,
   statuses: PropTypes.array.isRequired,
@@ -197,6 +199,7 @@ ContactForm.propTypes = {
 ContactForm.defaultProps = {
   errors: {},
   people: [],
+  selectedPeopleIds: [],
 }
 
 export default ContactForm

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -19,7 +19,7 @@ class ContactForm extends React.Component {
       status,
       note,
       purpose,
-      actions: {setField, touchField, create, touchAllFields},
+      actions: {setField, touchField, create, touchAllFields, selectPerson},
       statuses,
       purposes,
       communicationMethods,
@@ -112,6 +112,7 @@ class ContactForm extends React.Component {
                         id={`person_${index}`}
                         value={person.name}
                         checked={person.selected}
+                        onChange={() => selectPerson(index)}
                       />
                     )}
                   </FormField>

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -5,7 +5,7 @@ import nameFormatter from 'utils/nameFormatter'
 import SelectField from 'common/SelectField'
 import FormField from 'common/FormField'
 
-class Contact extends React.Component {
+class ContactForm extends React.Component {
   componentDidMount() {
     const {investigationId, actions: {build}} = this.props
     build({investigation_id: investigationId})
@@ -163,7 +163,7 @@ class Contact extends React.Component {
   }
 }
 
-Contact.propTypes = {
+ContactForm.propTypes = {
   actions: PropTypes.object,
   communicationMethod: PropTypes.string,
   communicationMethods: PropTypes.array.isRequired,
@@ -183,8 +183,8 @@ Contact.propTypes = {
   valid: PropTypes.bool,
 }
 
-Contact.defaultProps = {
+ContactForm.defaultProps = {
   errors: {},
 }
 
-export default Contact
+export default ContactForm

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -19,7 +19,7 @@ class ContactForm extends React.Component {
       status,
       note,
       purpose,
-      actions: {setField, touchField, create, touchAllFields, selectPerson},
+      actions: {setField, touchField, create, touchAllFields, selectPerson, deselectPerson},
       statuses,
       purposes,
       communicationMethods,
@@ -112,7 +112,13 @@ class ContactForm extends React.Component {
                         id={`person_${index}`}
                         value={person.name}
                         checked={person.selected}
-                        onChange={() => selectPerson(index)}
+                        onChange={({target: {checked}}) => {
+                          if (checked === true) {
+                            return selectPerson(index)
+                          } else {
+                            return deselectPerson(index)
+                          }
+                        }}
                       />
                     )}
                   </FormField>

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -198,8 +198,6 @@ ContactForm.propTypes = {
 
 ContactForm.defaultProps = {
   errors: {},
-  people: [],
-  selectedPeopleIds: [],
 }
 
 export default ContactForm

--- a/app/javascript/investigations/ContactFormContainer.jsx
+++ b/app/javascript/investigations/ContactFormContainer.jsx
@@ -15,7 +15,7 @@ import {
 import {
   getVisibleErrorsSelector,
   getHasErrorsValueSelector,
-  getPeopleSelector,
+  getFormattedContactPeople,
   getSelectedPeopleIdsSelector,
 } from 'selectors/contactFormSelectors'
 
@@ -37,7 +37,7 @@ const mapStateToProps = (state, ownProps) => {
     inPersonCode: getInPersonCommunicationMethodValueSelector(state),
     officeLocationCode: getOfficeLocationCodeValueSelector(state),
     locations: getLocationsSelector(state).toJS(),
-    people: getPeopleSelector(state).toJS(),
+    people: getFormattedContactPeople(state).toJS(),
     selectedPeopleIds: getSelectedPeopleIdsSelector(state).toJS(),
   }
 }

--- a/app/javascript/investigations/ContactFormContainer.jsx
+++ b/app/javascript/investigations/ContactFormContainer.jsx
@@ -35,7 +35,7 @@ const mapStateToProps = (state, ownProps) => {
     inPersonCode: getInPersonCommunicationMethodValueSelector(state),
     officeLocationCode: getOfficeLocationCodeValueSelector(state),
     locations: getLocationsSelector(state).toJS(),
-    people: contactForm.get('people').toJS(),
+    people: contactForm.get('people') && contactForm.get('people').toJS(),
   }
 }
 

--- a/app/javascript/investigations/ContactFormContainer.jsx
+++ b/app/javascript/investigations/ContactFormContainer.jsx
@@ -15,6 +15,7 @@ import {
 import {
   getVisibleErrorsSelector,
   getHasErrorsValueSelector,
+  getPeopleSelector,
   getSelectedPeopleIdsSelector,
 } from 'selectors/contactFormSelectors'
 
@@ -36,7 +37,7 @@ const mapStateToProps = (state, ownProps) => {
     inPersonCode: getInPersonCommunicationMethodValueSelector(state),
     officeLocationCode: getOfficeLocationCodeValueSelector(state),
     locations: getLocationsSelector(state).toJS(),
-    people: contactForm.get('people') && contactForm.get('people').toJS(),
+    people: getPeopleSelector(state).toJS(),
     selectedPeopleIds: getSelectedPeopleIdsSelector(state).toJS(),
   }
 }

--- a/app/javascript/investigations/ContactFormContainer.jsx
+++ b/app/javascript/investigations/ContactFormContainer.jsx
@@ -1,6 +1,6 @@
 import * as contactFormActions from 'actions/contactFormActions'
 import {create} from 'actions/contactActions'
-import Contact from 'investigations/Contact'
+import ContactForm from 'investigations/ContactForm'
 import {bindActionCreators} from 'redux'
 import {connect} from 'react-redux'
 import {
@@ -44,4 +44,4 @@ const mapDispatchToProps = (dispatch, _ownProps) => {
   return {actions: bindActionCreators(actions, dispatch)}
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(Contact)
+export default connect(mapStateToProps, mapDispatchToProps)(ContactForm)

--- a/app/javascript/investigations/ContactFormContainer.jsx
+++ b/app/javascript/investigations/ContactFormContainer.jsx
@@ -35,7 +35,7 @@ const mapStateToProps = (state, ownProps) => {
     inPersonCode: getInPersonCommunicationMethodValueSelector(state),
     officeLocationCode: getOfficeLocationCodeValueSelector(state),
     locations: getLocationsSelector(state).toJS(),
-    people: state.get('investigationPeople').toJS(),
+    people: contactForm.get('people').toJS(),
   }
 }
 

--- a/app/javascript/investigations/ContactFormContainer.jsx
+++ b/app/javascript/investigations/ContactFormContainer.jsx
@@ -15,6 +15,7 @@ import {
 import {
   getVisibleErrorsSelector,
   getHasErrorsValueSelector,
+  getSelectedPeopleIdsSelector,
 } from 'selectors/contactFormSelectors'
 
 const mapStateToProps = (state, ownProps) => {
@@ -36,6 +37,7 @@ const mapStateToProps = (state, ownProps) => {
     officeLocationCode: getOfficeLocationCodeValueSelector(state),
     locations: getLocationsSelector(state).toJS(),
     people: contactForm.get('people') && contactForm.get('people').toJS(),
+    selectedPeopleIds: getSelectedPeopleIdsSelector(state).toJS(),
   }
 }
 

--- a/app/javascript/reducers/contactFormReducer.js
+++ b/app/javascript/reducers/contactFormReducer.js
@@ -7,9 +7,10 @@ import {
 import {CREATE_CONTACT_SUCCESS} from 'actions/contactActions'
 import {createReducer} from 'utils/createReducer'
 import {Map, fromJS} from 'immutable'
+import nameFormatter from 'utils/nameFormatter'
 
 export default createReducer(Map(), {
-  [BUILD_CONTACT_SUCCESS](_state, {investigation_id, investigation_started_at}) {
+  [BUILD_CONTACT_SUCCESS](_state, {investigation_id, investigation_started_at, people = []}) {
     const fieldWithTouch = {value: null, touched: false}
     const fieldWithValue = (value) => ({value: value})
     return fromJS({
@@ -22,6 +23,7 @@ export default createReducer(Map(), {
       communication_method: fieldWithTouch,
       location: fieldWithTouch,
       investigation_started_at: fieldWithValue(investigation_started_at),
+      people: people.map((person) => ({name: nameFormatter(person), selected: false, id: person.legacy_descriptor})),
     })
   },
   [SET_CONTACT_FIELD](state, {field, value}) {

--- a/app/javascript/reducers/contactFormReducer.js
+++ b/app/javascript/reducers/contactFormReducer.js
@@ -3,6 +3,7 @@ import {
   SET_CONTACT_FIELD,
   TOUCH_CONTACT_FIELD,
   TOUCH_ALL_CONTACT_FIELDS,
+  SELECT_CONTACT_PERSON,
 } from 'actions/contactFormActions'
 import {CREATE_CONTACT_SUCCESS} from 'actions/contactActions'
 import {createReducer} from 'utils/createReducer'
@@ -40,6 +41,9 @@ export default createReducer(Map(), {
       (contact, field) => contact.setIn([field, 'touched'], true),
       state
     )
+  },
+  [SELECT_CONTACT_PERSON](state, {index}) {
+    return state.setIn(['people', index, 'selected'], true)
   },
   [CREATE_CONTACT_SUCCESS](state, {id, started_at, status, note, purpose, communication_method, location}) {
     return state.setIn(['id', 'value'], id)

--- a/app/javascript/reducers/contactFormReducer.js
+++ b/app/javascript/reducers/contactFormReducer.js
@@ -9,7 +9,6 @@ import {
 import {CREATE_CONTACT_SUCCESS} from 'actions/contactActions'
 import {createReducer} from 'utils/createReducer'
 import {Map, fromJS} from 'immutable'
-import nameFormatter from 'utils/nameFormatter'
 
 export default createReducer(Map(), {
   [BUILD_CONTACT_SUCCESS](_state, {investigation_id, investigation_started_at, people = []}) {
@@ -25,7 +24,13 @@ export default createReducer(Map(), {
       communication_method: fieldWithTouch,
       location: fieldWithTouch,
       investigation_started_at: fieldWithValue(investigation_started_at),
-      people: people.map((person) => ({name: nameFormatter(person), selected: false, id: person.legacy_descriptor})),
+      people: people.map(({first_name, last_name, middle_name, name_suffix, legacy_descriptor}) => ({
+        first_name,
+        last_name,
+        middle_name,
+        name_suffix,
+        selected: false,
+        id: legacy_descriptor})),
     })
   },
   [SET_CONTACT_FIELD](state, {field, value}) {

--- a/app/javascript/reducers/contactFormReducer.js
+++ b/app/javascript/reducers/contactFormReducer.js
@@ -29,8 +29,9 @@ export default createReducer(Map(), {
         last_name,
         middle_name,
         name_suffix,
+        legacy_descriptor,
         selected: false,
-        id: legacy_descriptor})),
+      })),
     })
   },
   [SET_CONTACT_FIELD](state, {field, value}) {

--- a/app/javascript/reducers/contactFormReducer.js
+++ b/app/javascript/reducers/contactFormReducer.js
@@ -4,6 +4,7 @@ import {
   TOUCH_CONTACT_FIELD,
   TOUCH_ALL_CONTACT_FIELDS,
   SELECT_CONTACT_PERSON,
+  DESELECT_CONTACT_PERSON,
 } from 'actions/contactFormActions'
 import {CREATE_CONTACT_SUCCESS} from 'actions/contactActions'
 import {createReducer} from 'utils/createReducer'
@@ -44,6 +45,9 @@ export default createReducer(Map(), {
   },
   [SELECT_CONTACT_PERSON](state, {index}) {
     return state.setIn(['people', index, 'selected'], true)
+  },
+  [DESELECT_CONTACT_PERSON](state, {index}) {
+    return state.setIn(['people', index, 'selected'], false)
   },
   [CREATE_CONTACT_SUCCESS](state, {id, started_at, status, note, purpose, communication_method, location}) {
     return state.setIn(['id', 'value'], id)

--- a/app/javascript/sagas/buildContactSaga.js
+++ b/app/javascript/sagas/buildContactSaga.js
@@ -11,6 +11,7 @@ export function* buildContact({investigation_id}) {
       buildSuccess({
         investigation_id,
         investigation_started_at: investigation.started_at,
+        people: investigation.people,
       })
     )
   } catch (error) {

--- a/app/javascript/selectors/contactFormSelectors.js
+++ b/app/javascript/selectors/contactFormSelectors.js
@@ -13,6 +13,7 @@ import {
   isBeforeDatetimeCreate,
   combineCompact,
 } from 'utils/validator'
+import nameFormatter from 'utils/nameFormatter'
 
 /* eslint-disable no-invalid-this */
 const systemCodeDisplayValue = (code, systemCodes, noSetValue = Map(), context = this) => systemCodes.find(
@@ -95,6 +96,12 @@ export const getHasErrorsValueSelector = createSelector(
 export const getPeopleSelector = createSelector(
   (state) => state.get('contactForm'),
   (contactForm) => contactForm.get('people') || List()
+)
+export const getFormattedContactPeople = createSelector(
+  getPeopleSelector,
+  (people) => (
+    people.map((person) => Map({name: nameFormatter(person.toJS()), selected: person.get('selected')}))
+  )
 )
 export const getSelectedPeopleIdsSelector = createSelector(
   getPeopleSelector,

--- a/app/javascript/selectors/contactFormSelectors.js
+++ b/app/javascript/selectors/contactFormSelectors.js
@@ -105,5 +105,8 @@ export const getFormattedContactPeople = createSelector(
 )
 export const getSelectedPeopleIdsSelector = createSelector(
   getPeopleSelector,
-  (people) => people.filter((person) => person.get('selected')).map((person) => person.get('id'))
+  (people = List()) => (
+    people.filter((person) => person.get('selected'))
+      .map((person) => Map({legacy_descriptor: person.get('legacy_descriptor')}))
+  )
 )

--- a/app/javascript/selectors/contactFormSelectors.js
+++ b/app/javascript/selectors/contactFormSelectors.js
@@ -92,3 +92,7 @@ export const getHasErrorsValueSelector = createSelector(
   getErrorsSelector,
   (errors) => errors.some((fieldErrors) => !fieldErrors.isEmpty())
 )
+export const getSelectedPeopleIdsSelector = createSelector(
+  (state) => state.getIn(['contactForm', 'people']),
+  (people = List()) => people.filter((person) => person.get('selected')).map((person) => person.get('id'))
+)

--- a/app/javascript/selectors/contactFormSelectors.js
+++ b/app/javascript/selectors/contactFormSelectors.js
@@ -92,7 +92,11 @@ export const getHasErrorsValueSelector = createSelector(
   getErrorsSelector,
   (errors) => errors.some((fieldErrors) => !fieldErrors.isEmpty())
 )
+export const getPeopleSelector = createSelector(
+  (state) => state.get('contactForm'),
+  (contactForm) => contactForm.get('people') || List()
+)
 export const getSelectedPeopleIdsSelector = createSelector(
-  (state) => state.getIn(['contactForm', 'people']),
-  (people = List()) => people.filter((person) => person.get('selected')).map((person) => person.get('id'))
+  getPeopleSelector,
+  (people) => people.filter((person) => person.get('selected')).map((person) => person.get('id'))
 )

--- a/spec/features/contacts/create_investigation_contact_spec.rb
+++ b/spec/features/contacts/create_investigation_contact_spec.rb
@@ -7,8 +7,8 @@ feature 'Create Investigation Contact' do
 
   before do
     people = [
-      { first_name: 'Emma', last_name: 'Woodhouse' },
-      { first_name: 'George', last_name: 'Knightley' }
+      { first_name: 'Emma', last_name: 'Woodhouse', legacy_descriptor: { legacy_id: '1' } },
+      { first_name: 'George', last_name: 'Knightley', legacy_descriptor: { legacy_id: '2' } }
     ]
     stub_request(
       :get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
@@ -50,7 +50,9 @@ feature 'Create Investigation Contact' do
           purpose: '1',
           communication_method: 'ABC',
           location: '123',
-          people: []
+          people: [
+            { first_name: 'Emma', last_name: 'Woodhouse', legacy_descriptor: { legacy_id: '1' } }
+          ]
         }.to_json,
         status: 201
       )
@@ -66,7 +68,7 @@ feature 'Create Investigation Contact' do
           note: 'This was an attempted contact',
           communication_method: 'ABC',
           location: '123',
-          people: []
+          people: [{ legacy_id: '1' }]
         }.to_json
       )
     ).to have_been_made

--- a/spec/features/contacts/create_investigation_contact_spec.rb
+++ b/spec/features/contacts/create_investigation_contact_spec.rb
@@ -7,8 +7,15 @@ feature 'Create Investigation Contact' do
 
   before do
     people = [
-      { first_name: 'Emma', last_name: 'Woodhouse', legacy_descriptor: { legacy_id: '1' } },
-      { first_name: 'George', last_name: 'Knightley', legacy_descriptor: { legacy_id: '2' } }
+      {
+        first_name: 'Emma',
+        last_name: 'Woodhouse',
+        legacy_descriptor: { legacy_id: '1', legacy_table_name: 'foo' }
+      }, {
+        first_name: 'George',
+        last_name: 'Knightley',
+        legacy_descriptor: { legacy_id: '2', legacy_table_name: 'foo' }
+      }
     ]
     stub_request(
       :get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
@@ -51,7 +58,11 @@ feature 'Create Investigation Contact' do
           communication_method: 'ABC',
           location: '123',
           people: [
-            { first_name: 'Emma', last_name: 'Woodhouse', legacy_descriptor: { legacy_id: '1' } }
+            {
+              first_name: 'Emma',
+              last_name: 'Woodhouse',
+              legacy_descriptor: { legacy_id: '1', legacy_table_name: 'foo' }
+            }
           ]
         }.to_json,
         status: 201
@@ -68,7 +79,7 @@ feature 'Create Investigation Contact' do
           note: 'This was an attempted contact',
           communication_method: 'ABC',
           location: '123',
-          people: [{ legacy_id: '1' }]
+          people: [{ legacy_descriptor: { legacy_id: '1', legacy_table_name: 'foo' } }]
         }.to_json
       )
     ).to have_been_made

--- a/spec/features/contacts/create_investigation_contact_spec.rb
+++ b/spec/features/contacts/create_investigation_contact_spec.rb
@@ -25,13 +25,14 @@ feature 'Create Investigation Contact' do
       select 'Attempted', from: 'Status'
       select 'In person', from: 'Communication Method'
       select 'School', from: 'Location'
+      find('label', text: 'Emma Woodhouse').click
       select 'Investigate Referral', from: 'Purpose'
       fill_in 'Contact Notes', with: 'This was an attempted contact'
     end
     expect(page).to have_field('Date/Time', with: '08/17/2016 3:00 AM')
     expect(page).to have_select('Communication Method', selected: 'In person')
-    expect(page).to have_content('Emma Woodhouse')
-    expect(page).to have_content('George Knightley')
+    expect(page).to have_checked_field('Emma Woodhouse')
+    expect(page).to have_unchecked_field('George Knightley')
     expect(page).to have_select('Location', selected: 'School')
     expect(page).to have_select('Status', selected: 'Attempted')
     expect(page).to have_field('Contact Notes', with: 'This was an attempted contact')

--- a/spec/javascripts/components/investigations/ContactFormSpec.jsx
+++ b/spec/javascripts/components/investigations/ContactFormSpec.jsx
@@ -230,8 +230,8 @@ describe('ContactForm', () => {
 
   it('displays people present', () => {
     const people = [
-      {first_name: 'Ferris', last_name: 'Bueller'},
-      {first_name: 'Cameron', last_name: 'Fry'},
+      {name: 'Ferris Bueller', selected: true},
+      {name: 'Cameron Fry', selected: false},
     ]
     const component = renderContact({people})
     expect(component.html()).toContain('Ferris Bueller')

--- a/spec/javascripts/components/investigations/ContactFormSpec.jsx
+++ b/spec/javascripts/components/investigations/ContactFormSpec.jsx
@@ -1,8 +1,8 @@
-import Contact from 'investigations/Contact'
+import ContactForm from 'investigations/ContactForm'
 import React from 'react'
 import {shallow, mount} from 'enzyme'
 
-describe('Contact', () => {
+describe('ContactForm', () => {
   function renderContact({
     investigationId = 'ABC123',
     actions = {},
@@ -41,7 +41,7 @@ describe('Contact', () => {
       people,
       valid,
     }
-    return shallow(<Contact {...props} />)
+    return shallow(<ContactForm {...props} />)
   }
 
   it('displays the investigation Id in the header', () => {
@@ -357,7 +357,7 @@ describe('Contact', () => {
   it('calls build when the component mounts', () => {
     const build = jasmine.createSpy('build')
     mount(
-      <Contact
+      <ContactForm
         investigationId='ABC123'
         actions={{build}}
         contact={{}}

--- a/spec/javascripts/components/investigations/ContactFormSpec.jsx
+++ b/spec/javascripts/components/investigations/ContactFormSpec.jsx
@@ -255,6 +255,17 @@ describe('ContactForm', () => {
     expect(selectPerson).toHaveBeenCalledWith(0)
   })
 
+  it('deselecting a checked person fires deselectContactPerson', () => {
+    const deselectPerson = jasmine.createSpy('deselectPerson')
+    const people = [
+      {name: 'Ferris Bueller', selected: true},
+    ]
+    const component = renderContact({actions: {deselectPerson}, people})
+    const personCheckBox = component.find('CheckboxField')
+    personCheckBox.simulate('change', {target: {checked: false}})
+    expect(deselectPerson).toHaveBeenCalledWith(0)
+  })
+
   it('displays note', () => {
     const component = renderContact({note: 'This is a simple contact note'})
     const noteField = component.find('textarea')

--- a/spec/javascripts/components/investigations/ContactFormSpec.jsx
+++ b/spec/javascripts/components/investigations/ContactFormSpec.jsx
@@ -21,6 +21,7 @@ describe('ContactForm', () => {
     officeLocationCode = '',
     people = [],
     valid = false,
+    selectedPeopleIds = [],
   }) {
     const props = {
       investigationId,
@@ -40,6 +41,7 @@ describe('ContactForm', () => {
       officeLocationCode,
       people,
       valid,
+      selectedPeopleIds,
     }
     return shallow(<ContactForm {...props} />)
   }
@@ -339,6 +341,7 @@ describe('ContactForm', () => {
         note: 'This is a new note',
         purpose: '1',
         actions: {create},
+        selectedPeopleIds: [{legacy_descriptor: '1'}],
       })
       component.find('form').simulate('submit', event)
       expect(create).toHaveBeenCalledWith({
@@ -349,7 +352,7 @@ describe('ContactForm', () => {
         status: 'S',
         note: 'This is a new note',
         purpose: '1',
-        people: [],
+        people: [{legacy_descriptor: '1'}],
       })
     })
 

--- a/spec/javascripts/components/investigations/ContactFormSpec.jsx
+++ b/spec/javascripts/components/investigations/ContactFormSpec.jsx
@@ -244,6 +244,17 @@ describe('ContactForm', () => {
     expect(peopleCheckBoxes.at(1).props().id).toEqual('person_1')
   })
 
+  it('selecting an unchecked person fires selectContactPerson', () => {
+    const selectPerson = jasmine.createSpy('selectPerson')
+    const people = [
+      {name: 'Cameron Fry', selected: false},
+    ]
+    const component = renderContact({actions: {selectPerson}, people})
+    const personCheckBox = component.find('CheckboxField')
+    personCheckBox.simulate('change', {target: {checked: true}})
+    expect(selectPerson).toHaveBeenCalledWith(0)
+  })
+
   it('displays note', () => {
     const component = renderContact({note: 'This is a simple contact note'})
     const noteField = component.find('textarea')

--- a/spec/javascripts/components/investigations/ContactFormSpec.jsx
+++ b/spec/javascripts/components/investigations/ContactFormSpec.jsx
@@ -234,8 +234,14 @@ describe('ContactForm', () => {
       {name: 'Cameron Fry', selected: false},
     ]
     const component = renderContact({people})
-    expect(component.html()).toContain('Ferris Bueller')
-    expect(component.html()).toContain('Cameron Fry')
+    const peopleCheckBoxes = component.find('CheckboxField')
+    expect(peopleCheckBoxes.length).toEqual(2)
+    expect(peopleCheckBoxes.at(0).props().value).toEqual('Ferris Bueller')
+    expect(peopleCheckBoxes.at(0).props().checked).toEqual(true)
+    expect(peopleCheckBoxes.at(0).props().id).toEqual('person_0')
+    expect(peopleCheckBoxes.at(1).props().value).toEqual('Cameron Fry')
+    expect(peopleCheckBoxes.at(1).props().checked).toEqual(false)
+    expect(peopleCheckBoxes.at(1).props().id).toEqual('person_1')
   })
 
   it('displays note', () => {

--- a/spec/javascripts/reducers/contactFormReducerSpec.js
+++ b/spec/javascripts/reducers/contactFormReducerSpec.js
@@ -56,8 +56,8 @@ describe('contactReducer', () => {
             value: 'date time',
           },
           people: [
-            {name: 'Bob Smith', selected: false, id: '1'},
-            {name: 'Jane Doe', selected: false, id: '2'},
+            {first_name: 'Bob', last_name: 'Smith', middle_name: undefined, name_suffix: undefined, selected: false, id: '1'},
+            {first_name: 'Jane', last_name: 'Doe', middle_name: undefined, name_suffix: undefined, selected: false, id: '2'},
           ],
         })
       )

--- a/spec/javascripts/reducers/contactFormReducerSpec.js
+++ b/spec/javascripts/reducers/contactFormReducerSpec.js
@@ -56,8 +56,21 @@ describe('contactReducer', () => {
             value: 'date time',
           },
           people: [
-            {first_name: 'Bob', last_name: 'Smith', middle_name: undefined, name_suffix: undefined, selected: false, id: '1'},
-            {first_name: 'Jane', last_name: 'Doe', middle_name: undefined, name_suffix: undefined, selected: false, id: '2'},
+            {
+              first_name: 'Bob',
+              last_name: 'Smith',
+              middle_name: undefined,
+              name_suffix: undefined,
+              selected: false,
+              legacy_descriptor: '1',
+            }, {
+              first_name: 'Jane',
+              last_name: 'Doe',
+              middle_name: undefined,
+              name_suffix: undefined,
+              selected: false,
+              legacy_descriptor: '2',
+            },
           ],
         })
       )

--- a/spec/javascripts/reducers/contactFormReducerSpec.js
+++ b/spec/javascripts/reducers/contactFormReducerSpec.js
@@ -4,6 +4,7 @@ import {
   setField,
   touchField,
   touchAllFields,
+  selectPerson,
 } from 'actions/contactFormActions'
 import {createSuccess} from 'actions/contactActions'
 import * as matchers from 'jasmine-immutable-matchers'
@@ -117,6 +118,21 @@ describe('contactReducer', () => {
           communication_method: {value: 'a communication method value', touched: true},
           location: {value: 'a location value', touched: true},
           investigation_started_at: {value: 'a datetime'},
+        })
+      )
+    })
+  })
+
+  describe('on SELECT_CONTACT_PERSON', () => {
+    it('changes the selected value for the passed index to true', () => {
+      const action = selectPerson('1')
+      const state = fromJS({people: [{selected: false}, {selected: false}]})
+      expect(contactFormReducer(state, action)).toEqualImmutable(
+        fromJS({
+          people: [
+            {selected: false},
+            {selected: true},
+          ],
         })
       )
     })

--- a/spec/javascripts/reducers/contactFormReducerSpec.js
+++ b/spec/javascripts/reducers/contactFormReducerSpec.js
@@ -14,7 +14,11 @@ describe('contactReducer', () => {
 
   describe('on BUILD_CONTACT_SUCCESS', () => {
     it('returns the contact', () => {
-      const action = buildSuccess({investigation_id: '123', investigation_started_at: 'date time'})
+      const people = [
+        {first_name: 'Bob', last_name: 'Smith', legacy_descriptor: '1'},
+        {first_name: 'Jane', last_name: 'Doe', legacy_descriptor: '2'},
+      ]
+      const action = buildSuccess({investigation_id: '123', investigation_started_at: 'date time', people})
       expect(contactFormReducer(Map(), action)).toEqualImmutable(
         fromJS({
           id: {
@@ -49,6 +53,10 @@ describe('contactReducer', () => {
           investigation_started_at: {
             value: 'date time',
           },
+          people: [
+            {name: 'Bob Smith', selected: false, id: '1'},
+            {name: 'Jane Doe', selected: false, id: '2'},
+          ],
         })
       )
     })

--- a/spec/javascripts/reducers/contactFormReducerSpec.js
+++ b/spec/javascripts/reducers/contactFormReducerSpec.js
@@ -5,6 +5,7 @@ import {
   touchField,
   touchAllFields,
   selectPerson,
+  deselectPerson,
 } from 'actions/contactFormActions'
 import {createSuccess} from 'actions/contactActions'
 import * as matchers from 'jasmine-immutable-matchers'
@@ -132,6 +133,21 @@ describe('contactReducer', () => {
           people: [
             {selected: false},
             {selected: true},
+          ],
+        })
+      )
+    })
+  })
+
+  describe('on DESELECT_CONTACT_PERSON', () => {
+    it('changes the selected value for the passed index to false', () => {
+      const action = deselectPerson('1')
+      const state = fromJS({people: [{selected: true}, {selected: true}]})
+      expect(contactFormReducer(state, action)).toEqualImmutable(
+        fromJS({
+          people: [
+            {selected: true},
+            {selected: false},
           ],
         })
       )

--- a/spec/javascripts/sagas/buildContactSagaSpec.js
+++ b/spec/javascripts/sagas/buildContactSagaSpec.js
@@ -15,7 +15,7 @@ describe('buildContactSaga', () => {
 describe('buildContact', () => {
   it('fetches the contacts investigation', () => {
     const gen = buildContact({investigation_id: '123ABC'})
-    const investigation = {id: '123ABC', started_at: 'date time'}
+    const investigation = {id: '123ABC', started_at: 'date time', people: ['bob']}
     expect(gen.next().value).toEqual(
       call(get, '/api/v1/investigations/123ABC')
     )
@@ -23,7 +23,7 @@ describe('buildContact', () => {
       put(fetchSuccess(investigation))
     )
     expect(gen.next(investigation).value).toEqual(
-      put(buildSuccess({investigation_id: '123ABC', investigation_started_at: 'date time'}))
+      put(buildSuccess({investigation_id: '123ABC', investigation_started_at: 'date time', people: ['bob']}))
     )
   })
 

--- a/spec/javascripts/selectors/contactFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/contactFormSelectorsSpec.js
@@ -10,6 +10,7 @@ import {
   getVisibleErrorsSelector,
   getHasErrorsValueSelector,
   getPeopleSelector,
+  getFormattedContactPeople,
   getSelectedPeopleIdsSelector,
 } from 'selectors/contactFormSelectors'
 import * as matchers from 'jasmine-immutable-matchers'
@@ -254,15 +255,15 @@ describe('contactFormSelectors', () => {
     it('returns the list of people on a contact form', () => {
       const contactForm = {
         people: [
-          {name: 'Bob'},
-          {name: 'Sally'},
+          {first_name: 'Bob'},
+          {first_name: 'Sally'},
         ],
       }
       const state = fromJS({contactForm})
       expect(getPeopleSelector(state)).toEqualImmutable(
         fromJS([
-          {name: 'Bob'},
-          {name: 'Sally'},
+          {first_name: 'Bob'},
+          {first_name: 'Sally'},
         ])
       )
     })
@@ -271,6 +272,30 @@ describe('contactFormSelectors', () => {
       const contactForm = {}
       const state = fromJS({contactForm})
       expect(getPeopleSelector(state)).toEqualImmutable(List())
+    })
+  })
+
+  describe('getFormattedContactPeople', () => {
+    it('returns the list of people on a contact form', () => {
+      const contactForm = {
+        people: [
+          {first_name: 'Bob', last_name: 'Smith', selected: true, legacy_descriptor: '1'},
+          {first_name: 'Sally', last_name: 'Doe', selected: false, legacy_descriptor: '2'},
+        ],
+      }
+      const state = fromJS({contactForm})
+      expect(getFormattedContactPeople(state)).toEqualImmutable(
+        fromJS([
+          {name: 'Bob Smith', selected: true},
+          {name: 'Sally Doe', selected: false},
+        ])
+      )
+    })
+
+    it('returns an empty list of the contact form is empty', () => {
+      const contactForm = {}
+      const state = fromJS({contactForm})
+      expect(getFormattedContactPeople(state)).toEqualImmutable(List())
     })
   })
 

--- a/spec/javascripts/selectors/contactFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/contactFormSelectorsSpec.js
@@ -9,6 +9,7 @@ import {
   getErrorsSelector,
   getVisibleErrorsSelector,
   getHasErrorsValueSelector,
+  getPeopleSelector,
   getSelectedPeopleIdsSelector,
 } from 'selectors/contactFormSelectors'
 import * as matchers from 'jasmine-immutable-matchers'
@@ -225,28 +226,6 @@ describe('contactFormSelectors', () => {
     })
 
     it('does not return an error if the field has not been touched', () => {
-      const contactForm = {
-        purpose: {
-          value: undefined,
-          touched: false,
-        },
-      }
-      const state = fromJS({contactForm})
-      expect(getVisibleErrorsSelector(state).get('purpose'))
-        .toEqualImmutable(List())
-    })
-  })
-
-  describe('getHasErrorsValueSelector', () => {
-    it('returns true if contact form has errors present', () => {
-      const contactForm = {
-        purpose: {value: undefined},
-      }
-      const state = fromJS({contactForm})
-      expect(getHasErrorsValueSelector(state)).toEqual(true)
-    })
-
-    it('does not return an error if the field has not been touched', () => {
       const yesterday = moment().subtract(1, 'days').toISOString()
       const contactForm = {
         started_at: {value: yesterday},
@@ -261,9 +240,41 @@ describe('contactFormSelectors', () => {
     })
   })
 
-  describe('getSelectedPeopleIdsSelector', () => {
-    beforeEach(() => jasmine.addMatchers(matchers))
+  describe('getHasErrorsValueSelector', () => {
+    it('returns true if contact form has errors present', () => {
+      const contactForm = {
+        purpose: {value: undefined},
+      }
+      const state = fromJS({contactForm})
+      expect(getHasErrorsValueSelector(state)).toEqual(true)
+    })
+  })
 
+  describe('getPeopleSelector', () => {
+    it('returns the list of people on a contact form', () => {
+      const contactForm = {
+        people: [
+          {name: 'Bob'},
+          {name: 'Sally'},
+        ],
+      }
+      const state = fromJS({contactForm})
+      expect(getPeopleSelector(state)).toEqualImmutable(
+        fromJS([
+          {name: 'Bob'},
+          {name: 'Sally'},
+        ])
+      )
+    })
+
+    it('returns an empty list of the contact form is empty', () => {
+      const contactForm = {}
+      const state = fromJS({contactForm})
+      expect(getPeopleSelector(state)).toEqualImmutable(List())
+    })
+  })
+
+  describe('getSelectedPeopleIdsSelector', () => {
     it('returns the ids of all people where selected is true', () => {
       const contactForm = {
         people: [

--- a/spec/javascripts/selectors/contactFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/contactFormSelectorsSpec.js
@@ -303,16 +303,16 @@ describe('contactFormSelectors', () => {
     it('returns the ids of all people where selected is true', () => {
       const contactForm = {
         people: [
-          {id: {legacy_id: '1'}, selected: true},
-          {id: {legacy_id: '2'}, selected: false},
-          {id: {legacy_id: '3'}, selected: true},
+          {legacy_descriptor: {legacy_id: '1'}, selected: true},
+          {legacy_descriptor: {legacy_id: '2'}, selected: false},
+          {legacy_descriptor: {legacy_id: '3'}, selected: true},
         ],
       }
       const state = fromJS({contactForm})
       expect(getSelectedPeopleIdsSelector(state)).toEqualImmutable(
         fromJS([
-          {legacy_id: '1'},
-          {legacy_id: '3'},
+          {legacy_descriptor: {legacy_id: '1'}},
+          {legacy_descriptor: {legacy_id: '3'}},
         ])
       )
     })

--- a/spec/javascripts/selectors/contactFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/contactFormSelectorsSpec.js
@@ -9,6 +9,7 @@ import {
   getErrorsSelector,
   getVisibleErrorsSelector,
   getHasErrorsValueSelector,
+  getSelectedPeopleIdsSelector,
 } from 'selectors/contactFormSelectors'
 import * as matchers from 'jasmine-immutable-matchers'
 
@@ -257,6 +258,33 @@ describe('contactFormSelectors', () => {
       }
       const state = fromJS({contactForm})
       expect(getHasErrorsValueSelector(state)).toEqual(false)
+    })
+  })
+
+  describe('getSelectedPeopleIdsSelector', () => {
+    beforeEach(() => jasmine.addMatchers(matchers))
+
+    it('returns the ids of all people where selected is true', () => {
+      const contactForm = {
+        people: [
+          {id: {legacy_id: '1'}, selected: true},
+          {id: {legacy_id: '2'}, selected: false},
+          {id: {legacy_id: '3'}, selected: true},
+        ],
+      }
+      const state = fromJS({contactForm})
+      expect(getSelectedPeopleIdsSelector(state)).toEqualImmutable(
+        fromJS([
+          {legacy_id: '1'},
+          {legacy_id: '3'},
+        ])
+      )
+    })
+
+    it('returns empty list when no people exist', () => {
+      const contactForm = {}
+      const state = fromJS({contactForm})
+      expect(getSelectedPeopleIdsSelector(state)).toEqualImmutable(List())
     })
   })
 })


### PR DESCRIPTION
### Pivotal Story

- [Investigator can select who they talked to during a contact #150411707](https://www.pivotaltracker.com/story/show/150411707)

### Purpose
A user can select the people he/she talked to for a contact

### Background


### Questions for Reviewer


### Notes for Reviewer
There are acceptance criteria for validation on save for people. I'll add that in as a separate pull request, since @NateOSI is still working on a chunk of that code. Also, there wasn't any acceptance criteria for seeing the selected people on the show page. Checking in with product and will add that as a follow-up PR if needed.

### Testing Notes

