### PR TITLE
In 149047599 ie increase delay

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -1,19 +1,11 @@
 pairs:
   aa: Aman Alshurafa; Aman.Alshurafa
-  as: Aaron Smith; Aaron.Smith
-  am: Andrew Marshall
   bf: Bruno Fagundez; Bruno.Fagundez
   jg: John Gedeon; John.Gedeon
-  jh: Johny Ho
   nj: Nate Jones; Nate.Jones
-  nl: Nora Lin; Nora.Lin
-  pg: Pema Geyleg; Pema.Geyleg
   pk: Pierre Klein; Pierre.Klein
-  ra: Rebecca Ackerman; Rebecca.Ackerman
   sb: Sara Bocciardi; Sara.Bocciardi
-  sg: Suman Gurung
-  sp: Sri Harsha Poosa; Sri.Poosa
-  sm: Siva Mukunda; Siva.Mukunda
+  tc: Tyler Clemens; Tyler.Clemens
   tr: Thomas Ramirez; Thomas.Ramirez
 email:
   prefix: pair

--- a/app/javascript/common/Autocompleter.jsx
+++ b/app/javascript/common/Autocompleter.jsx
@@ -16,7 +16,7 @@ export default class Autocompleter extends React.Component {
       isAutocompleterFocused: false,
     }
 
-    const debounceDelay = 100
+    const debounceDelay = 400
     this.onSuggestionsFetchRequested = this.onSuggestionsFetchRequested.bind(this)
     this.onSuggestionsClearRequested = this.onSuggestionsClearRequested.bind(this)
     this.onSuggestionSelected = this.onSuggestionSelected.bind(this)

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -39,7 +39,7 @@ feature 'home page' do
 
       expect(page).to_not have_link 'Start Screening'
 
-      fill_in_autocompleter 'People', with: 'Marge'
+      fill_in_autocompleter 'People', with: 'Marge', splitted: true
 
       expect(
         a_request(

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -39,7 +39,7 @@ feature 'home page' do
 
       expect(page).to_not have_link 'Start Screening'
 
-      fill_in_autocompleter 'People', with: 'Marge', splitted: true
+      fill_in_autocompleter 'People', with: 'Marge', split: true
 
       expect(
         a_request(

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -113,7 +113,7 @@ feature 'Edit Screening' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
-    %w[Ho].each do |search_text|
+    %w[Ho Homer].each do |search_text|
       stub_request(
         :get,
         intake_api_url(ExternalRoutes.intake_api_people_search_v2_path(search_term: search_text))

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -49,8 +49,8 @@ describe('<Autocompleter />', () => {
       expect(component.state('suggestions')).toEqual([bart_simpson])
     })
 
-    it('it debounces loadSuggestions for 100 ms', () => {
-      expect(_.debounce).toHaveBeenCalledWith(component.instance().loadSuggestions, 100)
+    it('it debounces loadSuggestions for 400 ms', () => {
+      expect(_.debounce).toHaveBeenCalledWith(component.instance().loadSuggestions, 400)
     })
   })
 

--- a/spec/support/helpers/autocompleter_helpers.rb
+++ b/spec/support/helpers/autocompleter_helpers.rb
@@ -7,20 +7,30 @@ module AutocompleterHelpers
   include KeyboardHelper
   RESULTS_CONTAINER = '.react-autosuggest__suggestions-container ul'
 
-  def fill_in_autocompleter(locator, with:, select_option_with: nil, skip_select: false)
+  def fill_in_autocompleter(
+    locator,
+    with:,
+    select_option_with: nil,
+    skip_select: false,
+    splitted: false
+  )
     select_option_with ||= with
-    populate_autocompleter_with_options(locator, with)
+    populate_autocompleter_with_options(locator, with, splitted)
     click_autocompleter_result(with, select_option_with) unless skip_select
   end
 
-  def populate_autocompleter_with_options(locator, value)
+  def populate_autocompleter_with_options(locator, value, splitted)
     unless /selenium|accessible/.match?(Capybara.current_driver.to_s)
       raise 'You need to tag your test with @javascript to use this step'
     end
-
-    value.split('').each do |character|
-      find_field(locator).native.send_keys(character)
-      sleep 0.15
+    if splitted
+      value.split('').each do |character|
+        find_field(locator).native.send_keys(character)
+        sleep 0.41
+      end
+    else
+      fill_in locator, with: value
+      sleep 0.5
     end
 
     # Firefox doesn't trigger focus/blur when the window doesn't have system focus

--- a/spec/support/helpers/autocompleter_helpers.rb
+++ b/spec/support/helpers/autocompleter_helpers.rb
@@ -12,18 +12,18 @@ module AutocompleterHelpers
     with:,
     select_option_with: nil,
     skip_select: false,
-    splitted: false
+    split: false
   )
     select_option_with ||= with
-    populate_autocompleter_with_options(locator, with, splitted)
+    populate_autocompleter_with_options(locator, with, split)
     click_autocompleter_result(with, select_option_with) unless skip_select
   end
 
-  def populate_autocompleter_with_options(locator, value, splitted)
+  def populate_autocompleter_with_options(locator, value, split)
     unless /selenium|accessible/.match?(Capybara.current_driver.to_s)
       raise 'You need to tag your test with @javascript to use this step'
     end
-    if splitted
+    if split
       value.split('').each do |character|
         find_field(locator).native.send_keys(character)
         sleep 0.41


### PR DESCRIPTION
### Pivotal Story
- [Search responsiveness in IE 149047599](https://www.pivotaltracker.com/story/show/149047599)

### Purpose
Increase the delay before making the search query call in order to reduce the impact of the ie bug 

### Background
[A chore is created](https://www.pivotaltracker.com/story/show/151965957) to replace react-autocomplete with something more ie friendly and has less conflicts with its dependences 

### Notes for Reviewer
This requires the test to wait half a second before search results are shown. Test changes were kept to a minimum to be easily removed once react-autocomplete is replaced.
