### PR TITLE
In 149047599 ie responsiveness bug

### DIFF
--- a/app/javascript/common/Autocompleter.jsx
+++ b/app/javascript/common/Autocompleter.jsx
@@ -3,6 +3,7 @@ import PersonSuggestion from 'common/PersonSuggestion'
 import PropTypes from 'prop-types'
 import React from 'react'
 import ReactAutosuggest from 'react-autosuggest'
+import _ from 'lodash'
 const MIN_SEARCHABLE_CHARS = 2
 
 export default class Autocompleter extends React.Component {
@@ -14,12 +15,16 @@ export default class Autocompleter extends React.Component {
       isLoading: false,
       isAutocompleterFocused: false,
     }
+
+    const debounceDelay = 100
     this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(this)
     this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(this)
     this.onSuggestionSelected = this.onSuggestionSelected.bind(this)
     this.renderSuggestion = this.renderSuggestion.bind(this)
     this.renderSuggestionsContainer = this.renderSuggestionsContainer.bind(this)
     this.onChange = this.onChange.bind(this)
+    this.loadSuggestions = this.loadSuggestions.bind(this)
+    this.debouncedLoadSuggestions = _.debounce(this.loadSuggestions, debounceDelay)
   }
 
   loadSuggestions(value) {
@@ -38,7 +43,7 @@ export default class Autocompleter extends React.Component {
   }
 
   onSuggestionsFetchRequested({value}) {
-    this.loadSuggestions(value)
+    this.debouncedLoadSuggestions(value)
   }
 
   onSuggestionSelected(event, {suggestion}) {

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -41,19 +41,22 @@ feature 'home page' do
 
       fill_in_autocompleter 'People', with: 'Marge'
 
-      expect(
-        a_request(
-          :get,
-          intake_api_url(ExternalRoutes.intake_api_people_search_v2_path(search_term: 'M'))
-        )
-      ).to_not have_been_made
-      %w[Ma Mar Marg Marge].each do |search_text|
+      within '.react-autosuggest__suggestion' do
+        %w[M Ma Mar Marg].each do |search_text|
+          expect(
+            a_request(
+              :get,
+              intake_api_url(
+                ExternalRoutes.intake_api_people_search_v2_path(search_term: search_text)
+              )
+            )
+          ).to_not have_been_made
+        end
+
         expect(
           a_request(
             :get,
-            intake_api_url(
-              ExternalRoutes.intake_api_people_search_v2_path(search_term: search_text)
-            )
+            intake_api_url(ExternalRoutes.intake_api_people_search_v2_path(search_term: 'Marge'))
           )
         ).to have_been_made
       end

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -21,14 +21,16 @@ feature 'searching a person' do
       fill_in_autocompleter 'Search for any person', with: 'aa', skip_select: true
     end
 
-    expect(
-      a_request(
-        :get,
-        intake_api_url(
-          ExternalRoutes.intake_api_people_search_v2_path(search_term: 'aa')
+    within '.react-autosuggest__suggestion' do
+      expect(
+        a_request(
+          :get,
+          intake_api_url(
+            ExternalRoutes.intake_api_people_search_v2_path(search_term: 'aa')
+          )
         )
-      )
-    ).to have_been_made
+      ).to have_been_made
+    end
   end
 end
 

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -4,6 +4,7 @@ import React from 'react'
 import ReactAutosuggest from 'react-autosuggest'
 import matchers from 'jasmine-immutable-matchers'
 import {shallow, mount} from 'enzyme'
+import _ from 'lodash'
 
 describe('<Autocompleter />', () => {
   function stubSuggestions(suggestions) {
@@ -14,6 +15,9 @@ describe('<Autocompleter />', () => {
   }
 
   beforeEach(() => {
+    spyOn(_, 'debounce').and.callFake(
+      (callback) => () => { callback() }
+    )
     jasmine.addMatchers(matchers)
   })
 
@@ -32,12 +36,21 @@ describe('<Autocompleter />', () => {
   })
 
   describe('#onSuggestionsFetchRequested', () => {
-    it('uses the people search api to get the result for the search term', () => {
-      const bart_simpson = {first_name: 'Bart', last_name: 'Simpson'}
+    const bart_simpson = {first_name: 'Bart', last_name: 'Simpson'}
+    let component
+
+    beforeEach(() => {
       stubSuggestions([bart_simpson])
-      const component = shallow(<Autocompleter />)
+      component = shallow(<Autocompleter />)
       component.instance().onSuggestionsFetchRequested({value: 'Simpson'})
+    })
+
+    it('uses the people search api to get the result for the search term', () => {
       expect(component.state('suggestions')).toEqual([bart_simpson])
+    })
+
+    it('it debounces loadSuggestions for 100 ms', () => {
+      expect(_.debounce).toHaveBeenCalledWith(component.instance().loadSuggestions, 100)
     })
   })
 


### PR DESCRIPTION
### Pivotal Story

- [Search responsiveness in IE - Cannot keep up with fast typing #149047599](https://www.pivotaltracker.com/story/show/149047599)

### Purpose
1- Search results sometimes doesn't reflect the term displayed in the search box
2- Fast typing can cause some characters to be skipped in IE11

### Background
This is related to a React bug that was fixed in ReactJS 15.6.1:
https://github.com/facebook/react/issues/7027
Debouncing was also affected by the bug until bug was fixed:
https://github.com/moroshko/react-autosuggest/issues/262

After the bug was fixed, debouncing was implemented and tested

### Testing Notes
This script was used in Windows virtual machine to confirm the bug as well as the fix.

```
require 'selenium-webdriver'
def test_ie_responsiveness element
    test_string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQSTUVWXYZ0123456789"
    element.send_keys test_string
    actual = element.attribute('value')
    actual==test_string ? 'Passed!!' : 'FAILED ...'
end
driver = Selenium::WebDriver.for :ie

# Test the bug locally
driver.navigate.to "http://10.10.1.20:3000/screenings/1/edit"
driver.find_element(css: 'button[type="submit"]').click
element = driver.find_element(id: 'screening_participants')
test_ie_responsiveness element

# Test the bug in preint
driver.navigate.to 'https://web.preint.cwds.io/'
driver.find_element(css: 'button[type="submit"]').click
driver.navigate.to 'https://web.preint.cwds.io/'
driver.find_element(link: 'Intake').click
driver.navigate.to "https://web.preint.cwds.io/intake/screenings/1/edit"
element = driver.find_element(id: 'screening_participants')
test_ie_responsiveness element
```
