### PR TITLE
In 150411707 include selected people in contact post

### DIFF
--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -48,6 +48,7 @@ class ContactForm extends React.Component {
         touchAllFields()
       }
     }
+    const peopleAriaLabel = people.map((_person, index) => `person_${index}`).join(' ')
     return (
       <div className='card show double-gap-top'>
         <div className='card-header'>
@@ -106,22 +107,28 @@ class ContactForm extends React.Component {
                   </div>
                 }
                 <div className='row'>
-                  <FormField gridClassName='col-md-12' label='People Present' htmlFor='people' errors={errors.people}>
-                    { people.map((person, index) =>
-                      <CheckboxField
-                        key={`person_${index}`}
-                        id={`person_${index}`}
-                        value={person.name}
-                        checked={person.selected}
-                        onChange={({target: {checked}}) => {
-                          if (checked === true) {
-                            return selectPerson(index)
-                          } else {
-                            return deselectPerson(index)
-                          }
-                        }}
-                      />
-                    )}
+                  <FormField gridClassName='col-md-12' label='People Present' htmlFor={peopleAriaLabel} errors={errors.people}>
+                    <ul className='unstyled-list'>
+                      {
+                        people.map((person, index) =>
+                          <li key={index}>
+                            <CheckboxField
+                              key={`person_${index}`}
+                              id={`person_${index}`}
+                              value={person.name}
+                              checked={person.selected}
+                              onChange={({target: {checked}}) => {
+                                if (checked === true) {
+                                  return selectPerson(index)
+                                } else {
+                                  return deselectPerson(index)
+                                }
+                              }}
+                            />
+                          </li>
+                        )
+                      }
+                    </ul>
                   </FormField>
                 </div>
                 <div className='row'>

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -106,7 +106,7 @@ class ContactForm extends React.Component {
                   </div>
                 }
                 <div className='row'>
-                  <FormField gridClassName='col-md-12' label='People Present' htmlFor='people'>
+                  <FormField gridClassName='col-md-12' label='People Present' htmlFor='people' errors={errors.people}>
                     { people.map((person, index) =>
                       <CheckboxField
                         key={`person_${index}`}

--- a/app/javascript/reducers/contactFormReducer.js
+++ b/app/javascript/reducers/contactFormReducer.js
@@ -31,6 +31,7 @@ export default createReducer(Map(), {
         name_suffix,
         legacy_descriptor,
         selected: false,
+        touched: false,
       })),
     })
   },
@@ -51,9 +52,11 @@ export default createReducer(Map(), {
   },
   [SELECT_CONTACT_PERSON](state, {index}) {
     return state.setIn(['people', index, 'selected'], true)
+      .setIn(['people', index, 'touched'], true)
   },
   [DESELECT_CONTACT_PERSON](state, {index}) {
     return state.setIn(['people', index, 'selected'], false)
+      .setIn(['people', index, 'touched'], true)
   },
   [CREATE_CONTACT_SUCCESS](state, {id, started_at, status, note, purpose, communication_method, location}) {
     return state.setIn(['id', 'value'], id)

--- a/app/javascript/reducers/contactFormReducer.js
+++ b/app/javascript/reducers/contactFormReducer.js
@@ -48,7 +48,7 @@ export default createReducer(Map(), {
     return fieldsWithTouch.reduce(
       (contact, field) => contact.setIn([field, 'touched'], true),
       state
-    )
+    ).set('people', state.get('people').map((person) => person.set('touched', true)))
   },
   [SELECT_CONTACT_PERSON](state, {index}) {
     return state.setIn(['people', index, 'selected'], true)

--- a/spec/features/contacts/create_investigation_contact_spec.rb
+++ b/spec/features/contacts/create_investigation_contact_spec.rb
@@ -4,9 +4,8 @@ require 'rails_helper'
 
 feature 'Create Investigation Contact' do
   let(:investigation_id) { '123ABC' }
-
-  before do
-    people = [
+  let(:people) do
+    [
       {
         first_name: 'Emma',
         last_name: 'Woodhouse',
@@ -17,6 +16,9 @@ feature 'Create Investigation Contact' do
         legacy_descriptor: { legacy_id: '2', legacy_table_name: 'foo' }
       }
     ]
+  end
+
+  before do
     stub_request(
       :get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
     ).and_return(json_body({ people: people }.to_json, status: 200))
@@ -114,6 +116,7 @@ feature 'Create Investigation Contact' do
     fill_in_datepicker 'Date/Time', with: '08/17/2016 3:00 AM'
     select 'Attempted', from: 'Status'
     select 'Fax', from: 'Communication Method'
+    find('label', text: 'Emma Woodhouse').click
     select 'Investigate Referral', from: 'Purpose'
     fill_in 'Contact Notes', with: 'This was an attempted contact'
     click_button 'Save'
@@ -127,7 +130,7 @@ feature 'Create Investigation Contact' do
           note: 'This was an attempted contact',
           communication_method: 'FAX',
           location: 'OFFICE',
-          people: []
+          people: [{ legacy_descriptor: { legacy_id: '1', legacy_table_name: 'foo' } }]
         }.to_json
       )
     ).to have_been_made

--- a/spec/features/contacts/validation_spec.rb
+++ b/spec/features/contacts/validation_spec.rb
@@ -4,6 +4,19 @@ require 'rails_helper'
 
 feature 'Validate Investigation Contact' do
   let(:investigation_started_at) { Time.parse('2017-08-15T14:00:00.000') }
+  let(:people) do
+    [
+      {
+        first_name: 'Emma',
+        last_name: 'Woodhouse',
+        legacy_descriptor: { legacy_id: '1', legacy_table_name: 'foo' }
+      }, {
+        first_name: 'George',
+        last_name: 'Knightley',
+        legacy_descriptor: { legacy_id: '2', legacy_table_name: 'foo' }
+      }
+    ]
+  end
   before do
     investigation_id = '123ABC'
     stub_request(
@@ -12,7 +25,7 @@ feature 'Validate Investigation Contact' do
       json_body(
         {
           started_at: investigation_started_at.strftime('%Y-%m-%dT%H:%M:%S.%L'),
-          people: []
+          people: people
         }.to_json,
         status: 200
       )
@@ -107,6 +120,7 @@ feature 'Validate Investigation Contact' do
     expect(page).to_not have_content 'Please enter a contact date'
     expect(page).to_not have_content 'Please enter a contact purpose'
     expect(page).to_not have_content 'Please enter the communication method'
+    expect(page).to_not have_content 'At least one person must be present for a contact'
 
     click_on 'Save'
 
@@ -114,12 +128,14 @@ feature 'Validate Investigation Contact' do
     expect(page).to have_content 'Please enter a contact date'
     expect(page).to have_content 'Please enter a contact purpose'
     expect(page).to have_content 'Please enter the communication method'
+    expect(page).to have_content 'At least one person must be present for a contact'
 
     select 'Attempted', from: 'Status'
     fill_in_datepicker 'Date/Time', with: 2.years.from_now
     select 'Investigate Referral', from: 'Purpose'
     select 'In person', from: 'Communication Method'
     select 'School', from: 'Location'
+    find('label', text: 'Emma Woodhouse').click
 
     click_on 'Save'
 
@@ -127,5 +143,6 @@ feature 'Validate Investigation Contact' do
     expect(page).to_not have_content 'Please enter a contact date'
     expect(page).to_not have_content 'Please enter a contact purpose'
     expect(page).to_not have_content 'Please enter the communication method'
+    expect(page).to_not have_content 'At least one person must be present for a contact'
   end
 end

--- a/spec/javascripts/components/investigations/ContactFormSpec.jsx
+++ b/spec/javascripts/components/investigations/ContactFormSpec.jsx
@@ -235,7 +235,9 @@ describe('ContactForm', () => {
       {name: 'Ferris Bueller', selected: true},
       {name: 'Cameron Fry', selected: false},
     ]
-    const component = renderContact({people})
+    const component = renderContact({people, errors: {people: ['No people present']}})
+    const peopleFormField = component.find('FormField[label="People Present"]')
+    expect(peopleFormField.props().errors).toEqual(['No people present'])
     const peopleCheckBoxes = component.find('CheckboxField')
     expect(peopleCheckBoxes.length).toEqual(2)
     expect(peopleCheckBoxes.at(0).props().value).toEqual('Ferris Bueller')

--- a/spec/javascripts/reducers/contactFormReducerSpec.js
+++ b/spec/javascripts/reducers/contactFormReducerSpec.js
@@ -61,15 +61,17 @@ describe('contactReducer', () => {
               last_name: 'Smith',
               middle_name: undefined,
               name_suffix: undefined,
-              selected: false,
               legacy_descriptor: '1',
+              selected: false,
+              touched: false,
             }, {
               first_name: 'Jane',
               last_name: 'Doe',
               middle_name: undefined,
               name_suffix: undefined,
-              selected: false,
               legacy_descriptor: '2',
+              selected: false,
+              touched: false,
             },
           ],
         })
@@ -138,14 +140,14 @@ describe('contactReducer', () => {
   })
 
   describe('on SELECT_CONTACT_PERSON', () => {
-    it('changes the selected value for the passed index to true', () => {
+    it('changes the selected and touched flags for the passed index to true', () => {
       const action = selectPerson('1')
-      const state = fromJS({people: [{selected: false}, {selected: false}]})
+      const state = fromJS({people: [{selected: false, touched: false}, {selected: false, touched: false}]})
       expect(contactFormReducer(state, action)).toEqualImmutable(
         fromJS({
           people: [
-            {selected: false},
-            {selected: true},
+            {selected: false, touched: false},
+            {selected: true, touched: true},
           ],
         })
       )
@@ -153,14 +155,14 @@ describe('contactReducer', () => {
   })
 
   describe('on DESELECT_CONTACT_PERSON', () => {
-    it('changes the selected value for the passed index to false', () => {
+    it('changes the selected value for the passed index to false, and the touched flag to true', () => {
       const action = deselectPerson('1')
-      const state = fromJS({people: [{selected: true}, {selected: true}]})
+      const state = fromJS({people: [{selected: true, touched: false}, {selected: true, touched: false}]})
       expect(contactFormReducer(state, action)).toEqualImmutable(
         fromJS({
           people: [
-            {selected: true},
-            {selected: false},
+            {selected: true, touched: false},
+            {selected: false, touched: true},
           ],
         })
       )

--- a/spec/javascripts/reducers/contactFormReducerSpec.js
+++ b/spec/javascripts/reducers/contactFormReducerSpec.js
@@ -122,6 +122,7 @@ describe('contactReducer', () => {
         communication_method: {value: 'a communication method value', touched: false},
         location: {value: 'a location value', touched: false},
         investigation_started_at: {value: 'a datetime'},
+        people: [{selected: false}, {selected: true}],
       })
       expect(contactFormReducer(initialContactForm, action)).toEqualImmutable(
         fromJS({
@@ -134,6 +135,7 @@ describe('contactReducer', () => {
           communication_method: {value: 'a communication method value', touched: true},
           location: {value: 'a location value', touched: true},
           investigation_started_at: {value: 'a datetime'},
+          people: [{selected: false, touched: true}, {selected: true, touched: true}],
         })
       )
     })

--- a/spec/javascripts/selectors/contactFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/contactFormSelectorsSpec.js
@@ -231,13 +231,14 @@ describe('contactFormSelectors', () => {
       const contactForm = {
         started_at: {value: yesterday},
         investigation_started_at: {value: yesterday},
-        communication_method: {value: 'a value'},
-        location: {value: 'a value'},
-        status: {value: 'a value'},
-        purpose: {value: 'a value'},
+        communication_method: {value: ''},
+        location: {value: ''},
+        status: {value: ''},
+        purpose: {value: ''},
       }
       const state = fromJS({contactForm})
-      expect(getHasErrorsValueSelector(state)).toEqual(false)
+      const errors = getVisibleErrorsSelector(state)
+      expect(errors.some((fieldErrors) => !fieldErrors.isEmpty())).toEqual(false)
     })
   })
 

--- a/spec/javascripts/selectors/contactFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/contactFormSelectorsSpec.js
@@ -83,15 +83,16 @@ describe('contactFormSelectors', () => {
   })
 
   describe('getTouchedFieldsSelector', () => {
-    it('returns the contactForm field names that are touched', () => {
+    it('returns the contactForm field names that are touched, including nested objects', () => {
       const contactForm = {
         fieldA: {touched: false},
         fieldB: {touched: true},
         fieldC: {},
         fieldD: {touched: true},
+        fieldE: [{touched: true}, {touched: false}],
       }
       const state = fromJS({contactForm})
-      expect(getTouchedFieldsSelector(state)).toEqualImmutable(Seq(['fieldB', 'fieldD']))
+      expect(getTouchedFieldsSelector(state)).toEqualImmutable(Seq(['fieldB', 'fieldD', 'fieldE']))
     })
 
     it('returns empty list when no contact', () => {
@@ -211,6 +212,29 @@ describe('contactFormSelectors', () => {
           .toEqualImmutable(List())
       })
     })
+
+    describe('people', () => {
+      it('returns an error if no people are present', () => {
+        const contactForm = {people: []}
+        const state = fromJS({contactForm})
+        expect(getErrorsSelector(state).get('people'))
+          .toEqualImmutable(List(['At least one person must be present for a contact']))
+      })
+
+      it('returns an error if people are present, but none are selected', () => {
+        const contactForm = {people: [{selected: false}, {selected: false}]}
+        const state = fromJS({contactForm})
+        expect(getErrorsSelector(state).get('people'))
+          .toEqualImmutable(List(['At least one person must be present for a contact']))
+      })
+
+      it('returns no error if at least one person is selected', () => {
+        const contactForm = {people: [{selected: true}, {selected: false}]}
+        const state = fromJS({contactForm})
+        expect(getErrorsSelector(state).get('people'))
+          .toEqualImmutable(List())
+      })
+    })
   })
 
   describe('getVisibleErrorsSelector', () => {
@@ -220,10 +244,14 @@ describe('contactFormSelectors', () => {
           value: undefined,
           touched: true,
         },
+        people: [{selected: false, touched: 'true'}],
       }
       const state = fromJS({contactForm})
-      expect(getVisibleErrorsSelector(state).get('purpose'))
+      const errors = getVisibleErrorsSelector(state)
+      expect(errors.get('purpose'))
         .toEqualImmutable(List(['Please enter a contact purpose']))
+      expect(errors.get('people'))
+        .toEqualImmutable(List(['At least one person must be present for a contact']))
     })
 
     it('does not return an error if the field has not been touched', () => {
@@ -235,6 +263,7 @@ describe('contactFormSelectors', () => {
         location: {value: ''},
         status: {value: ''},
         purpose: {value: ''},
+        people: [],
       }
       const state = fromJS({contactForm})
       const errors = getVisibleErrorsSelector(state)


### PR DESCRIPTION
### Pivotal Story

- [Investigator can select who they talked to during a contact #150411707](https://www.pivotaltracker.com/story/show/150411707)

### Purpose
Now that the validate on save pattern has been merged in, add additional validation to make sure at least one person has been selected on a contact.

### Background


### Questions for Reviewer
How's your day going?

### Notes for Reviewer
This is our first time dealing with validations on a nested array. I've written some code inline that is somewhat specialized, rather than pulling it out into a more abstract pattern we can reuse. IMO, this hasn't reached the Rule of Three(tm) for refactoring. But I'm open to discussing further if it makes sense to tackle some of that work now and set us up better for future work.

### Testing Notes
![Don't have sharks do your QA](https://media.giphy.com/media/lIbVrBqGGHUl2/giphy.gif)
