### PR TITLE
In update parameter names for errors and labels

### DIFF
--- a/app/javascript/common/CheckboxField.jsx
+++ b/app/javascript/common/CheckboxField.jsx
@@ -24,7 +24,7 @@ const CheckboxField = ({
       onBlur={onBlur}
     />
     <label className={required && 'required'} htmlFor={id}>{value}</label>
-    <ErrorMessages id={id} errors={errors}/>
+    <ErrorMessages ariaDescribedBy={id} errors={errors}/>
   </div>
 )
 

--- a/app/javascript/common/DateField.jsx
+++ b/app/javascript/common/DateField.jsx
@@ -58,7 +58,7 @@ const DateField = ({
   }
 
   return (
-    <FormField id={`${id}_input`} label={label} gridClassName={gridClassName} labelClassName={labelClassName}
+    <FormField htmlFor={`${id}_input`} label={label} gridClassName={gridClassName} labelClassName={labelClassName}
       required={required} errors={errors}
     >
       <DateTimePicker

--- a/app/javascript/common/ErrorMessages.jsx
+++ b/app/javascript/common/ErrorMessages.jsx
@@ -1,18 +1,18 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const ErrorMessages = ({id, errors}) => (
+const ErrorMessages = ({ariaDescribedBy, errors}) => (
   <div>
     {errors &&
       errors.map((error, index) =>
-        <span key={`error-${index}`} className='input-error-message' role='alert' aria-describedby={id}>{error}</span>
+        <span key={`error-${index}`} className='input-error-message' role='alert' aria-describedby={ariaDescribedBy}>{error}</span>
       )
     }
   </div>
 )
 
 ErrorMessages.propTypes = {
+  ariaDescribedBy: PropTypes.string,
   errors: PropTypes.array,
-  id: PropTypes.string,
 }
 export default ErrorMessages

--- a/app/javascript/common/FormField.jsx
+++ b/app/javascript/common/FormField.jsx
@@ -15,7 +15,7 @@ const FormField = ({children, errors, gridClassName, labelClassName, htmlFor, la
         {label}
       </label>
       {children}
-      <ErrorMessages id={htmlFor} errors={errors}/>
+      <ErrorMessages ariaDescribedBy={htmlFor} errors={errors}/>
     </div>
   )
 }

--- a/app/javascript/common/FormField.jsx
+++ b/app/javascript/common/FormField.jsx
@@ -3,7 +3,7 @@ import ErrorMessages from 'common/ErrorMessages'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const FormField = ({children, errors, gridClassName, labelClassName, id, label, required}) => {
+const FormField = ({children, errors, gridClassName, labelClassName, htmlFor, label, required}) => {
   const emptyArrayLength = 0
   const hasErrors = errors && errors.length > emptyArrayLength
   const gridClassNames = ClassNames(gridClassName, {'input-error': hasErrors})
@@ -11,11 +11,11 @@ const FormField = ({children, errors, gridClassName, labelClassName, id, label, 
     ClassNames(labelClassName, {'input-error-label': hasErrors}, {required: required})
   return (
     <div className={gridClassNames}>
-      <label htmlFor={id} className={labelClassNames}>
+      <label htmlFor={htmlFor} className={labelClassNames}>
         {label}
       </label>
       {children}
-      <ErrorMessages id={id} errors={errors}/>
+      <ErrorMessages id={htmlFor} errors={errors}/>
     </div>
   )
 }
@@ -27,7 +27,7 @@ FormField.propTypes = {
   ]).isRequired,
   errors: PropTypes.array,
   gridClassName: PropTypes.string,
-  id: PropTypes.string,
+  htmlFor: PropTypes.string,
   label: PropTypes.string.isRequired,
   labelClassName: PropTypes.string,
   required: PropTypes.bool,

--- a/app/javascript/common/InputField.jsx
+++ b/app/javascript/common/InputField.jsx
@@ -19,13 +19,13 @@ const InputField = ({
   disabled,
 }) => {
   const formFieldProps = {
-    disabled: disabled,
-    errors: errors,
-    gridClassName: gridClassName,
-    id: id,
-    label: label,
-    labelClassName: labelClassName,
-    required: required,
+    disabled,
+    errors,
+    gridClassName,
+    htmlFor: id,
+    label,
+    labelClassName,
+    required,
   }
 
   const sanitizeValue = (string, allowRegex) => {

--- a/app/javascript/common/MaskedInputField.jsx
+++ b/app/javascript/common/MaskedInputField.jsx
@@ -18,7 +18,7 @@ const MaskedInputField = ({
   type,
   value,
 }) => {
-  const formFieldProps = {errors, gridClassName, id, label, labelClassName, required}
+  const formFieldProps = {errors, gridClassName, htmlFor: id, label, labelClassName, required}
 
   return (
     <FormField {...formFieldProps}>

--- a/app/javascript/common/SelectField.jsx
+++ b/app/javascript/common/SelectField.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 const SelectField = ({gridClassName, labelClassName, id, label, value, onChange, onBlur, children, required, errors}) => (
-  <FormField id={id} label={label} labelClassName={labelClassName} gridClassName={gridClassName}
+  <FormField htmlFor={id} label={label} labelClassName={labelClassName} gridClassName={gridClassName}
     errors={errors} required={required}
   >
     <select id={id} value={value || ''} onChange={onChange} onBlur={onBlur}

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -106,7 +106,7 @@ class ContactForm extends React.Component {
                   </div>
                 }
                 <div className='row'>
-                  <FormField gridClassName='col-md-12' label='People Present' id='people'>
+                  <FormField gridClassName='col-md-12' label='People Present' htmlFor='people'>
                     { people.map((person, index) =>
                       <CheckboxField
                         key={`person_${index}`}
@@ -155,7 +155,7 @@ class ContactForm extends React.Component {
               </div>
               <div className='col-md-6'>
                 <div className='row'>
-                  <FormField id='note' gridClassName='col-md-12' label='Contact Notes (Optional)'>
+                  <FormField htmlFor='note' gridClassName='col-md-12' label='Contact Notes (Optional)'>
                     <textarea id='note' onChange={(event) => setField('note', event.target.value)}>
                       {note}
                     </textarea>

--- a/app/javascript/screenings/NarrativeEditView.jsx
+++ b/app/javascript/screenings/NarrativeEditView.jsx
@@ -8,7 +8,7 @@ const NarrativeEditView = ({errors, screening, onBlur, onCancel, onChange, onSav
       <FormField
         errors={errors.report_narrative}
         gridClassName='col-md-12'
-        id='report_narrative'
+        htmlFor='report_narrative'
         label='Report Narrative'
         required
       >

--- a/spec/javascripts/components/common/CheckboxFieldSpec.jsx
+++ b/spec/javascripts/components/common/CheckboxFieldSpec.jsx
@@ -19,8 +19,8 @@ describe('CheckboxField', () => {
     component = shallow(<CheckboxField {...props} />)
   })
 
-  it('passes id to the ErrorMessages', () => {
-    expect(component.find('ErrorMessages').props().id).toEqual('myCheckboxFieldId')
+  it('passes ariaDescribedBy to the ErrorMessages', () => {
+    expect(component.find('ErrorMessages').props().ariaDescribedBy).toEqual('myCheckboxFieldId')
   })
 
   it('passes errors to the ErrorMessages', () => {

--- a/spec/javascripts/components/common/DateFieldSpec.jsx
+++ b/spec/javascripts/components/common/DateFieldSpec.jsx
@@ -25,7 +25,7 @@ describe('DateField', () => {
   it('passes props to the FormField', () => {
     expect(formField.props().labelClassName).toEqual('myLabelTest')
     expect(formField.props().gridClassName).toEqual('myWrapperTest')
-    expect(formField.props().id).toEqual('myDateFieldId_input')
+    expect(formField.props().htmlFor).toEqual('myDateFieldId_input')
     expect(formField.props().label).toEqual('this is my label')
     expect(formField.find('DateTimePicker').exists()).toEqual(true)
   })

--- a/spec/javascripts/components/common/ErrorMessagesSpec.jsx
+++ b/spec/javascripts/components/common/ErrorMessagesSpec.jsx
@@ -30,9 +30,9 @@ describe('ErrorMessages', () => {
 
   describe('when there are errors', () => {
     const errors = ['You have failed this city', 'Stick to the plan!']
-    describe('when id is passed', () => {
+    describe('when ariaDescribedBy is passed', () => {
       beforeEach(() => {
-        const props = {id: 'myInputFieldId', errors}
+        const props = {ariaDescribedBy: 'myInputFieldId', errors}
         component = shallow(<ErrorMessages {...props}/>)
       })
 
@@ -51,7 +51,7 @@ describe('ErrorMessages', () => {
       })
     })
 
-    describe('when id is not passed', () => {
+    describe('when ariaDescribedBy is not passed', () => {
       beforeEach(() => {
         component = shallow(<ErrorMessages errors={errors}/>)
       })

--- a/spec/javascripts/components/common/InputFieldSpec.jsx
+++ b/spec/javascripts/components/common/InputFieldSpec.jsx
@@ -35,7 +35,7 @@ describe('InputField', () => {
     it('passes props to the FormField', () => {
       expect(formField.props().labelClassName).toEqual('myLabelTest')
       expect(formField.props().gridClassName).toEqual('myWrapperTest')
-      expect(formField.props().id).toEqual('myInputFieldId')
+      expect(formField.props().htmlFor).toEqual('myInputFieldId')
       expect(formField.props().label).toEqual('this is my label')
       expect(formField.props().errors).toEqual([])
       expect(formField.props().required).toEqual(false)

--- a/spec/javascripts/components/common/MaskedInputFieldSpec.jsx
+++ b/spec/javascripts/components/common/MaskedInputFieldSpec.jsx
@@ -37,7 +37,7 @@ describe('MaskedInputField', () => {
     it('passes props to the FormField', () => {
       expect(formField.props().labelClassName).toEqual('myLabelTest')
       expect(formField.props().gridClassName).toEqual('myWrapperTest')
-      expect(formField.props().id).toEqual('myInputFieldId')
+      expect(formField.props().htmlFor).toEqual('myInputFieldId')
       expect(formField.props().label).toEqual('this is my label')
       expect(formField.props().errors).toEqual([])
       expect(formField.props().required).toEqual(false)

--- a/spec/javascripts/components/common/SelectFieldSpec.jsx
+++ b/spec/javascripts/components/common/SelectFieldSpec.jsx
@@ -29,7 +29,7 @@ describe('SelectField', () => {
   it('passes props to the FormField', () => {
     expect(formField.props().labelClassName).toEqual('myLabelTest')
     expect(formField.props().gridClassName).toEqual('myWrapperTest')
-    expect(formField.props().id).toEqual('myDateFieldId')
+    expect(formField.props().htmlFor).toEqual('myDateFieldId')
     expect(formField.props().label).toEqual('this is my label')
     expect(formField.childAt(0).node.type).toEqual('select')
   })


### PR DESCRIPTION
### Pivotal Story

- None (Friday 20% time side project. Do we have Friday 20% time? Not really. But I'm pretending we do.)

### Purpose
Use more descriptive parameter names in components so it is clear what we are using them for.

### Background
We have a situation in the story I am currently working on where the `ariaDescribedBy` and `htmlFor` is a list of div ids, not one single div id. This is entirely valid per [W3 recommendations](https://www.w3.org/TR/wai-aria/states_and_properties#aria-describedby), but having our app support it was a bit wonky. This makes it less wonky.

### Questions for Reviewer


### Notes for Reviewer


### Testing Notes
![I regret nothing](https://media.giphy.com/media/RLTpetV3xFBCg/giphy.gif)
