### PR TITLE
In 152011067 split licensing into two

### DIFF
--- a/app/controllers/api/v1/screenings_controller.rb
+++ b/app/controllers/api/v1/screenings_controller.rb
@@ -28,7 +28,7 @@ module Api
           id
           county
           agency_type
-          agency_name
+          agency_code
           reported_on
           communication_method
         ],

--- a/app/javascript/common/CheckboxField.jsx
+++ b/app/javascript/common/CheckboxField.jsx
@@ -8,6 +8,7 @@ const CheckboxField = ({
   value,
   checked,
   disabled,
+  label,
   onChange,
   onBlur,
   required,
@@ -23,7 +24,7 @@ const CheckboxField = ({
       onChange={onChange}
       onBlur={onBlur}
     />
-    <label className={required && 'required'} htmlFor={id}>{value}</label>
+    <label className={required && 'required'} htmlFor={id}>{label}</label>
     <ErrorMessages ariaDescribedBy={id} errors={errors}/>
   </div>
 )
@@ -33,6 +34,7 @@ CheckboxField.propTypes = {
   disabled: PropTypes.bool,
   errors: PropTypes.array,
   id: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
   onBlur: PropTypes.func,
   onChange: PropTypes.func.isRequired,
   required: PropTypes.bool,

--- a/app/javascript/enums/CrossReport.js
+++ b/app/javascript/enums/CrossReport.js
@@ -1,9 +1,16 @@
-export const AGENCY_TYPES = Object.freeze([
-  'District attorney',
-  'Law enforcement',
-  'Department of justice',
-  'Licensing',
-])
+export const COMMUNITY_CARE_LICENSING = 'COMMUNITY_CARE_LICENSING'
+export const COUNTY_LICENSING = 'COUNTY_LICENSING'
+export const DEPARTMENT_OF_JUSTICE = 'DEPARTMENT_OF_JUSTICE'
+export const DISTRICT_ATTORNEY = 'DISTRICT_ATTORNEY'
+export const LAW_ENFORCEMENT = 'LAW_ENFORCEMENT'
+
+export const AGENCY_TYPES = Object.freeze({
+  [DISTRICT_ATTORNEY]: 'District attorney',
+  [LAW_ENFORCEMENT]: 'Law enforcement',
+  [DEPARTMENT_OF_JUSTICE]: 'Department of justice',
+  [COUNTY_LICENSING]: 'County licensing',
+  [COMMUNITY_CARE_LICENSING]: 'Community care licensing',
+})
 
 export const COMMUNICATION_METHODS = Object.freeze([
   'Child Abuse Form',
@@ -15,7 +22,6 @@ export const COMMUNICATION_METHODS = Object.freeze([
 export const ALLEGATIONS_REQUIRE_CROSS_REPORTS_MESSAGE = 'Any report that includes allegations (except General Neglect, Caretaker Absence, or "At risk, sibling abused") must be cross-reported to law enforcement and the district attorney.'
 
 export const CROSS_REPORTS_REQUIRED_FOR_ALLEGATIONS = Object.freeze([
-  'District attorney',
-  'Law enforcement',
+  DISTRICT_ATTORNEY,
+  LAW_ENFORCEMENT,
 ])
-

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -116,6 +116,7 @@ class ContactForm extends React.Component {
                               key={`person_${index}`}
                               id={`person_${index}`}
                               value={person.name}
+                              label={person.name}
                               checked={person.selected}
                               onChange={({target: {checked}}) => {
                                 if (checked === true) {

--- a/app/javascript/people/EthnicityEditView.jsx
+++ b/app/javascript/people/EthnicityEditView.jsx
@@ -47,6 +47,7 @@ export class EthnicityEditView extends React.Component {
                     <CheckboxField
                       id={`${id}-ethnicity-${option.replace(/ /gi, '_')}`}
                       value={option}
+                      label={option}
                       checked={selected}
                       disabled={Boolean(disabled)}
                       onChange={(event) => this.changeEthnicity(option, event.target.checked)}

--- a/app/javascript/people/RacesEditView.jsx
+++ b/app/javascript/people/RacesEditView.jsx
@@ -73,6 +73,7 @@ export class RacesEditView extends React.Component {
                     key={race}
                     id={`${id}-race-${raceId}`}
                     value={race}
+                    label={race}
                     checked={selected}
                     disabled={disabled}
                     onChange={(event) => this.changeRace(race, event.target.checked)}

--- a/app/javascript/screenings/CrossReportCardView.jsx
+++ b/app/javascript/screenings/CrossReportCardView.jsx
@@ -5,8 +5,15 @@ import Immutable from 'immutable'
 import PropTypes from 'prop-types'
 import React from 'react'
 import {AGENCY_TYPES} from 'enums/CrossReport'
-import {ALLEGATIONS_REQUIRE_CROSS_REPORTS_MESSAGE} from 'enums/CrossReport'
-import {CROSS_REPORTS_REQUIRED_FOR_ALLEGATIONS} from 'enums/CrossReport'
+import {
+  ALLEGATIONS_REQUIRE_CROSS_REPORTS_MESSAGE,
+  CROSS_REPORTS_REQUIRED_FOR_ALLEGATIONS,
+  LAW_ENFORCEMENT,
+  DISTRICT_ATTORNEY,
+  DEPARTMENT_OF_JUSTICE,
+  COUNTY_LICENSING,
+  COMMUNITY_CARE_LICENSING,
+} from 'enums/CrossReport'
 import ScreeningCardHeader from 'screenings/ScreeningCardHeader'
 
 export default class CrossReportCardView extends React.Component {
@@ -21,82 +28,99 @@ export default class CrossReportCardView extends React.Component {
     this.onSave = this.onSave.bind(this)
     this.validateField = this.validateField.bind(this)
     this.fieldValidations = Immutable.fromJS({
-      'Law enforcement': {
+      [LAW_ENFORCEMENT]: {
         agency_type: [{
           rule: 'isRequiredIf',
           message: 'Please indicate cross-reporting to law enforcement.',
-          condition: () => this.isAgencyRequired('Law enforcement'),
+          condition: () => this.isAgencyRequired(LAW_ENFORCEMENT),
         }],
         agency_code: [{
           rule: 'isRequiredIf',
           message: 'Please enter an agency name.',
-          condition: () => this.isAgencyChecked('Law enforcement'),
+          condition: () => this.isAgencyChecked(LAW_ENFORCEMENT),
         }],
         communication_method: [{
           rule: 'isRequiredIf',
           message: 'Please select cross-report communication method.',
-          condition: () => this.isAgencyChecked('Law enforcement'),
+          condition: () => this.isAgencyChecked(LAW_ENFORCEMENT),
         }],
         reported_on: [{
           rule: 'isRequiredIf',
           message: 'Please enter a cross-report date.',
-          condition: () => this.isAgencyChecked('Law enforcement'),
+          condition: () => this.isAgencyChecked(LAW_ENFORCEMENT),
         }],
       },
-      'District attorney': {
+      [DISTRICT_ATTORNEY]: {
         agency_type: [{
           rule: 'isRequiredIf',
           message: 'Please indicate cross-reporting to district attorney.',
-          condition: () => this.isAgencyRequired('District attorney'),
+          condition: () => this.isAgencyRequired(DISTRICT_ATTORNEY),
         }],
         agency_code: [{
           rule: 'isRequiredIf',
           message: 'Please enter an agency name.',
-          condition: () => this.isAgencyChecked('District attorney'),
+          condition: () => this.isAgencyChecked(DISTRICT_ATTORNEY),
         }],
         communication_method: [{
           rule: 'isRequiredIf',
           message: 'Please select cross-report communication method.',
-          condition: () => this.isAgencyChecked('District attorney'),
+          condition: () => this.isAgencyChecked(DISTRICT_ATTORNEY),
         }],
         reported_on: [{
           rule: 'isRequiredIf',
           message: 'Please enter a cross-report date.',
-          condition: () => this.isAgencyChecked('District attorney'),
+          condition: () => this.isAgencyChecked(DISTRICT_ATTORNEY),
         }],
       },
-      'Department of justice': {
+      [DEPARTMENT_OF_JUSTICE]: {
         agency_code: [{
           rule: 'isRequiredIf',
           message: 'Please enter an agency name.',
-          condition: () => this.isAgencyChecked('Department of justice'),
+          condition: () => this.isAgencyChecked(DEPARTMENT_OF_JUSTICE),
         }],
         communication_method: [{
           rule: 'isRequiredIf',
           message: 'Please select cross-report communication method.',
-          condition: () => this.isAgencyChecked('Department of justice'),
+          condition: () => this.isAgencyChecked(DEPARTMENT_OF_JUSTICE),
         }],
         reported_on: [{
           rule: 'isRequiredIf',
           message: 'Please enter a cross-report date.',
-          condition: () => this.isAgencyChecked('Department of justice'),
+          condition: () => this.isAgencyChecked(DEPARTMENT_OF_JUSTICE),
         }],
       },
-      Licensing: {
+      [COUNTY_LICENSING]: {
         agency_code: [{
           rule: 'isRequiredIf',
           message: 'Please enter an agency name.',
-          condition: () => this.isAgencyChecked('Licensing'),
+          condition: () => this.isAgencyChecked(COUNTY_LICENSING),
         }],
         communication_method: [{
           rule: 'isRequiredIf',
           message: 'Please select cross-report communication method.',
-          condition: () => this.isAgencyChecked('Licensing'),
+          condition: () => this.isAgencyChecked(COUNTY_LICENSING),
         }],
         reported_on: [{
           rule: 'isRequiredIf',
           message: 'Please enter a cross-report date.',
-          condition: () => this.isAgencyChecked('Licensing'),
+          condition: () => this.isAgencyChecked(COUNTY_LICENSING),
+        }],
+      },
+      [COMMUNITY_CARE_LICENSING]: {
+        agency_code: [{
+          rule: 'isRequiredIf',
+          message: 'Please enter an agency name.',
+          condition: () => this.isAgencyChecked(COMMUNITY_CARE_LICENSING),
+        }],
+        communication_method: [{
+          rule: 'isRequiredIf',
+          message: 'Please select cross-report communication method.',
+          condition: () => this.isAgencyChecked(COMMUNITY_CARE_LICENSING),
+        }],
+        reported_on: [{
+          rule: 'isRequiredIf',
+          message: 'Please enter a cross-report date.',
+          condition: () => this.isAgencyChecked(COMMUNITY_CARE_LICENSING),
         }],
       },
     })
@@ -163,7 +187,7 @@ export default class CrossReportCardView extends React.Component {
         break
       case 'communication_method':
       case 'reported_on':
-        AGENCY_TYPES.map((agency) => {
+        Object.keys(AGENCY_TYPES).map((agency) => {
           updatedReport = reports.find((report) =>
             report.get('agency_type') === agency
           ) || Immutable.Map()

--- a/app/javascript/screenings/CrossReportCardView.jsx
+++ b/app/javascript/screenings/CrossReportCardView.jsx
@@ -260,6 +260,7 @@ export default class CrossReportCardView extends React.Component {
         onChange: this.onChange,
       },
       show: {
+        agencyCodeToName: this.props.agencyCodeToName,
         errors: errors,
         onEdit: this.onEdit,
         countyAgencies: this.props.countyAgencies,
@@ -283,6 +284,7 @@ export default class CrossReportCardView extends React.Component {
 }
 
 CrossReportCardView.defaultProps = {
+  agencyCodeToName: {},
   allegations: Immutable.fromJS([]),
   counties: [],
   countyAgencies: {},
@@ -290,6 +292,7 @@ CrossReportCardView.defaultProps = {
 
 CrossReportCardView.propTypes = {
   actions: PropTypes.object.isRequired,
+  agencyCodeToName: PropTypes.object,
   areCrossReportsRequired: PropTypes.bool.isRequired,
   counties: PropTypes.array,
   countyAgencies: PropTypes.object,

--- a/app/javascript/screenings/CrossReportCardView.jsx
+++ b/app/javascript/screenings/CrossReportCardView.jsx
@@ -27,7 +27,7 @@ export default class CrossReportCardView extends React.Component {
           message: 'Please indicate cross-reporting to law enforcement.',
           condition: () => this.isAgencyRequired('Law enforcement'),
         }],
-        agency_name: [{
+        agency_code: [{
           rule: 'isRequiredIf',
           message: 'Please enter an agency name.',
           condition: () => this.isAgencyChecked('Law enforcement'),
@@ -49,7 +49,7 @@ export default class CrossReportCardView extends React.Component {
           message: 'Please indicate cross-reporting to district attorney.',
           condition: () => this.isAgencyRequired('District attorney'),
         }],
-        agency_name: [{
+        agency_code: [{
           rule: 'isRequiredIf',
           message: 'Please enter an agency name.',
           condition: () => this.isAgencyChecked('District attorney'),
@@ -66,7 +66,7 @@ export default class CrossReportCardView extends React.Component {
         }],
       },
       'Department of justice': {
-        agency_name: [{
+        agency_code: [{
           rule: 'isRequiredIf',
           message: 'Please enter an agency name.',
           condition: () => this.isAgencyChecked('Department of justice'),
@@ -83,7 +83,7 @@ export default class CrossReportCardView extends React.Component {
         }],
       },
       Licensing: {
-        agency_name: [{
+        agency_code: [{
           rule: 'isRequiredIf',
           message: 'Please enter an agency name.',
           condition: () => this.isAgencyChecked('Licensing'),
@@ -154,11 +154,11 @@ export default class CrossReportCardView extends React.Component {
         updatedValue = (updatedReport !== undefined)
         errors = this.validateField(agencyType, fieldName, updatedValue)
         break
-      case 'agency_name':
+      case 'agency_code':
         updatedReport = reports.find((report) =>
           report.get('agency_type') === agencyType
         ) || Immutable.Map()
-        updatedValue = updatedReport.get('agency_name')
+        updatedValue = updatedReport.get('agency_code')
         errors = this.validateField(agencyType, fieldName, updatedValue)
         break
       case 'communication_method':

--- a/app/javascript/screenings/CrossReportEditView.jsx
+++ b/app/javascript/screenings/CrossReportEditView.jsx
@@ -85,6 +85,7 @@ export default class CrossReportEditView extends React.Component {
                       checked={selected}
                       errors={errors.getIn([agencyType, 'agency_type']) && errors.getIn([agencyType, 'agency_type']).toJS()}
                       disabled={this.props.countyAgencies[typeId] === undefined || this.props.countyAgencies[typeId].length === 0}
+                      label={agencyType}
                       onBlur={(event) =>
                         this.props.onBlur(
                           this.updatedCrossReports(agencyType, 'agency_type', event.target.checked),

--- a/app/javascript/screenings/CrossReportEditView.jsx
+++ b/app/javascript/screenings/CrossReportEditView.jsx
@@ -29,16 +29,16 @@ export default class CrossReportEditView extends React.Component {
       return {
         agencyType: agencyType,
         selected: Boolean(persistedInfo),
-        agencyName: persistedInfo && persistedInfo.agency_name,
+        agencyName: persistedInfo && persistedInfo.agency_code,
       }
     })
   }
 
   updatedCrossReports(agencyType, fieldName, value) {
     const {crossReports} = this.props
-    if (fieldName === 'agency_name') {
+    if (fieldName === 'agency_code') {
       const index = crossReports.toJS().findIndex((item) => item.agency_type === agencyType)
-      return crossReports.setIn([index, 'agency_name'], value || null)
+      return crossReports.setIn([index, 'agency_code'], value || null)
     }
     if (fieldName === 'agency_type') {
       const existingReport = crossReports.find((report) => report.get('agency_type') === agencyType)
@@ -50,7 +50,7 @@ export default class CrossReportEditView extends React.Component {
           Immutable.Map({
             county: this.state.county,
             agency_type: agencyType,
-            agency_name: null,
+            agency_code: null,
             reported_on: this.state.reportedOn,
             communication_method: this.state.communicationMethod,
           }))
@@ -103,19 +103,19 @@ export default class CrossReportEditView extends React.Component {
                     {
                       selected &&
                           <SelectField
-                            errors={errors.getIn([agencyType, 'agency_name']) && errors.getIn([agencyType, 'agency_name']).toJS()}
-                            id={`${typeId}-agency-name`}
+                            errors={errors.getIn([agencyType, 'agency_code']) && errors.getIn([agencyType, 'agency_code']).toJS()}
+                            id={`${typeId}-agency-code`}
                             label={`${agencyType} agency name`}
                             onBlur={(event) =>
                               this.props.onBlur(
-                                this.updatedCrossReports(agencyType, 'agency_name', event.target.value),
-                                ['agency_name', agencyType]
+                                this.updatedCrossReports(agencyType, 'agency_code', event.target.value),
+                                ['agency_code', agencyType]
                               )
                             }
                             onChange={(event) =>
                               this.props.onChange(
-                                this.updatedCrossReports(agencyType, 'agency_name', event.target.value),
-                                ['agency_name', agencyType]
+                                this.updatedCrossReports(agencyType, 'agency_code', event.target.value),
+                                ['agency_code', agencyType]
                               )
                             }
                             required

--- a/app/javascript/screenings/CrossReportEditView.jsx
+++ b/app/javascript/screenings/CrossReportEditView.jsx
@@ -24,12 +24,12 @@ export default class CrossReportEditView extends React.Component {
   }
 
   crossReportData() {
-    return AGENCY_TYPES.map((agencyType) => {
+    return Object.keys(AGENCY_TYPES).map((agencyType) => {
       const persistedInfo = this.persistedInfo(agencyType)
       return {
         agencyType: agencyType,
         selected: Boolean(persistedInfo),
-        agencyName: persistedInfo && persistedInfo.agency_code,
+        agencyCode: persistedInfo && persistedInfo.agency_code,
       }
     })
   }
@@ -75,17 +75,16 @@ export default class CrossReportEditView extends React.Component {
         <ul className='unstyled-list'>
           {
             crossReportOptions.map((item) => {
-              const {agencyType, selected, agencyName} = item
-              const typeId = agencyType.replace(/ /gi, '_').toUpperCase()
+              const {agencyType, selected, agencyCode} = item
               return (
                 <li key={agencyType}>
                   <div className='half-gap-bottom'>
                     <CheckboxField
-                      id={`type-${typeId}`}
+                      id={`type-${agencyType}`}
                       checked={selected}
                       errors={errors.getIn([agencyType, 'agency_type']) && errors.getIn([agencyType, 'agency_type']).toJS()}
-                      disabled={this.props.countyAgencies[typeId] === undefined || this.props.countyAgencies[typeId].length === 0}
-                      label={agencyType}
+                      disabled={this.props.countyAgencies[agencyType] === undefined || this.props.countyAgencies[agencyType].length === 0}
+                      label={AGENCY_TYPES[agencyType]}
                       onBlur={(event) =>
                         this.props.onBlur(
                           this.updatedCrossReports(agencyType, 'agency_type', event.target.checked),
@@ -105,8 +104,8 @@ export default class CrossReportEditView extends React.Component {
                       selected &&
                           <SelectField
                             errors={errors.getIn([agencyType, 'agency_code']) && errors.getIn([agencyType, 'agency_code']).toJS()}
-                            id={`${typeId}-agency-code`}
-                            label={`${agencyType} agency name`}
+                            id={`${agencyType}-agency-code`}
+                            label={`${AGENCY_TYPES[agencyType]} agency name`}
                             onBlur={(event) =>
                               this.props.onBlur(
                                 this.updatedCrossReports(agencyType, 'agency_code', event.target.value),
@@ -120,10 +119,10 @@ export default class CrossReportEditView extends React.Component {
                               )
                             }
                             required
-                            value={agencyName || ''}
+                            value={agencyCode || ''}
                           >
                             <option key='' />
-                            {this.props.countyAgencies[typeId] !== undefined && this.props.countyAgencies[typeId].map((agency) => <option key={agency.id} value={agency.id}>{agency.name}</option>)}
+                            {this.props.countyAgencies[agencyType] !== undefined && this.props.countyAgencies[agencyType].map((agency) => <option key={agency.id} value={agency.id}>{agency.name}</option>)}
                           </SelectField>
                     }
                   </div>

--- a/app/javascript/screenings/CrossReportShowView.jsx
+++ b/app/javascript/screenings/CrossReportShowView.jsx
@@ -5,6 +5,7 @@ import React from 'react'
 import ShowField from 'common/ShowField'
 import _ from 'lodash'
 import {dateFormatter} from 'utils/dateFormatter'
+import {AGENCY_TYPES} from 'enums/CrossReport'
 
 export default class CrossReportShowView extends React.Component {
   constructor() {
@@ -35,7 +36,7 @@ export default class CrossReportShowView extends React.Component {
                   {
                     crossReports.map(({agency_type, agency_code}, index) => (
                       <div key={index}>
-                        <li>{agency_code ? this.props.agencyCodeToName[agency_code] : agency_type}</li>
+                        <li>{agency_code ? this.props.agencyCodeToName[agency_code] : AGENCY_TYPES[agency_type]}</li>
                         <ErrorMessages
                           errors={this.props.errors.getIn([agency_type, 'agency_code']) && this.props.errors.getIn([agency_type, 'agency_code']).toJS()}
                         />

--- a/app/javascript/screenings/CrossReportShowView.jsx
+++ b/app/javascript/screenings/CrossReportShowView.jsx
@@ -34,11 +34,11 @@ export default class CrossReportShowView extends React.Component {
               crossReports &&
                 <ul className='unstyled-list'>
                   {
-                    crossReports.map(({agency_type, agency_name}, index) => (
+                    crossReports.map(({agency_type, agency_code}, index) => (
                       <div key={index}>
-                        <li>{agencyTypeAndName(agency_type, agency_name, this.props.countyAgencies)}</li>
+                        <li>{agencyTypeAndName(agency_type, agency_code, this.props.countyAgencies)}</li>
                         <ErrorMessages
-                          errors={this.props.errors.getIn([agency_type, 'agency_name']) && this.props.errors.getIn([agency_type, 'agency_name']).toJS()}
+                          errors={this.props.errors.getIn([agency_type, 'agency_code']) && this.props.errors.getIn([agency_type, 'agency_code']).toJS()}
                         />
                       </div>
                     ))

--- a/app/javascript/screenings/CrossReportShowView.jsx
+++ b/app/javascript/screenings/CrossReportShowView.jsx
@@ -5,7 +5,6 @@ import React from 'react'
 import ShowField from 'common/ShowField'
 import _ from 'lodash'
 import {dateFormatter} from 'utils/dateFormatter'
-import {agencyTypeAndName} from 'selectors/countyAgenciesSelectors'
 
 export default class CrossReportShowView extends React.Component {
   constructor() {
@@ -36,7 +35,7 @@ export default class CrossReportShowView extends React.Component {
                   {
                     crossReports.map(({agency_type, agency_code}, index) => (
                       <div key={index}>
-                        <li>{agencyTypeAndName(agency_type, agency_code, this.props.countyAgencies)}</li>
+                        <li>{agency_code ? this.props.agencyCodeToName[agency_code] : agency_type}</li>
                         <ErrorMessages
                           errors={this.props.errors.getIn([agency_type, 'agency_code']) && this.props.errors.getIn([agency_type, 'agency_code']).toJS()}
                         />
@@ -74,8 +73,8 @@ export default class CrossReportShowView extends React.Component {
 }
 
 CrossReportShowView.propTypes = {
+  agencyCodeToName: PropTypes.object,
   alertInfoMessage: PropTypes.string,
-  countyAgencies: PropTypes.object.isRequired,
   crossReports: PropTypes.object,
   errors: PropTypes.object.isRequired,
   onEdit: PropTypes.func.isRequired,

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -28,12 +28,16 @@ import {
   DISTRICT_ATTORNEY,
   DEPARTMENT_OF_JUSTICE,
   LAW_ENFORCEMENT,
-  LICENSING,
+  COUNTY_LICENSING,
+  COMMUNITY_CARE_LICENSING,
+} from 'enums/CrossReport'
+import {
   getAgencyCodeToName,
   getDistrictAttorneyAgencies,
   getDepartmentOfJusticeAgencies,
   getLawEnforcementAgencies,
-  getLicensingAgencies,
+  getCountyLicensingAgencies,
+  getCommunityCareLicensingAgencies,
 } from 'selectors/countyAgenciesSelectors'
 
 export class ScreeningPage extends React.Component {
@@ -435,7 +439,8 @@ export function mapStateToProps(state, ownProps) {
       [DEPARTMENT_OF_JUSTICE]: getDepartmentOfJusticeAgencies(state).toJS(),
       [DISTRICT_ATTORNEY]: getDistrictAttorneyAgencies(state).toJS(),
       [LAW_ENFORCEMENT]: getLawEnforcementAgencies(state).toJS(),
-      [LICENSING]: getLicensingAgencies(state).toJS(),
+      [COMMUNITY_CARE_LICENSING]: getCommunityCareLicensingAgencies(state).toJS(),
+      [COUNTY_LICENSING]: getCountyLicensingAgencies(state).toJS(),
     },
     hasAddSensitivePerson: state.getIn(['staff', 'add_sensitive_people']),
     involvements: state.get('involvements'),

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -29,6 +29,7 @@ import {
   DEPARTMENT_OF_JUSTICE,
   LAW_ENFORCEMENT,
   LICENSING,
+  getAgencyCodeToName,
   getDistrictAttorneyAgencies,
   getDepartmentOfJusticeAgencies,
   getLawEnforcementAgencies,
@@ -348,6 +349,7 @@ export class ScreeningPage extends React.Component {
           {
             releaseTwoInactive &&
               <CrossReportCardView
+                agencyCodeToName={this.props.agencyCodeToName}
                 areCrossReportsRequired={AllegationsHelper.areCrossReportsRequired(sortedAllegations)}
                 {...cardCallbacks}
                 counties={this.props.counties}
@@ -401,6 +403,7 @@ export class ScreeningPage extends React.Component {
 
 ScreeningPage.propTypes = {
   actions: PropTypes.object.isRequired,
+  agencyCodeToName: PropTypes.object,
   counties: PropTypes.array,
   countyAgencies: PropTypes.object,
   editable: PropTypes.bool,
@@ -415,6 +418,7 @@ ScreeningPage.propTypes = {
 }
 
 ScreeningPage.defaultProps = {
+  agencyCodeToName: {},
   counties: [],
   countyAgencies: {},
   mode: 'show',
@@ -423,6 +427,7 @@ ScreeningPage.defaultProps = {
 
 export function mapStateToProps(state, ownProps) {
   return {
+    agencyCodeToName: getAgencyCodeToName(state),
     editable: !state.getIn(['screening', 'referral_id']),
     counties: state.get('counties').toJS(),
     countyAgencies: {

--- a/app/javascript/selectors/countyAgenciesSelectors.js
+++ b/app/javascript/selectors/countyAgenciesSelectors.js
@@ -1,12 +1,13 @@
 import {createSelector} from 'reselect'
 import {List} from 'immutable'
-
-export const COMMUNITY_CARE_LICENSING = 'COMMUNITY_CARE_LICENSING'
-export const COUNTY_LICENSING = 'COUNTY_LICENSING'
-export const DEPARTMENT_OF_JUSTICE = 'DEPARTMENT_OF_JUSTICE'
-export const DISTRICT_ATTORNEY = 'DISTRICT_ATTORNEY'
-export const LAW_ENFORCEMENT = 'LAW_ENFORCEMENT'
-export const LICENSING = 'LICENSING'
+import {
+  AGENCY_TYPES,
+  DISTRICT_ATTORNEY,
+  DEPARTMENT_OF_JUSTICE,
+  LAW_ENFORCEMENT,
+  COMMUNITY_CARE_LICENSING,
+  COUNTY_LICENSING,
+} from 'enums/CrossReport'
 
 export const getCountyAgencies = (state) => state.get('countyAgencies')
 export const getDistrictAttorneyAgencies = createSelector(
@@ -21,23 +22,27 @@ export const getLawEnforcementAgencies = createSelector(
   getCountyAgencies,
   (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === LAW_ENFORCEMENT)
 )
-export const getLicensingAgencies = createSelector(
+export const getCountyLicensingAgencies = createSelector(
   getCountyAgencies,
-  (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === COMMUNITY_CARE_LICENSING || countyAgency.get('type') === COUNTY_LICENSING)
+  (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === COUNTY_LICENSING)
+)
+export const getCommunityCareLicensingAgencies = createSelector(
+  getCountyAgencies,
+  (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === COMMUNITY_CARE_LICENSING)
 )
 
 export const getAgencyCodeToName = createSelector(
   (state) => state.getIn(['screening', 'cross_reports']) || List(),
   getCountyAgencies,
   (crossReports, countyAgencies) => crossReports.reduce((agencyCodeToName, crossReport) => {
-    const agencyType = crossReport.get('agency_type')
+    const agencyTypeName = AGENCY_TYPES[crossReport.get('agency_type')]
     const agencyCode = crossReport.get('agency_code')
     if (agencyCode) {
       const agency = countyAgencies.find((countyAgency) => countyAgency.get('id') === agencyCode)
       if (agency && agency.get('name')) {
-        agencyCodeToName[agencyCode] = `${agencyType} - ${agency.get('name')}`
+        agencyCodeToName[agencyCode] = `${agencyTypeName} - ${agency.get('name')}`
       } else {
-        agencyCodeToName[agencyCode] = `${agencyType} - ${agencyCode}`
+        agencyCodeToName[agencyCode] = `${agencyTypeName} - ${agencyCode}`
       }
     }
     return agencyCodeToName

--- a/app/javascript/selectors/countyAgenciesSelectors.js
+++ b/app/javascript/selectors/countyAgenciesSelectors.js
@@ -1,5 +1,5 @@
 import {createSelector} from 'reselect'
-import _ from 'lodash'
+import {List} from 'immutable'
 
 export const COMMUNITY_CARE_LICENSING = 'COMMUNITY_CARE_LICENSING'
 export const COUNTY_LICENSING = 'COUNTY_LICENSING'
@@ -8,36 +8,38 @@ export const DISTRICT_ATTORNEY = 'DISTRICT_ATTORNEY'
 export const LAW_ENFORCEMENT = 'LAW_ENFORCEMENT'
 export const LICENSING = 'LICENSING'
 
+export const getCountyAgencies = (state) => state.get('countyAgencies')
 export const getDistrictAttorneyAgencies = createSelector(
-  (state) => state.get('countyAgencies'),
+  getCountyAgencies,
   (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === DISTRICT_ATTORNEY)
 )
 export const getDepartmentOfJusticeAgencies = createSelector(
-  (state) => state.get('countyAgencies'),
+  getCountyAgencies,
   (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === DEPARTMENT_OF_JUSTICE)
 )
 export const getLawEnforcementAgencies = createSelector(
-  (state) => state.get('countyAgencies'),
+  getCountyAgencies,
   (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === LAW_ENFORCEMENT)
 )
 export const getLicensingAgencies = createSelector(
-  (state) => state.get('countyAgencies'),
+  getCountyAgencies,
   (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === COMMUNITY_CARE_LICENSING || countyAgency.get('type') === COUNTY_LICENSING)
 )
 
-// TODO: This should become a real selector like the above in the future say in #150924573
-export const agencyTypeAndName = (agency_type, agency_code, countyAgencies) => {
-  const typeId = agency_type.replace(/ /gi, '_').toUpperCase()
-  const agencies = countyAgencies[typeId]
-  if (_.isEmpty(agencies)) {
-    return agency_type
-  } else {
-    const filteredAgencies = agencies.filter((countyAgency) => countyAgency.id === agency_code)
-    if (_.isEmpty(filteredAgencies)) {
-      return agency_type
-    } else {
-      const agencyName = filteredAgencies[0].name
-      return agencyName ? `${agency_type} - ${agencyName}` : agency_type
+export const getAgencyCodeToName = createSelector(
+  (state) => state.getIn(['screening', 'cross_reports']) || List(),
+  getCountyAgencies,
+  (crossReports, countyAgencies) => crossReports.reduce((agencyCodeToName, crossReport) => {
+    const agencyType = crossReport.get('agency_type')
+    const agencyCode = crossReport.get('agency_code')
+    if (agencyCode) {
+      const agency = countyAgencies.find((countyAgency) => countyAgency.get('id') === agencyCode)
+      if (agency && agency.get('name')) {
+        agencyCodeToName[agencyCode] = `${agencyType} - ${agency.get('name')}`
+      } else {
+        agencyCodeToName[agencyCode] = `${agencyType} - ${agencyCode}`
+      }
     }
-  }
-}
+    return agencyCodeToName
+  }, {})
+)

--- a/app/models/cross_report.rb
+++ b/app/models/cross_report.rb
@@ -6,7 +6,7 @@ class CrossReport
 
   attribute :county, String
   attribute :agency_type, String
-  attribute :agency_name, String
+  attribute :agency_code, String
   attribute :communication_method, String
   attribute :reported_on, String
 end

--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -9,6 +9,8 @@ namespace :docker do # rubocop:disable BlockLength
   task :reup do
     run_commands [
       'docker-compose down',
+      'docker-compose run --rm api bundle',
+      'docker-compose run --rm ca_intake bundle',
       'docker-compose up -d',
       'docker-compose exec api bundle exec rake db:migrate',
       'docker-compose exec api bundle exec rake db:test:prepare',

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -58,17 +58,10 @@ namespace :spec do # rubocop:disable BlockLength
   namespace :api do
     desc 'Run ALL THE SPECS, & RUBOCOP!!!'
     task :full do
-      Rake::Task['spec:api'].invoke
-      system 'docker-compose exec api rubocop'
+      system('rubocop ../intake_api') && Rake::Task['spec:api'].invoke
     end
   end
 
   desc 'Run specs and linters for both intake and api'
-  task :full do
-    Rake::Task['spec:intake:parallel'].invoke
-    system 'bin/lint'
-    system 'bin/karma'
-    Rake::Task['spec:api'].invoke
-    system 'docker-compose exec api rubocop'
-  end
+  task full: ['spec:api:full', 'spec:intake:full']
 end

--- a/spec/controllers/api/v1/screenings_controller_spec.rb
+++ b/spec/controllers/api/v1/screenings_controller_spec.rb
@@ -122,14 +122,14 @@ describe Api::V1::ScreeningsController do
           {
             county: 'sacramento',
             agency_type: 'Department of justice',
-            agency_name: 'SCD office',
+            agency_code: 'SCDOFFCODE',
             reported_on: '1990-01-15',
             communication_method: 'Child Abuse Form'
           },
           {
             county: 'sacramento',
             agency_type: 'Licensing',
-            agency_name: 'SCD office',
+            agency_code: 'SCDOFFCODE',
             reported_on: '1990-01-15',
             communication_method: 'Child Abuse Form'
           }

--- a/spec/factories/cross_report_factory.rb
+++ b/spec/factories/cross_report_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
   factory :cross_report, class: CrossReport do
     skip_create
 
-    agency_name { FFaker::Lorem.sentence(3) }
+    agency_code { FFaker::Lorem.sentence(3) }
     reported_on { Faker::Date.between(1.year.ago, 1.day.ago).to_s(:db) }
 
     agency_type do
@@ -27,13 +27,13 @@ FactoryGirl.define do
 
     trait :unpopulated do
       agency_type { nil }
-      agency_name { nil }
+      agency_code { nil }
       communication_method { nil }
       reported_on nil
     end
 
     trait :invalid do
-      agency_name { nil }
+      agency_code { nil }
       communication_method { nil }
       reported_on nil
     end

--- a/spec/features/screening/allegations_cross_reports_spec.rb
+++ b/spec/features/screening/allegations_cross_reports_spec.rb
@@ -27,7 +27,7 @@ feature 'show cross reports' do
         CrossReport.new(
           county: 'c41',
           agency_type: 'Law enforcement',
-          agency_name: 'LA Office',
+          agency_code: 'LAOFFCODE',
           communication_method: 'Child Abuse Form'
         )
       ]
@@ -90,7 +90,7 @@ feature 'show cross reports' do
         CrossReport.new(
           county: 'c41',
           agency_type: 'Law enforcement',
-          agency_name: 'LA Office',
+          agency_code: 'LAOFFCODE',
           communication_method: 'Child Abuse Form'
         )
       ]

--- a/spec/features/screening/allegations_cross_reports_spec.rb
+++ b/spec/features/screening/allegations_cross_reports_spec.rb
@@ -26,7 +26,7 @@ feature 'show cross reports' do
       cross_reports: [
         CrossReport.new(
           county: 'c41',
-          agency_type: 'Law enforcement',
+          agency_type: 'LAW_ENFORCEMENT',
           agency_code: 'LAOFFCODE',
           communication_method: 'Child Abuse Form'
         )
@@ -89,7 +89,7 @@ feature 'show cross reports' do
       cross_reports: [
         CrossReport.new(
           county: 'c41',
-          agency_type: 'Law enforcement',
+          agency_type: 'LAW_ENFORCEMENT',
           agency_code: 'LAOFFCODE',
           communication_method: 'Child Abuse Form'
         )
@@ -160,8 +160,8 @@ feature 'show cross reports' do
       expect(page).to_not have_content('must be cross-reported to law enforcement')
     end
 
-    screening.cross_reports << { county: 'c41', agency_type: 'Disctrict attorney' }
-    screening.cross_reports << { county: 'c41', agency_type: 'Law enforcement' }
+    screening.cross_reports << { county: 'c41', agency_type: 'DISCTRICT_ATTORNEY' }
+    screening.cross_reports << { county: 'c41', agency_type: 'LAW_ENFORCEMENT' }
     stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
     within '#cross-report-card.edit' do

--- a/spec/features/screening/cross_reports_spec.rb
+++ b/spec/features/screening/cross_reports_spec.rb
@@ -44,14 +44,14 @@ feature 'cross reports' do
           'cross_reports' => array_including(
             hash_including(
               'county' => 'c42',
-              'agency_type' => 'Law enforcement',
+              'agency_type' => 'LAW_ENFORCEMENT',
               'agency_code' => 'BMG2f3J75C',
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
             ),
             hash_including(
               'county' => 'c42',
-              'agency_type' => 'Department of justice',
+              'agency_type' => 'DEPARTMENT_OF_JUSTICE',
               'agency_code' => 'EYIS9Nh75C',
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
@@ -69,14 +69,14 @@ feature 'cross reports' do
     existing_screening.cross_reports = [
       CrossReport.new(
         county: 'c42',
-        agency_type: 'Department of justice',
+        agency_type: 'DEPARTMENT_OF_JUSTICE',
         agency_code: 'EYIS9Nh75C',
         communication_method: communication_method,
         reported_on: reported_on.to_s(:db)
       ),
       CrossReport.new(
         county: 'c42',
-        agency_type: 'Law enforcement',
+        agency_type: 'LAW_ENFORCEMENT',
         agency_code: 'BMG2f3J75C',
         communication_method: communication_method,
         reported_on: reported_on.to_s(:db)
@@ -113,14 +113,14 @@ feature 'cross reports' do
           'cross_reports' => array_including(
             hash_including(
               'county' => 'c40',
-              'agency_type' => 'Law enforcement',
+              'agency_type' => 'LAW_ENFORCEMENT',
               'agency_code' => 'BMG2f3J75C',
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
             ),
             hash_including(
               'county' => 'c40',
-              'agency_type' => 'District attorney',
+              'agency_type' => 'DISTRICT_ATTORNEY',
               'agency_code' => nil,
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
@@ -135,14 +135,14 @@ feature 'cross reports' do
     existing_screening.cross_reports = [
       CrossReport.new(
         county: 'c42',
-        agency_type: 'Department of justice',
+        agency_type: 'DEPARTMENT_OF_JUSTICE',
         agency_code: 'EYIS9Nh75C',
         communication_method: 'Child Abuse Form',
         reported_on: Date.today.to_s(:db)
       ),
       CrossReport.new(
         county: 'c42',
-        agency_type: 'Law enforcement',
+        agency_type: 'LAW_ENFORCEMENT',
         agency_code: 'BMG2f3J75C',
         communication_method: 'Child Abuse Form',
         reported_on: Date.today.to_s(:db)
@@ -221,7 +221,7 @@ feature 'cross reports' do
         body: hash_including(
           'cross_reports' => array_including(
             hash_including(
-              'agency_type' => 'Law enforcement',
+              'agency_type' => 'LAW_ENFORCEMENT',
               'agency_code' => nil,
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
@@ -266,7 +266,7 @@ feature 'cross reports' do
         body: hash_including(
           'cross_reports' => array_including(
             hash_including(
-              'agency_type' => 'Law enforcement',
+              'agency_type' => 'LAW_ENFORCEMENT',
               'agency_code' => nil,
               'reported_on' => nil,
               'communication_method' => nil

--- a/spec/features/screening/cross_reports_spec.rb
+++ b/spec/features/screening/cross_reports_spec.rb
@@ -45,14 +45,14 @@ feature 'cross reports' do
             hash_including(
               'county' => 'c42',
               'agency_type' => 'Law enforcement',
-              'agency_name' => 'BMG2f3J75C',
+              'agency_code' => 'BMG2f3J75C',
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
             ),
             hash_including(
               'county' => 'c42',
               'agency_type' => 'Department of justice',
-              'agency_name' => 'EYIS9Nh75C',
+              'agency_code' => 'EYIS9Nh75C',
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
             )
@@ -70,14 +70,14 @@ feature 'cross reports' do
       CrossReport.new(
         county: 'c42',
         agency_type: 'Department of justice',
-        agency_name: 'EYIS9Nh75C',
+        agency_code: 'EYIS9Nh75C',
         communication_method: communication_method,
         reported_on: reported_on.to_s(:db)
       ),
       CrossReport.new(
         county: 'c42',
         agency_type: 'Law enforcement',
-        agency_name: 'BMG2f3J75C',
+        agency_code: 'BMG2f3J75C',
         communication_method: communication_method,
         reported_on: reported_on.to_s(:db)
       )
@@ -114,14 +114,14 @@ feature 'cross reports' do
             hash_including(
               'county' => 'c40',
               'agency_type' => 'Law enforcement',
-              'agency_name' => 'BMG2f3J75C',
+              'agency_code' => 'BMG2f3J75C',
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
             ),
             hash_including(
               'county' => 'c40',
               'agency_type' => 'District attorney',
-              'agency_name' => nil,
+              'agency_code' => nil,
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
             )
@@ -136,14 +136,14 @@ feature 'cross reports' do
       CrossReport.new(
         county: 'c42',
         agency_type: 'Department of justice',
-        agency_name: 'EYIS9Nh75C',
+        agency_code: 'EYIS9Nh75C',
         communication_method: 'Child Abuse Form',
         reported_on: Date.today.to_s(:db)
       ),
       CrossReport.new(
         county: 'c42',
         agency_type: 'Law enforcement',
-        agency_name: 'BMG2f3J75C',
+        agency_code: 'BMG2f3J75C',
         communication_method: 'Child Abuse Form',
         reported_on: Date.today.to_s(:db)
       )
@@ -222,7 +222,7 @@ feature 'cross reports' do
           'cross_reports' => array_including(
             hash_including(
               'agency_type' => 'Law enforcement',
-              'agency_name' => nil,
+              'agency_code' => nil,
               'reported_on' => reported_on.to_s(:db),
               'communication_method' => communication_method
             )
@@ -267,7 +267,7 @@ feature 'cross reports' do
           'cross_reports' => array_including(
             hash_including(
               'agency_type' => 'Law enforcement',
-              'agency_name' => nil,
+              'agency_code' => nil,
               'reported_on' => nil,
               'communication_method' => nil
             )

--- a/spec/features/screening/edit_screening_spec.rb
+++ b/spec/features/screening/edit_screening_spec.rb
@@ -36,7 +36,7 @@ feature 'Edit Screening' do
         {
           county: 'c42',
           agency_type: 'District attorney',
-          agency_name: '45Hvp7x00F'
+          agency_code: '45Hvp7x00F'
         },
         {
           county: 'c42',
@@ -292,7 +292,7 @@ feature 'individual card save' do
       {
         county: 'c41',
         agency_type: 'District attorney',
-        agency_name: '65Hvp7x01F'
+        agency_code: '65Hvp7x01F'
       }
     ]
 
@@ -333,7 +333,7 @@ feature 'individual card save' do
       {
         county: 'c41',
         agency_type: 'District attorney',
-        agency_name: '45Hvp7x00F'
+        agency_code: '45Hvp7x00F'
       }
     ]
 

--- a/spec/features/screening/edit_screening_spec.rb
+++ b/spec/features/screening/edit_screening_spec.rb
@@ -35,12 +35,12 @@ feature 'Edit Screening' do
       cross_reports: [
         {
           county: 'c42',
-          agency_type: 'District attorney',
+          agency_type: 'DISTRICT_ATTORNEY',
           agency_code: '45Hvp7x00F'
         },
         {
           county: 'c42',
-          agency_type: 'Law enforcement'
+          agency_type: 'LAW_ENFORCEMENT'
         }
       ]
     )
@@ -116,12 +116,12 @@ feature 'Edit Screening' do
 
       within '#cross-report-card.edit', text: 'Cross Report' do
         expect(page).to have_content('This report has cross reported to:')
-        expect(page.find('input[value="District attorney"]')).to be_checked
+        expect(page.find('input[value="DISTRICT_ATTORNEY"]')).to be_checked
         expect(page).to have_select(
           'District attorney agency name',
           selected: 'LA District Attorney'
         )
-        expect(page.find('input[value="Law enforcement"]')).to be_checked
+        expect(page.find('input[value="LAW_ENFORCEMENT"]')).to be_checked
         expect(page).to have_select('Law enforcement agency name', selected: '')
         expect(page).to have_button 'Save'
         expect(page).to have_button 'Cancel'
@@ -291,7 +291,7 @@ feature 'individual card save' do
     existing_screening.cross_reports = [
       {
         county: 'c41',
-        agency_type: 'District attorney',
+        agency_type: 'DISTRICT_ATTORNEY',
         agency_code: '65Hvp7x01F'
       }
     ]
@@ -332,7 +332,7 @@ feature 'individual card save' do
     existing_screening.cross_reports = [
       {
         county: 'c41',
-        agency_type: 'District attorney',
+        agency_type: 'DISTRICT_ATTORNEY',
         agency_code: '45Hvp7x00F'
       }
     ]

--- a/spec/features/screening/show_screening_spec.rb
+++ b/spec/features/screening/show_screening_spec.rb
@@ -33,8 +33,8 @@ feature 'Show Screening' do
       screening_decision_detail: 'consultation',
       started_at: '2016-08-13T10:00:00.000Z',
       cross_reports: [
-        { county: 'c41', agency_type: 'District attorney', agency_code: '45Hvp7x00F' },
-        { county: 'c41', agency_type: 'Licensing' }
+        { county: 'c41', agency_type: 'DISTRICT_ATTORNEY', agency_code: '45Hvp7x00F' },
+        { county: 'c41', agency_type: 'COUNTY_LICENSING' }
       ]
     )
   end
@@ -100,7 +100,7 @@ feature 'Show Screening' do
     within '#cross-report-card', text: 'Cross Report' do
       expect(page).to have_content 'District attorney'
       expect(page).to have_content 'LA District Attorney'
-      expect(page).to have_content 'Licensing'
+      expect(page).to have_content 'County licensing'
       click_link 'Edit cross report'
       expect(page).to have_select('District attorney agency name', selected: 'LA District Attorney')
       select '', from: 'District attorney agency name'
@@ -148,8 +148,8 @@ feature 'Show Screening' do
         screening_decision_detail: 'consultation',
         started_at: '2016-08-13T10:00:00.000Z',
         cross_reports: [
-          { agency_type: 'District attorney', agency_code: '45Hvp7x00F' },
-          { agency_type: 'Licensing' }
+          { agency_type: 'DISTRICT_ATTORNEY', agency_code: '45Hvp7x00F' },
+          { agency_type: 'COUNTY_LICENSING' }
         ]
       )
     end

--- a/spec/features/screening/show_screening_spec.rb
+++ b/spec/features/screening/show_screening_spec.rb
@@ -33,7 +33,7 @@ feature 'Show Screening' do
       screening_decision_detail: 'consultation',
       started_at: '2016-08-13T10:00:00.000Z',
       cross_reports: [
-        { county: 'c41', agency_type: 'District attorney', agency_name: '45Hvp7x00F' },
+        { county: 'c41', agency_type: 'District attorney', agency_code: '45Hvp7x00F' },
         { county: 'c41', agency_type: 'Licensing' }
       ]
     )
@@ -148,7 +148,7 @@ feature 'Show Screening' do
         screening_decision_detail: 'consultation',
         started_at: '2016-08-13T10:00:00.000Z',
         cross_reports: [
-          { agency_type: 'District attorney', agency_name: '45Hvp7x00F' },
+          { agency_type: 'District attorney', agency_code: '45Hvp7x00F' },
           { agency_type: 'Licensing' }
         ]
       )

--- a/spec/features/screening/validations/cross_reports_validations_spec.rb
+++ b/spec/features/screening/validations/cross_reports_validations_spec.rb
@@ -46,7 +46,7 @@ feature 'Cross Reports Validations' do
           error_message: error_message,
           screening_updates:
           { cross_reports:
-            [county: 'c41', agency_type: 'Department of justice', agency_name: 'EYIS9Nh75C'] }
+            [county: 'c41', agency_type: 'Department of justice', agency_code: 'EYIS9Nh75C'] }
         ) do
           within '#cross-report-card.edit' do
             select 'DOJ Agency', from: 'Department of justice agency name'

--- a/spec/features/screening/validations/cross_reports_validations_spec.rb
+++ b/spec/features/screening/validations/cross_reports_validations_spec.rb
@@ -12,7 +12,7 @@ feature 'Cross Reports Validations' do
           :cross_report,
           :invalid,
           county: 'c41',
-          agency_type: 'Department of justice'
+          agency_type: 'DEPARTMENT_OF_JUSTICE'
         )
       ]
     )
@@ -46,7 +46,7 @@ feature 'Cross Reports Validations' do
           error_message: error_message,
           screening_updates:
           { cross_reports:
-            [county: 'c41', agency_type: 'Department of justice', agency_code: 'EYIS9Nh75C'] }
+            [county: 'c41', agency_type: 'DEPARTMENT_OF_JUSTICE', agency_code: 'EYIS9Nh75C'] }
         ) do
           within '#cross-report-card.edit' do
             select 'DOJ Agency', from: 'Department of justice agency name'

--- a/spec/javascripts/components/common/CheckboxFieldSpec.jsx
+++ b/spec/javascripts/components/common/CheckboxFieldSpec.jsx
@@ -10,6 +10,7 @@ describe('CheckboxField', () => {
     errors: [],
     id: 'myCheckboxFieldId',
     value: 'this-is-my-value',
+    label: 'This is my label',
   }
   beforeEach(() => {
     onChange = jasmine.createSpy('onChange')
@@ -35,7 +36,7 @@ describe('CheckboxField', () => {
 
     it('renders the value', () => {
       expect(component.find('input').props().value).toEqual('this-is-my-value')
-      expect(component.find('label').text()).toEqual('this-is-my-value')
+      expect(component.find('label').text()).toEqual('This is my label')
     })
 
     it('renders with NO checked prop', () => {

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -143,7 +143,7 @@ describe('ScreeningPage', () => {
           participants: participants,
           safety_alerts: [],
           cross_reports: [
-            {agency_type: 'District attorney', agency_name: 'SCDA Office'},
+            {agency_type: 'District attorney', agency_code: 'SCDAOFFCODE'},
             {agency_type: 'Department of justice'},
           ],
         }),
@@ -305,8 +305,8 @@ describe('ScreeningPage', () => {
         report_narrative: 'This is what happened',
         additional_information: 'Some more relevant information',
         cross_reports: [
-          {agency_type: 'District attorney', agency_name: 'SAC DA'},
-          {agency_type: 'Licensing', agency_name: ''},
+          {agency_type: 'District attorney', agency_code: 'SACDACODE'},
+          {agency_type: 'Licensing', agency_code: ''},
         ],
         safety_alerts: [
           'Firearms in Home',
@@ -337,7 +337,7 @@ describe('ScreeningPage', () => {
     it('cross_reports edits override the entire screeningEdits.cross_reports array', () => {
       const changeJS = {
         cross_reports: [
-          {agency_type: 'Gibberish', agency_name: 'Irrelevant'},
+          {agency_type: 'Gibberish', agency_code: 'IRRELEVANTCODE'},
         ],
       }
       const updated_screening = instance.mergeScreeningWithEdits(Immutable.fromJS(changeJS))
@@ -710,8 +710,8 @@ describe('ScreeningPage', () => {
           name: 'The old name',
           reference: 'old reference',
           cross_reports: [
-            {agency_name: 'a name', agency_type: 'Licensing'},
-            {agency_name: '', agency_type: 'District attorney'},
+            {agency_code: 'ANAMECODE', agency_type: 'Licensing'},
+            {agency_code: '', agency_type: 'District attorney'},
           ],
           address: {city: 'Davis', county: 'Yolo'},
           report_narrative: 'I have things to say',
@@ -724,7 +724,7 @@ describe('ScreeningPage', () => {
       instance.setField(['report_narrative'], 'This is my new narrative')
       instance.setField(['name'], 'A name')
       instance.setField(['reference'], 'ABC123')
-      instance.setField(['cross_reports'], [{agency_name: 'new name', agency_type: 'District attorney'}])
+      instance.setField(['cross_reports'], [{agency_code: 'NEWNAMECODE', agency_type: 'District attorney'}])
       instance.setField(['address', 'city'], 'Sacramento')
     })
 
@@ -735,7 +735,7 @@ describe('ScreeningPage', () => {
         name: 'The old name',
         reference: 'old reference',
         cross_reports: [
-          {agency_name: 'new name', agency_type: 'District attorney'},
+          {agency_code: 'NEWNAMECODE', agency_type: 'District attorney'},
         ],
         address: {city: 'Davis', county: 'Yolo'},
         report_narrative: 'I have things to say',
@@ -749,8 +749,8 @@ describe('ScreeningPage', () => {
         name: 'The old name',
         reference: 'ABC123',
         cross_reports: [
-          {agency_name: 'a name', agency_type: 'Licensing'},
-          {agency_name: '', agency_type: 'District attorney'},
+          {agency_code: 'ANAMECODE', agency_type: 'Licensing'},
+          {agency_code: '', agency_type: 'District attorney'},
         ],
         address: {city: 'Sacramento', county: 'Yolo'},
         report_narrative: 'I have things to say',
@@ -764,8 +764,8 @@ describe('ScreeningPage', () => {
         name: 'The old name',
         reference: 'old reference',
         cross_reports: [
-          {agency_name: 'a name', agency_type: 'Licensing'},
-          {agency_name: '', agency_type: 'District attorney'},
+          {agency_code: 'ANAMECODE', agency_type: 'Licensing'},
+          {agency_code: '', agency_type: 'District attorney'},
         ],
         address: {city: 'Sacramento', county: 'Yolo'},
         report_narrative: 'I have things to say',
@@ -779,8 +779,8 @@ describe('ScreeningPage', () => {
         name: 'The old name',
         reference: 'old reference',
         cross_reports: [
-          {agency_name: 'a name', agency_type: 'Licensing'},
-          {agency_name: '', agency_type: 'District attorney'},
+          {agency_code: 'ANAMECODE', agency_type: 'Licensing'},
+          {agency_code: '', agency_type: 'District attorney'},
         ],
         address: {city: 'Davis', county: 'Yolo'},
         report_narrative: 'This is my new narrative',
@@ -794,8 +794,8 @@ describe('ScreeningPage', () => {
         name: 'The old name',
         reference: 'old reference',
         cross_reports: [
-          {agency_name: 'a name', agency_type: 'Licensing'},
-          {agency_name: '', agency_type: 'District attorney'},
+          {agency_code: 'ANAMECODE', agency_type: 'Licensing'},
+          {agency_code: '', agency_type: 'District attorney'},
         ],
         address: {city: 'Davis', county: 'Yolo'},
         report_narrative: 'I have things to say',

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -17,6 +17,7 @@ export const requiredProps = {
     fetchScreening: () => null,
     fetchCountyAgencies: () => null,
   },
+  agencyCodeToName: {code123: 'Name of Agency'},
   counties: [{code: '123', value: 'county'}],
   countyAgencies: {DEPARTMENT_OF_JUSTICE: []},
   params: {id: '1'},
@@ -154,6 +155,7 @@ describe('ScreeningPage', () => {
       expect(crossReportsCard.length).toEqual(1)
       expect(crossReportsCard.props().areCrossReportsRequired).toEqual(true)
       expect(crossReportsCard.props().counties).toEqual([{code: '123', value: 'county'}])
+      expect(crossReportsCard.props().agencyCodeToName).toEqual(props.agencyCodeToName)
       expect(crossReportsCard.props().countyAgencies).toEqual({DEPARTMENT_OF_JUSTICE: []})
       expect(crossReportsCard.props().crossReports).toEqual(props.screening.get('cross_reports'))
       expect(crossReportsCard.props().mode).toEqual('edit')

--- a/spec/javascripts/components/screenings/crossReports/CrossReportCardViewSpec.jsx
+++ b/spec/javascripts/components/screenings/crossReports/CrossReportCardViewSpec.jsx
@@ -15,7 +15,7 @@ describe('CrossReportCardView', () => {
     counties: [{code: '123', value: 'county'}],
     countyAgencies: {DEPARTMENT_OF_JUSTICE: []},
     crossReports: Immutable.fromJS([
-      {county: '123', agency_type: 'District attorney', agency_name: '1234'},
+      {county: '123', agency_type: 'District attorney', agency_code: '1234'},
       {county: '123', agency_type: 'Department of justice'},
     ]),
     editable: true,
@@ -137,7 +137,7 @@ describe('CrossReportCardView', () => {
         expect(component.find('CrossReportEditView').props().counties).toEqual([{code: '123', value: 'county'}])
         expect(component.find('CrossReportEditView').props().countyAgencies).toEqual({DEPARTMENT_OF_JUSTICE: []})
         expect(component.find('CrossReportEditView').props().crossReports.toJS()).toEqual([
-          {county: '123', agency_type: 'District attorney', agency_name: '1234'},
+          {county: '123', agency_type: 'District attorney', agency_code: '1234'},
           {county: '123', agency_type: 'Department of justice'},
         ])
         expect(component.find('CrossReportEditView').props().actions.fetchCountyAgencies).toEqual(fetchCountyAgencies)
@@ -187,7 +187,7 @@ describe('CrossReportCardView', () => {
             onSave: jasmine.createSpy('onSave'),
             areCrossReportsRequired: true,
             crossReports: Immutable.fromJS([
-              {agency_type: 'District attorney', agency_name: '1234'},
+              {agency_type: 'District attorney', agency_code: '1234'},
               {agency_type: 'Department of justice'},
             ]),
             editable: true,
@@ -198,12 +198,12 @@ describe('CrossReportCardView', () => {
 
         it('is called by a child onChange', () => {
           const report = Immutable.fromJS([
-            {agency_type: 'District attorney', agency_name: 'LAPD'},
+            {agency_type: 'District attorney', agency_code: 'LAPD'},
             {agency_type: 'Department of justice'},
           ])
           component.find('CrossReportEditView').props().onChange(
             report,
-            ['agency_name', 'District attorney']
+            ['agency_code', 'District attorney']
           )
           expect(validationProps.onChange).toHaveBeenCalledWith(
             ['cross_reports'],
@@ -221,13 +221,13 @@ describe('CrossReportCardView', () => {
               errors: Immutable.fromJS({
                 'Law enforcement': {
                   agency_type: ['Please indicate cross-reporting to law enforcement.'],
-                  agency_name: [],
+                  agency_code: [],
                   communication_method: [],
                   reported_on: [],
                 },
                 'District attorney': {
                   agency_type: [],
-                  agency_name: ['Please enter an agency name.'],
+                  agency_code: ['PLEASECODE'],
                   communication_method: ['Please select cross-report communication method.'],
                   reported_on: ['Please enter a cross-report date.'],
                 },
@@ -239,7 +239,7 @@ describe('CrossReportCardView', () => {
           it('handles agency_type if it got added', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'District attorney', agency_name: 'LAPD'},
+                {agency_type: 'District attorney', agency_code: 'LAPDCODE'},
                 {agency_type: 'Law enforcement'},
               ]),
               ['agency_type', 'Law enforcement']
@@ -250,7 +250,7 @@ describe('CrossReportCardView', () => {
           it('handles agency_type if it got removed', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'District attorney', agency_name: 'LAPD'},
+                {agency_type: 'District attorney', agency_code: 'LAPDCODE'},
                 {agency_type: 'Department of justice'},
               ]),
               ['agency_type', 'Law enforcement']
@@ -261,7 +261,7 @@ describe('CrossReportCardView', () => {
           it('handles communication_method & reported_on', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'District attorney', agency_name: 'LAPD'},
+                {agency_type: 'District attorney', agency_code: 'LAPDCODE'},
                 {agency_type: 'Department of justice'},
               ]),
               ['communication_method']
@@ -269,24 +269,24 @@ describe('CrossReportCardView', () => {
             expect(validateFieldSpy.calls.count()).toEqual(4)
           })
 
-          it('handles agency_name', () => {
+          it('handles agency_code', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'District attorney', agency_name: 'LAPD'},
+                {agency_type: 'District attorney', agency_code: 'LAPDCODE'},
                 {agency_type: 'Department of justice'},
               ]),
-              ['agency_name', 'District attorney']
+              ['agency_code', 'District attorney']
             )
-            expect(validateFieldSpy).toHaveBeenCalledWith('District attorney', 'agency_name', 'LAPD')
+            expect(validateFieldSpy).toHaveBeenCalledWith('District attorney', 'agency_code', 'LAPDCODE')
           })
 
           it('does not make the call if there are no errors on the changed field', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'Law enforcement', agency_name: 'LAPD'},
+                {agency_type: 'Law enforcement', agency_code: 'LAPDCODE'},
                 {agency_type: 'Department of justice'},
               ]),
-              ['agency_name', 'Law enforcement']
+              ['agency_code', 'Law enforcement']
             )
             expect(validateFieldSpy).not.toHaveBeenCalled()
           })
@@ -332,22 +332,22 @@ describe('CrossReportCardView', () => {
           const expectedErrors = {
             'Law enforcement': {
               agency_type: ['Please indicate cross-reporting to law enforcement.'],
-              agency_name: [],
+              agency_code: [],
               communication_method: [],
               reported_on: [],
             },
             'District attorney': {
               agency_type: [],
-              agency_name: [],
+              agency_code: [],
               communication_method: ['Please select cross-report communication method.'],
               reported_on: ['Please enter a cross-report date.'],
             },
             'Department of justice': {
-              agency_name: ['Please enter an agency name.'],
+              agency_code: ['Please enter an agency name.'],
               communication_method: ['Please select cross-report communication method.'],
               reported_on: ['Please enter a cross-report date.'],
             },
-            Licensing: {agency_name: [], communication_method: [], reported_on: []},
+            Licensing: {agency_code: [], communication_method: [], reported_on: []},
           }
           expect(actualErrors.toJS()).toEqual(expectedErrors)
         })
@@ -366,22 +366,22 @@ describe('CrossReportCardView', () => {
         const expectedErrors = {
           'Law enforcement': {
             agency_type: ['Please indicate cross-reporting to law enforcement.'],
-            agency_name: [],
+            agency_code: [],
             communication_method: [],
             reported_on: [],
           },
           'District attorney': {
             agency_type: [],
-            agency_name: [],
+            agency_code: [],
             communication_method: ['Please select cross-report communication method.'],
             reported_on: ['Please enter a cross-report date.'],
           },
           'Department of justice': {
-            agency_name: ['Please enter an agency name.'],
+            agency_code: ['Please enter an agency name.'],
             communication_method: ['Please select cross-report communication method.'],
             reported_on: ['Please enter a cross-report date.'],
           },
-          Licensing: {agency_name: [], communication_method: [], reported_on: []},
+          Licensing: {agency_code: [], communication_method: [], reported_on: []},
         }
         expect(actualErrors.toJS()).toEqual(expectedErrors)
       })
@@ -400,22 +400,22 @@ describe('CrossReportCardView', () => {
         const expectedErrors = {
           'Law enforcement': {
             agency_type: ['Please indicate cross-reporting to law enforcement.'],
-            agency_name: [],
+            agency_code: [],
             communication_method: [],
             reported_on: [],
           },
           'District attorney': {
             agency_type: [],
-            agency_name: [],
+            agency_code: [],
             communication_method: ['Please select cross-report communication method.'],
             reported_on: ['Please enter a cross-report date.'],
           },
           'Department of justice': {
-            agency_name: ['Please enter an agency name.'],
+            agency_code: ['Please enter an agency name.'],
             communication_method: ['Please select cross-report communication method.'],
             reported_on: ['Please enter a cross-report date.'],
           },
-          Licensing: {agency_name: [], communication_method: [], reported_on: []},
+          Licensing: {agency_code: [], communication_method: [], reported_on: []},
         }
         expect(component.find('CrossReportShowView').props().errors.toJS()).toEqual(expectedErrors)
       })

--- a/spec/javascripts/components/screenings/crossReports/CrossReportCardViewSpec.jsx
+++ b/spec/javascripts/components/screenings/crossReports/CrossReportCardViewSpec.jsx
@@ -10,6 +10,7 @@ describe('CrossReportCardView', () => {
 
   const fetchCountyAgencies = jasmine.createSpy('fetchCountyAgencies')
   const props = {
+    agencyCodeToName: {code123: 'Name of Agency'},
     areCrossReportsRequired: true,
     actions: {fetchCountyAgencies},
     counties: [{code: '123', value: 'county'}],
@@ -321,7 +322,7 @@ describe('CrossReportCardView', () => {
         it('renders the cross report show view', () => {
           component.find('button[children="Cancel"]').simulate('click')
           expect(component.find('CrossReportShowView').length).toEqual(1)
-          expect(component.find('CrossReportShowView').props().countyAgencies).toEqual({DEPARTMENT_OF_JUSTICE: []})
+          expect(component.find('CrossReportShowView').props().agencyCodeToName).toEqual(props.agencyCodeToName)
         })
 
         it('validates all cross reports', () => {

--- a/spec/javascripts/components/screenings/crossReports/CrossReportCardViewSpec.jsx
+++ b/spec/javascripts/components/screenings/crossReports/CrossReportCardViewSpec.jsx
@@ -16,8 +16,8 @@ describe('CrossReportCardView', () => {
     counties: [{code: '123', value: 'county'}],
     countyAgencies: {DEPARTMENT_OF_JUSTICE: []},
     crossReports: Immutable.fromJS([
-      {county: '123', agency_type: 'District attorney', agency_code: '1234'},
-      {county: '123', agency_type: 'Department of justice'},
+      {county: '123', agency_type: 'DISTRICT_ATTORNEY', agency_code: '1234'},
+      {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE'},
     ]),
     editable: true,
   }
@@ -85,7 +85,7 @@ describe('CrossReportCardView', () => {
     })
 
     it('returns a message when cross reports are required but district attorney has not been selected', () => {
-      const crossReports = Immutable.fromJS([{agency_type: 'Law enforcement'}])
+      const crossReports = Immutable.fromJS([{agency_type: 'LAW_ENFORCEMENT'}])
       const component = shallow(
         <CrossReportCardView
           {...props}
@@ -98,7 +98,7 @@ describe('CrossReportCardView', () => {
     })
 
     it('returns a message when cross reports are required but law enforcement has not been selected', () => {
-      const crossReports = Immutable.fromJS([{agency_type: 'District attorney'}])
+      const crossReports = Immutable.fromJS([{agency_type: 'DISTRICT_ATTORNEY'}])
       const component = shallow(
         <CrossReportCardView
           {...props}
@@ -111,7 +111,7 @@ describe('CrossReportCardView', () => {
     })
 
     it('returns a message when cross reports are required, and law enforcement and D.A. have both been selected', () => {
-      const crossReports = Immutable.fromJS([{agency_type: 'District attorney'}, {agency_type: 'Law enforcement'}])
+      const crossReports = Immutable.fromJS([{agency_type: 'DISTRICT_ATTORNEY'}, {agency_type: 'LAW_ENFORCEMENT'}])
       const component = shallow(
         <CrossReportCardView
           {...props}
@@ -138,24 +138,25 @@ describe('CrossReportCardView', () => {
         expect(component.find('CrossReportEditView').props().counties).toEqual([{code: '123', value: 'county'}])
         expect(component.find('CrossReportEditView').props().countyAgencies).toEqual({DEPARTMENT_OF_JUSTICE: []})
         expect(component.find('CrossReportEditView').props().crossReports.toJS()).toEqual([
-          {county: '123', agency_type: 'District attorney', agency_code: '1234'},
-          {county: '123', agency_type: 'Department of justice'},
+          {county: '123', agency_type: 'DISTRICT_ATTORNEY', agency_code: '1234'},
+          {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE'},
         ])
         expect(component.find('CrossReportEditView').props().actions.fetchCountyAgencies).toEqual(fetchCountyAgencies)
       })
 
       describe('isAgencyRequired', () => {
         it('returns true if the agency is required and cross reporting is required', () => {
-          expect(component.instance().isAgencyRequired('District attorney')).toEqual(true)
+          expect(component.instance().isAgencyRequired('DISTRICT_ATTORNEY')).toEqual(true)
+          expect(component.instance().isAgencyRequired('LAW_ENFORCEMENT')).toEqual(true)
         })
 
         it('returns false if an agency is not required even if cross reporting is required', () => {
-          expect(component.instance().isAgencyRequired('Licensing')).toEqual(false)
+          expect(component.instance().isAgencyRequired('COUNTY_LICENSING')).toEqual(false)
         })
 
         it('returns false if cross reporting is not required', () => {
           component = shallow(<CrossReportCardView {...props} mode='edit' areCrossReportsRequired={false}/>)
-          expect(component.instance().isAgencyRequired('District attorney')).toEqual(false)
+          expect(component.instance().isAgencyRequired('DISTRICT_ATTORNEY')).toEqual(false)
         })
       })
 
@@ -188,8 +189,8 @@ describe('CrossReportCardView', () => {
             onSave: jasmine.createSpy('onSave'),
             areCrossReportsRequired: true,
             crossReports: Immutable.fromJS([
-              {agency_type: 'District attorney', agency_code: '1234'},
-              {agency_type: 'Department of justice'},
+              {agency_type: 'DISTRICT_ATTORNEY', agency_code: '1234'},
+              {agency_type: 'DEPARTMENT_OF_JUSTICE'},
             ]),
             editable: true,
           }
@@ -199,12 +200,12 @@ describe('CrossReportCardView', () => {
 
         it('is called by a child onChange', () => {
           const report = Immutable.fromJS([
-            {agency_type: 'District attorney', agency_code: 'LAPD'},
-            {agency_type: 'Department of justice'},
+            {agency_type: 'DISTRICT_ATTORNEY', agency_code: 'LAPD'},
+            {agency_type: 'DEPARTMENT_OF_JUSTICE'},
           ])
           component.find('CrossReportEditView').props().onChange(
             report,
-            ['agency_code', 'District attorney']
+            ['agency_code', 'DISTRICT_ATTORNEY']
           )
           expect(validationProps.onChange).toHaveBeenCalledWith(
             ['cross_reports'],
@@ -220,13 +221,13 @@ describe('CrossReportCardView', () => {
           beforeEach(() => {
             component.setState({
               errors: Immutable.fromJS({
-                'Law enforcement': {
+                LAW_ENFORCEMENT: {
                   agency_type: ['Please indicate cross-reporting to law enforcement.'],
                   agency_code: [],
                   communication_method: [],
                   reported_on: [],
                 },
-                'District attorney': {
+                DISTRICT_ATTORNEY: {
                   agency_type: [],
                   agency_code: ['PLEASECODE'],
                   communication_method: ['Please select cross-report communication method.'],
@@ -240,54 +241,54 @@ describe('CrossReportCardView', () => {
           it('handles agency_type if it got added', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'District attorney', agency_code: 'LAPDCODE'},
-                {agency_type: 'Law enforcement'},
+                {agency_type: 'DISTRICT_ATTORNEY', agency_code: 'LAPDCODE'},
+                {agency_type: 'LAW_ENFORCEMENT'},
               ]),
-              ['agency_type', 'Law enforcement']
+              ['agency_type', 'LAW_ENFORCEMENT']
             )
-            expect(validateFieldSpy).toHaveBeenCalledWith('Law enforcement', 'agency_type', true)
+            expect(validateFieldSpy).toHaveBeenCalledWith('LAW_ENFORCEMENT', 'agency_type', true)
           })
 
           it('handles agency_type if it got removed', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'District attorney', agency_code: 'LAPDCODE'},
-                {agency_type: 'Department of justice'},
+                {agency_type: 'DISTRICT_ATTORNEY', agency_code: 'LAPDCODE'},
+                {agency_type: 'DEPARTMENT_OF_JUSTICE'},
               ]),
-              ['agency_type', 'Law enforcement']
+              ['agency_type', 'LAW_ENFORCEMENT']
             )
-            expect(validateFieldSpy).toHaveBeenCalledWith('Law enforcement', 'agency_type', false)
+            expect(validateFieldSpy).toHaveBeenCalledWith('LAW_ENFORCEMENT', 'agency_type', false)
           })
 
           it('handles communication_method & reported_on', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'District attorney', agency_code: 'LAPDCODE'},
-                {agency_type: 'Department of justice'},
+                {agency_type: 'DISTRICT_ATTORNEY', agency_code: 'LAPDCODE'},
+                {agency_type: 'DEPARTMENT_OF_JUSTICE'},
               ]),
               ['communication_method']
             )
-            expect(validateFieldSpy.calls.count()).toEqual(4)
+            expect(validateFieldSpy.calls.count()).toEqual(5)
           })
 
           it('handles agency_code', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'District attorney', agency_code: 'LAPDCODE'},
-                {agency_type: 'Department of justice'},
+                {agency_type: 'DISTRICT_ATTORNEY', agency_code: 'LAPDCODE'},
+                {agency_type: 'DEPARTMENT_OF_JUSTICE'},
               ]),
-              ['agency_code', 'District attorney']
+              ['agency_code', 'DISTRICT_ATTORNEY']
             )
-            expect(validateFieldSpy).toHaveBeenCalledWith('District attorney', 'agency_code', 'LAPDCODE')
+            expect(validateFieldSpy).toHaveBeenCalledWith('DISTRICT_ATTORNEY', 'agency_code', 'LAPDCODE')
           })
 
           it('does not make the call if there are no errors on the changed field', () => {
             component.instance().onChange(
               Immutable.fromJS([
-                {agency_type: 'Law enforcement', agency_code: 'LAPDCODE'},
-                {agency_type: 'Department of justice'},
+                {agency_type: 'LAW_ENFORCEMENT', agency_code: 'LAPDCODE'},
+                {agency_type: 'DEPARTMENT_OF_JUSTICE'},
               ]),
-              ['agency_code', 'Law enforcement']
+              ['agency_code', 'LAW_ENFORCEMENT']
             )
             expect(validateFieldSpy).not.toHaveBeenCalled()
           })
@@ -296,17 +297,17 @@ describe('CrossReportCardView', () => {
 
       describe('validateField', () => {
         it('sets error if Law enforcement is required but not checked', () => {
-          const actualErrors = component.instance().validateField('Law enforcement', 'agency_type', false)
+          const actualErrors = component.instance().validateField('LAW_ENFORCEMENT', 'agency_type', false)
           const expectedErrors = {
-            'Law enforcement': {agency_type: ['Please indicate cross-reporting to law enforcement.']},
+            LAW_ENFORCEMENT: {agency_type: ['Please indicate cross-reporting to law enforcement.']},
           }
           expect(actualErrors.toJS()).toEqual(expectedErrors)
         })
 
         it('does not set a new error if Law enforcement is required and checked', () => {
-          const actualErrors = component.instance().validateField('Law enforcement', 'agency_type', true)
+          const actualErrors = component.instance().validateField('LAW_ENFORCEMENT', 'agency_type', true)
           const expectedErrors = {
-            'Law enforcement': {agency_type: []},
+            LAW_ENFORCEMENT: {agency_type: []},
           }
           expect(actualErrors.toJS()).toEqual(expectedErrors)
         })
@@ -331,24 +332,25 @@ describe('CrossReportCardView', () => {
           expect(setStateSpy).toHaveBeenCalled()
           const actualErrors = setStateSpy.calls.argsFor(0)[0].errors
           const expectedErrors = {
-            'Law enforcement': {
+            LAW_ENFORCEMENT: {
               agency_type: ['Please indicate cross-reporting to law enforcement.'],
               agency_code: [],
               communication_method: [],
               reported_on: [],
             },
-            'District attorney': {
+            DISTRICT_ATTORNEY: {
               agency_type: [],
               agency_code: [],
               communication_method: ['Please select cross-report communication method.'],
               reported_on: ['Please enter a cross-report date.'],
             },
-            'Department of justice': {
+            DEPARTMENT_OF_JUSTICE: {
               agency_code: ['Please enter an agency name.'],
               communication_method: ['Please select cross-report communication method.'],
               reported_on: ['Please enter a cross-report date.'],
             },
-            Licensing: {agency_code: [], communication_method: [], reported_on: []},
+            COUNTY_LICENSING: {agency_code: [], communication_method: [], reported_on: []},
+            COMMUNITY_CARE_LICENSING: {agency_code: [], communication_method: [], reported_on: []},
           }
           expect(actualErrors.toJS()).toEqual(expectedErrors)
         })
@@ -365,24 +367,25 @@ describe('CrossReportCardView', () => {
         component = shallow(<CrossReportCardView {...props} mode='show'/>)
         const actualErrors = component.instance().validateAllCrossReports()
         const expectedErrors = {
-          'Law enforcement': {
+          LAW_ENFORCEMENT: {
             agency_type: ['Please indicate cross-reporting to law enforcement.'],
             agency_code: [],
             communication_method: [],
             reported_on: [],
           },
-          'District attorney': {
+          DISTRICT_ATTORNEY: {
             agency_type: [],
             agency_code: [],
             communication_method: ['Please select cross-report communication method.'],
             reported_on: ['Please enter a cross-report date.'],
           },
-          'Department of justice': {
+          DEPARTMENT_OF_JUSTICE: {
             agency_code: ['Please enter an agency name.'],
             communication_method: ['Please select cross-report communication method.'],
             reported_on: ['Please enter a cross-report date.'],
           },
-          Licensing: {agency_code: [], communication_method: [], reported_on: []},
+          COUNTY_LICENSING: {agency_code: [], communication_method: [], reported_on: []},
+          COMMUNITY_CARE_LICENSING: {agency_code: [], communication_method: [], reported_on: []},
         }
         expect(actualErrors.toJS()).toEqual(expectedErrors)
       })
@@ -399,24 +402,25 @@ describe('CrossReportCardView', () => {
 
       it('validates all fields and pass errors to show view', () => {
         const expectedErrors = {
-          'Law enforcement': {
+          LAW_ENFORCEMENT: {
             agency_type: ['Please indicate cross-reporting to law enforcement.'],
             agency_code: [],
             communication_method: [],
             reported_on: [],
           },
-          'District attorney': {
+          DISTRICT_ATTORNEY: {
             agency_type: [],
             agency_code: [],
             communication_method: ['Please select cross-report communication method.'],
             reported_on: ['Please enter a cross-report date.'],
           },
-          'Department of justice': {
+          DEPARTMENT_OF_JUSTICE: {
             agency_code: ['Please enter an agency name.'],
             communication_method: ['Please select cross-report communication method.'],
             reported_on: ['Please enter a cross-report date.'],
           },
-          Licensing: {agency_code: [], communication_method: [], reported_on: []},
+          COUNTY_LICENSING: {agency_code: [], communication_method: [], reported_on: []},
+          COMMUNITY_CARE_LICENSING: {agency_code: [], communication_method: [], reported_on: []},
         }
         expect(component.find('CrossReportShowView').props().errors.toJS()).toEqual(expectedErrors)
       })

--- a/spec/javascripts/components/screenings/crossReports/CrossReportEditViewSpec.jsx
+++ b/spec/javascripts/components/screenings/crossReports/CrossReportEditViewSpec.jsx
@@ -13,8 +13,8 @@ describe('CrossReportEditView', () => {
       counties: [{code: '123', value: 'County Bob'}],
       countyAgencies: {DISTRICT_ATTORNEY: []},
       crossReports: Immutable.fromJS([
-        {county: '123', agency_type: 'District attorney', agency_code: 'SCDAOFFCODE'},
-        {county: '123', agency_type: 'Department of justice'},
+        {county: '123', agency_type: 'DISTRICT_ATTORNEY', agency_code: 'SCDAOFFCODE'},
+        {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE'},
       ]),
       errors: Immutable.fromJS({}),
       onBlur: jasmine.createSpy(),
@@ -81,12 +81,20 @@ describe('CrossReportEditView', () => {
     })
     it('does render the cross report agency fields', () => {
       const checkboxes = component.find('CheckboxField')
-      expect(checkboxes.length).toEqual(4)
+      expect(checkboxes.length).toEqual(5)
       expect(checkboxes.nodes.map((checkbox) => checkbox.props.value)).toEqual([
+        'DISTRICT_ATTORNEY',
+        'LAW_ENFORCEMENT',
+        'DEPARTMENT_OF_JUSTICE',
+        'COUNTY_LICENSING',
+        'COMMUNITY_CARE_LICENSING',
+      ])
+      expect(checkboxes.nodes.map((checkbox) => checkbox.props.label)).toEqual([
         'District attorney',
         'Law enforcement',
         'Department of justice',
-        'Licensing',
+        'County licensing',
+        'Community care licensing',
       ])
     })
 
@@ -122,17 +130,17 @@ describe('CrossReportEditView', () => {
   describe('updatedCrossReports', () => {
     it('returns an updated crossReports when agency_code and value are passed', () => {
       expect(component.instance().updatedCrossReports(null, 'communication_method', 'Email').toJS()).toEqual([
-        {county: '123', agency_type: 'District attorney', agency_code: 'SCDAOFFCODE', communication_method: 'Email'},
-        {county: '123', agency_type: 'Department of justice', communication_method: 'Email'},
+        {county: '123', agency_type: 'DISTRICT_ATTORNEY', agency_code: 'SCDAOFFCODE', communication_method: 'Email'},
+        {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE', communication_method: 'Email'},
       ])
     })
     it('returns an updated crossReports with agency added when value is true', () => {
-      expect(component.instance().updatedCrossReports('Law enforcement', 'agency_type', true).toJS()).toEqual([
-        {county: '123', agency_type: 'District attorney', agency_code: 'SCDAOFFCODE'},
-        {county: '123', agency_type: 'Department of justice'},
+      expect(component.instance().updatedCrossReports('LAW_ENFORCEMENT', 'agency_type', true).toJS()).toEqual([
+        {county: '123', agency_type: 'DISTRICT_ATTORNEY', agency_code: 'SCDAOFFCODE'},
+        {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE'},
         {
           county: '123',
-          agency_type: 'Law enforcement',
+          agency_type: 'LAW_ENFORCEMENT',
           agency_code: null,
           reported_on: undefined,
           communication_method: undefined,
@@ -140,17 +148,17 @@ describe('CrossReportEditView', () => {
       ])
     })
     it('returns an updated crossReports with agency removed when value is false', () => {
-      expect(component.instance().updatedCrossReports('Department of justice', 'agency_type', false).toJS()).toEqual([
-        {county: '123', agency_type: 'District attorney', agency_code: 'SCDAOFFCODE'},
+      expect(component.instance().updatedCrossReports('DEPARTMENT_OF_JUSTICE', 'agency_type', false).toJS()).toEqual([
+        {county: '123', agency_type: 'DISTRICT_ATTORNEY', agency_code: 'SCDAOFFCODE'},
       ])
     })
     it('returns an updated crossReports with all agencys removed if county is changed', () => {
       expect(component.instance().updatedCrossReports(null, 'county', '1086').toJS()).toEqual([])
     })
     it('returns an updated crossReports when communication_method and value are passed', () => {
-      expect(component.instance().updatedCrossReports('District attorney', 'agency_code', '').toJS()).toEqual([
-        {county: '123', agency_type: 'District attorney', agency_code: null},
-        {county: '123', agency_type: 'Department of justice'},
+      expect(component.instance().updatedCrossReports('DISTRICT_ATTORNEY', 'agency_code', '').toJS()).toEqual([
+        {county: '123', agency_type: 'DISTRICT_ATTORNEY', agency_code: null},
+        {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE'},
       ])
     })
     it('returns an empty crossReports when county is passed', () => {
@@ -162,18 +170,18 @@ describe('CrossReportEditView', () => {
     it('marks labels as required', () => {
       const isAgencyRequiredSpy = jasmine.createSpy('isAgencyRequired').and.returnValue(true)
       component.setProps({isAgencyRequired: isAgencyRequiredSpy})
-      expect(component.find('CheckboxField[value="District attorney"]').props().required)
+      expect(component.find('CheckboxField[value="DISTRICT_ATTORNEY"]').props().required)
         .toBeTruthy()
-      expect(component.find('CheckboxField[value="Law enforcement"]').props().required)
+      expect(component.find('CheckboxField[value="LAW_ENFORCEMENT"]').props().required)
         .toBeTruthy()
     })
 
     it('does not mark labels required when not required', () => {
       const isAgencyRequiredSpy = jasmine.createSpy('isAgencyRequired').and.returnValue(false)
       component.setProps({isAgencyRequired: isAgencyRequiredSpy})
-      expect(component.find('CheckboxField[value="District attorney"]').props().required)
+      expect(component.find('CheckboxField[value="DISTRICT_ATTORNEY"]').props().required)
         .toBeFalsy()
-      expect(component.find('CheckboxField[value="Law enforcement"]').props().required)
+      expect(component.find('CheckboxField[value="LAW_ENFORCEMENT"]').props().required)
         .toBeFalsy()
     })
   })
@@ -190,12 +198,20 @@ describe('CrossReportEditView', () => {
 
   it('renders the checkboxes', () => {
     const checkboxes = component.find('CheckboxField')
-    expect(checkboxes.length).toEqual(4)
+    expect(checkboxes.length).toEqual(5)
     expect(checkboxes.nodes.map((checkbox) => checkbox.props.value)).toEqual([
+      'DISTRICT_ATTORNEY',
+      'LAW_ENFORCEMENT',
+      'DEPARTMENT_OF_JUSTICE',
+      'COUNTY_LICENSING',
+      'COMMUNITY_CARE_LICENSING',
+    ])
+    expect(checkboxes.nodes.map((checkbox) => checkbox.props.label)).toEqual([
       'District attorney',
       'Law enforcement',
       'Department of justice',
-      'Licensing',
+      'County licensing',
+      'Community care licensing',
     ])
   })
 
@@ -208,13 +224,15 @@ describe('CrossReportEditView', () => {
           DEPARTMENT_OF_JUSTICE: [{id: 'Ad213', name: 'CA DOJ'}],
           DISTRICT_ATTORNEY: [{id: 'Ad214', name: 'I do exist'}],
           LAW_ENFORCEMENT: [{id: 'Ad215', name: 'Tony\'s SWAT'}],
-          LICENSING: [{id: 'Ad216', name: 'Licensing palace'}],
+          COUNTY_LICENSING: [{id: 'Ad216', name: 'Licensing palace'}],
+          COMMUNITY_CARE_LICENSING: [{id: 'Ad217', name: 'Licensing care'}],
         },
         crossReports: Immutable.fromJS([
-          {county: '1086', agency_type: 'District attorney', agency_code: '124'},
-          {county: '1086', agency_type: 'Law enforcement', agency_code: '125'},
-          {county: '1086', agency_type: 'Department of justice', agency_code: '126'},
-          {county: '1086', agency_type: 'Licensing', agency_code: '127'},
+          {county: '1086', agency_type: 'DISTRICT_ATTORNEY', agency_code: '124'},
+          {county: '1086', agency_type: 'LAW_ENFORCEMENT', agency_code: '125'},
+          {county: '1086', agency_type: 'DEPARTMENT_OF_JUSTICE', agency_code: '126'},
+          {county: '1086', agency_type: 'COUNTY_LICENSING', agency_code: '127'},
+          {county: '1086', agency_type: 'COMMUNITY_CARE_LICENSING', agency_code: '128'},
         ]),
         errors: Immutable.fromJS({}),
         onBlur: jasmine.createSpy(),
@@ -227,7 +245,7 @@ describe('CrossReportEditView', () => {
     })
     it('enables the checkbox appropriately', () => {
       const checkboxes = component.find('CheckboxField')
-      expect(checkboxes.length).toEqual(4)
+      expect(checkboxes.length).toEqual(5)
       checkboxes.nodes.map((checkbox) => {
         expect(checkbox.props.disabled).toEqual(false)
       })
@@ -245,17 +263,21 @@ describe('CrossReportEditView', () => {
       expect(leSelect.props().children[1][0].key).toEqual('Ad215')
       expect(leSelect.props().children[1][0].props.value).toEqual('Ad215')
       expect(leSelect.props().children[1][0].props.children).toEqual('Tony\'s SWAT')
-      const lSelect = component.find('SelectField[id="LICENSING-agency-code"]')
-      expect(lSelect.props().children[1][0].key).toEqual('Ad216')
-      expect(lSelect.props().children[1][0].props.value).toEqual('Ad216')
-      expect(lSelect.props().children[1][0].props.children).toEqual('Licensing palace')
+      const clSelect = component.find('SelectField[id="COUNTY_LICENSING-agency-code"]')
+      expect(clSelect.props().children[1][0].key).toEqual('Ad216')
+      expect(clSelect.props().children[1][0].props.value).toEqual('Ad216')
+      expect(clSelect.props().children[1][0].props.children).toEqual('Licensing palace')
+      const cclSelect = component.find('SelectField[id="COMMUNITY_CARE_LICENSING-agency-code"]')
+      expect(cclSelect.props().children[1][0].key).toEqual('Ad217')
+      expect(cclSelect.props().children[1][0].props.value).toEqual('Ad217')
+      expect(cclSelect.props().children[1][0].props.children).toEqual('Licensing care')
     })
   })
 
   describe('when no data is returned for county agency look up', () => {
     it('disables the checkbox appropriately', () => {
       const checkboxes = component.find('CheckboxField')
-      expect(checkboxes.length).toEqual(4)
+      expect(checkboxes.length).toEqual(5)
       checkboxes.nodes.map((checkbox) => {
         expect(checkbox.props.disabled).toEqual(true)
       })
@@ -275,8 +297,8 @@ describe('CrossReportEditView', () => {
         counties: [{code: '123', value: 'County Bob'}],
         countyAgencies: {},
         crossReports: Immutable.fromJS([
-          {county: '123', agency_type: 'Department of justice', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
-          {county: '123', agency_type: 'Law enforcement', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+          {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+          {county: '123', agency_type: 'LAW_ENFORCEMENT', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
         ]),
         errors: Immutable.fromJS({communication_method: ['Please select cross-report communication method.']}),
         onBlur: jasmine.createSpy('onBlur'),
@@ -306,8 +328,8 @@ describe('CrossReportEditView', () => {
       reportedOnField.simulate('change', newReportedOn)
       expect(props.onChange).toHaveBeenCalled()
       expect(props.onChange.calls.argsFor(0)[0].toJS()).toEqual([
-        {county: '123', agency_type: 'Department of justice', reported_on: newReportedOn, communication_method: 'Child Abuse Form'},
-        {county: '123', agency_type: 'Law enforcement', reported_on: newReportedOn, communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE', reported_on: newReportedOn, communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'LAW_ENFORCEMENT', reported_on: newReportedOn, communication_method: 'Child Abuse Form'},
       ])
     })
 
@@ -317,28 +339,28 @@ describe('CrossReportEditView', () => {
       communicationMethodField.simulate('change', {target: {value: newCommunicationMethod}})
       expect(props.onChange).toHaveBeenCalled()
       expect(props.onChange.calls.argsFor(0)[0].toJS()).toEqual([
-        {county: '123', agency_type: 'Department of justice', reported_on: '2011-02-13', communication_method: newCommunicationMethod},
-        {county: '123', agency_type: 'Law enforcement', reported_on: '2011-02-13', communication_method: newCommunicationMethod},
+        {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE', reported_on: '2011-02-13', communication_method: newCommunicationMethod},
+        {county: '123', agency_type: 'LAW_ENFORCEMENT', reported_on: '2011-02-13', communication_method: newCommunicationMethod},
       ])
     })
 
     it('adds new cross report agency when a new agency is checked', () => {
-      const checkbox = component.find('CheckboxField[value="District attorney"]')
+      const checkbox = component.find('CheckboxField[value="DISTRICT_ATTORNEY"]')
       checkbox.simulate('change', {target: {checked: true}})
       expect(props.onChange).toHaveBeenCalled()
       expect(props.onChange.calls.argsFor(0)[0].toJS()).toEqual([
-        {county: '123', agency_type: 'Department of justice', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
-        {county: '123', agency_type: 'Law enforcement', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
-        {county: '123', agency_type: 'District attorney', agency_code: null, reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'LAW_ENFORCEMENT', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'DISTRICT_ATTORNEY', agency_code: null, reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
       ])
     })
 
     it('removes cross reports agency when an agency is unchecked', () => {
-      const uncheck = component.find('CheckboxField[value="Department of justice"]')
+      const uncheck = component.find('CheckboxField[value="DEPARTMENT_OF_JUSTICE"]')
       uncheck.simulate('change', {target: {checked: false}})
       expect(props.onChange).toHaveBeenCalled()
       expect(props.onChange.calls.argsFor(0)[0].toJS()).toEqual([
-        {county: '123', agency_type: 'Law enforcement', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'LAW_ENFORCEMENT', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
       ])
     })
 
@@ -347,8 +369,8 @@ describe('CrossReportEditView', () => {
       input.simulate('change', {target: {value: 'DOJCODE'}})
       expect(props.onChange).toHaveBeenCalled()
       expect(props.onChange.calls.argsFor(0)[0].toJS()).toEqual([
-        {county: '123', agency_type: 'Department of justice', agency_code: 'DOJCODE', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
-        {county: '123', agency_type: 'Law enforcement', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE', agency_code: 'DOJCODE', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'LAW_ENFORCEMENT', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
       ])
     })
   })
@@ -362,7 +384,7 @@ describe('CrossReportEditView', () => {
         countyAgencies: {},
         crossReports: Immutable.fromJS([{
           county: 'gotham',
-          agency_type: 'Department of justice',
+          agency_type: 'DEPARTMENT_OF_JUSTICE',
           agency_code: null,
           reported_on: null,
           communication_method: null,
@@ -379,17 +401,17 @@ describe('CrossReportEditView', () => {
     describe('when user selects a communication method, then de-selects agency', () => {
       beforeEach(() => {
         component.find('SelectField[label="Communication Method"]').simulate('change', {target: {value: 'Electronic Report'}})
-        component.find('CheckboxField[value="Department of justice"]')
+        component.find('CheckboxField[value="DEPARTMENT_OF_JUSTICE"]')
           .simulate('change', {target: {checked: false}})
         component.setProps({crossReports: Immutable.fromJS([])})
       })
 
       it('adds agency with cached communication method when user selects an agency', () => {
-        component.find('CheckboxField[value="Law enforcement"]')
+        component.find('CheckboxField[value="LAW_ENFORCEMENT"]')
           .simulate('change', {target: {checked: true}})
         expect(props.onChange.calls.mostRecent().args[0].toJS()).toEqual([{
           county: 'gotham',
-          agency_type: 'Law enforcement',
+          agency_type: 'LAW_ENFORCEMENT',
           agency_code: null,
           reported_on: null,
           communication_method: 'Electronic Report',
@@ -400,17 +422,17 @@ describe('CrossReportEditView', () => {
     describe('when user adds a reported on, then de-selects agency', () => {
       beforeEach(() => {
         component.find('DateField').simulate('change', '2011-05-09')
-        component.find('CheckboxField[value="Department of justice"]')
+        component.find('CheckboxField[value="DEPARTMENT_OF_JUSTICE"]')
           .simulate('change', {target: {checked: false}})
         component.setProps({crossReports: Immutable.fromJS([])})
       })
 
       it('adds agency with cached reported on when user selects an agency', () => {
-        component.find('CheckboxField[value="Law enforcement"]')
+        component.find('CheckboxField[value="LAW_ENFORCEMENT"]')
           .simulate('change', {target: {checked: true}})
         expect(props.onChange.calls.mostRecent().args[0].toJS()).toEqual([{
           county: 'gotham',
-          agency_type: 'Law enforcement',
+          agency_type: 'LAW_ENFORCEMENT',
           agency_code: null,
           reported_on: '2011-05-09',
           communication_method: null,
@@ -422,17 +444,17 @@ describe('CrossReportEditView', () => {
       beforeEach(() => {
         component.find('SelectField[label="Communication Method"]').simulate('change', {target: {value: 'Electronic Report'}})
         component.find('DateField').simulate('change', '2011-05-09')
-        component.find('CheckboxField[value="Department of justice"]')
+        component.find('CheckboxField[value="DEPARTMENT_OF_JUSTICE"]')
           .simulate('change', {target: {checked: false}})
         component.setProps({crossReports: Immutable.fromJS([])})
       })
 
       it('adds agency with cached communication method and reported on when user selects an agency', () => {
-        component.find('CheckboxField[value="Law enforcement"]')
+        component.find('CheckboxField[value="LAW_ENFORCEMENT"]')
           .simulate('change', {target: {checked: true}})
         expect(props.onChange.calls.mostRecent().args[0].toJS()).toEqual([{
           county: 'gotham',
-          agency_type: 'Law enforcement',
+          agency_type: 'LAW_ENFORCEMENT',
           agency_code: null,
           reported_on: '2011-05-09',
           communication_method: 'Electronic Report',
@@ -479,23 +501,24 @@ describe('CrossReportEditView', () => {
         counties: [{code: '123', value: 'County Bob'}],
         countyAgencies: {},
         crossReports: Immutable.fromJS([
-          {county: 'smallville', agency_type: 'District attorney'},
-          {county: 'smallville', agency_type: 'Law enforcement'},
-          {county: 'smallville', agency_type: 'Department of justice'},
-          {county: 'smallville', agency_type: 'Licensing'},
+          {county: '123', agency_type: 'DISTRICT_ATTORNEY'},
+          {county: '123', agency_type: 'LAW_ENFORCEMENT'},
+          {county: '123', agency_type: 'DEPARTMENT_OF_JUSTICE'},
+          {county: '123', agency_type: 'COUNTY_LICENSING'},
+          {county: '123', agency_type: 'COMMUNITY_CARE_LICENSING'},
         ]),
         errors: Immutable.fromJS({}),
         onBlur: jasmine.createSpy(),
-        onChange: () => null,
-        onSave: () => null,
-        onCancel: () => null,
+        onChange: jasmine.createSpy(),
+        onSave: jasmine.createSpy(),
+        onCancel: jasmine.createSpy(),
       }
       component = shallow(<CrossReportEditView {...props}/>)
     })
 
     it('renders DA agency field', () => {
-      const DAField = component.find('SelectField[id="DISTRICT_ATTORNEY-agency-code"]')
-      expect(DAField.props().value).toEqual('')
+      const daField = component.find('SelectField[id="DISTRICT_ATTORNEY-agency-code"]')
+      expect(daField.props().value).toEqual('')
     })
 
     it('renders law enforcement agency field', () => {
@@ -508,15 +531,20 @@ describe('CrossReportEditView', () => {
       expect(dojField.props().value).toEqual('')
     })
 
-    it('renders Licensing agency field', () => {
-      const licensingAgencyField = component.find('SelectField[id="LICENSING-agency-code"]')
+    it('renders County Licensing agency field', () => {
+      const licensingAgencyField = component.find('SelectField[id="COUNTY_LICENSING-agency-code"]')
+      expect(licensingAgencyField.props().value).toEqual('')
+    })
+
+    it('renders Community Care Licensing agency field', () => {
+      const licensingAgencyField = component.find('SelectField[id="COMMUNITY_CARE_LICENSING-agency-code"]')
       expect(licensingAgencyField.props().value).toEqual('')
     })
   })
 
   it('preselect cross report details passed to props', () => {
-    expect(component.find('CheckboxField[value="District attorney"]').props().checked).toEqual(true)
-    expect(component.find('CheckboxField[value="Department of justice"]').props().checked).toEqual(true)
+    expect(component.find('CheckboxField[value="DISTRICT_ATTORNEY"]').props().checked).toEqual(true)
+    expect(component.find('CheckboxField[value="DEPARTMENT_OF_JUSTICE"]').props().checked).toEqual(true)
     expect(component.find('SelectField').length).toEqual(3)
     expect(component.find('SelectField[id="DISTRICT_ATTORNEY-agency-code"]').props().value).toEqual('SCDAOFFCODE')
     expect(component.find('SelectField[id="DEPARTMENT_OF_JUSTICE-agency-code"]').props().value).toEqual('')

--- a/spec/javascripts/components/screenings/crossReports/CrossReportEditViewSpec.jsx
+++ b/spec/javascripts/components/screenings/crossReports/CrossReportEditViewSpec.jsx
@@ -13,7 +13,7 @@ describe('CrossReportEditView', () => {
       counties: [{code: '123', value: 'County Bob'}],
       countyAgencies: {DISTRICT_ATTORNEY: []},
       crossReports: Immutable.fromJS([
-        {county: '123', agency_type: 'District attorney', agency_name: 'SCDA Office'},
+        {county: '123', agency_type: 'District attorney', agency_code: 'SCDAOFFCODE'},
         {county: '123', agency_type: 'Department of justice'},
       ]),
       errors: Immutable.fromJS({}),
@@ -120,20 +120,20 @@ describe('CrossReportEditView', () => {
   })
 
   describe('updatedCrossReports', () => {
-    it('returns an updated crossReports when agency_name and value are passed', () => {
+    it('returns an updated crossReports when agency_code and value are passed', () => {
       expect(component.instance().updatedCrossReports(null, 'communication_method', 'Email').toJS()).toEqual([
-        {county: '123', agency_type: 'District attorney', agency_name: 'SCDA Office', communication_method: 'Email'},
+        {county: '123', agency_type: 'District attorney', agency_code: 'SCDAOFFCODE', communication_method: 'Email'},
         {county: '123', agency_type: 'Department of justice', communication_method: 'Email'},
       ])
     })
     it('returns an updated crossReports with agency added when value is true', () => {
       expect(component.instance().updatedCrossReports('Law enforcement', 'agency_type', true).toJS()).toEqual([
-        {county: '123', agency_type: 'District attorney', agency_name: 'SCDA Office'},
+        {county: '123', agency_type: 'District attorney', agency_code: 'SCDAOFFCODE'},
         {county: '123', agency_type: 'Department of justice'},
         {
           county: '123',
           agency_type: 'Law enforcement',
-          agency_name: null,
+          agency_code: null,
           reported_on: undefined,
           communication_method: undefined,
         },
@@ -141,15 +141,15 @@ describe('CrossReportEditView', () => {
     })
     it('returns an updated crossReports with agency removed when value is false', () => {
       expect(component.instance().updatedCrossReports('Department of justice', 'agency_type', false).toJS()).toEqual([
-        {county: '123', agency_type: 'District attorney', agency_name: 'SCDA Office'},
+        {county: '123', agency_type: 'District attorney', agency_code: 'SCDAOFFCODE'},
       ])
     })
     it('returns an updated crossReports with all agencys removed if county is changed', () => {
       expect(component.instance().updatedCrossReports(null, 'county', '1086').toJS()).toEqual([])
     })
     it('returns an updated crossReports when communication_method and value are passed', () => {
-      expect(component.instance().updatedCrossReports('District attorney', 'agency_name', '').toJS()).toEqual([
-        {county: '123', agency_type: 'District attorney', agency_name: null},
+      expect(component.instance().updatedCrossReports('District attorney', 'agency_code', '').toJS()).toEqual([
+        {county: '123', agency_type: 'District attorney', agency_code: null},
         {county: '123', agency_type: 'Department of justice'},
       ])
     })
@@ -211,10 +211,10 @@ describe('CrossReportEditView', () => {
           LICENSING: [{id: 'Ad216', name: 'Licensing palace'}],
         },
         crossReports: Immutable.fromJS([
-          {county: '1086', agency_type: 'District attorney', agency_name: '124'},
-          {county: '1086', agency_type: 'Law enforcement', agency_name: '125'},
-          {county: '1086', agency_type: 'Department of justice', agency_name: '126'},
-          {county: '1086', agency_type: 'Licensing', agency_name: '127'},
+          {county: '1086', agency_type: 'District attorney', agency_code: '124'},
+          {county: '1086', agency_type: 'Law enforcement', agency_code: '125'},
+          {county: '1086', agency_type: 'Department of justice', agency_code: '126'},
+          {county: '1086', agency_type: 'Licensing', agency_code: '127'},
         ]),
         errors: Immutable.fromJS({}),
         onBlur: jasmine.createSpy(),
@@ -233,19 +233,19 @@ describe('CrossReportEditView', () => {
       })
     })
     it('passes the agencies to the checkbox appropriately', () => {
-      const daSelect = component.find('SelectField[id="DISTRICT_ATTORNEY-agency-name"]')
+      const daSelect = component.find('SelectField[id="DISTRICT_ATTORNEY-agency-code"]')
       expect(daSelect.props().children[1][0].key).toEqual('Ad214')
       expect(daSelect.props().children[1][0].props.value).toEqual('Ad214')
       expect(daSelect.props().children[1][0].props.children).toEqual('I do exist')
-      const dojSelect = component.find('SelectField[id="DEPARTMENT_OF_JUSTICE-agency-name"]')
+      const dojSelect = component.find('SelectField[id="DEPARTMENT_OF_JUSTICE-agency-code"]')
       expect(dojSelect.props().children[1][0].key).toEqual('Ad213')
       expect(dojSelect.props().children[1][0].props.value).toEqual('Ad213')
       expect(dojSelect.props().children[1][0].props.children).toEqual('CA DOJ')
-      const leSelect = component.find('SelectField[id="LAW_ENFORCEMENT-agency-name"]')
+      const leSelect = component.find('SelectField[id="LAW_ENFORCEMENT-agency-code"]')
       expect(leSelect.props().children[1][0].key).toEqual('Ad215')
       expect(leSelect.props().children[1][0].props.value).toEqual('Ad215')
       expect(leSelect.props().children[1][0].props.children).toEqual('Tony\'s SWAT')
-      const lSelect = component.find('SelectField[id="LICENSING-agency-name"]')
+      const lSelect = component.find('SelectField[id="LICENSING-agency-code"]')
       expect(lSelect.props().children[1][0].key).toEqual('Ad216')
       expect(lSelect.props().children[1][0].props.value).toEqual('Ad216')
       expect(lSelect.props().children[1][0].props.children).toEqual('Licensing palace')
@@ -329,7 +329,7 @@ describe('CrossReportEditView', () => {
       expect(props.onChange.calls.argsFor(0)[0].toJS()).toEqual([
         {county: '123', agency_type: 'Department of justice', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
         {county: '123', agency_type: 'Law enforcement', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
-        {county: '123', agency_type: 'District attorney', agency_name: null, reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'District attorney', agency_code: null, reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
       ])
     })
 
@@ -344,10 +344,10 @@ describe('CrossReportEditView', () => {
 
     it('changes existing cross reports agency name when agency name is changed', () => {
       const input = component.find('SelectField[label="Department of justice agency name"]')
-      input.simulate('change', {target: {value: 'DoJ Office'}})
+      input.simulate('change', {target: {value: 'DOJCODE'}})
       expect(props.onChange).toHaveBeenCalled()
       expect(props.onChange.calls.argsFor(0)[0].toJS()).toEqual([
-        {county: '123', agency_type: 'Department of justice', agency_name: 'DoJ Office', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
+        {county: '123', agency_type: 'Department of justice', agency_code: 'DOJCODE', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
         {county: '123', agency_type: 'Law enforcement', reported_on: '2011-02-13', communication_method: 'Child Abuse Form'},
       ])
     })
@@ -363,7 +363,7 @@ describe('CrossReportEditView', () => {
         crossReports: Immutable.fromJS([{
           county: 'gotham',
           agency_type: 'Department of justice',
-          agency_name: null,
+          agency_code: null,
           reported_on: null,
           communication_method: null,
         }]),
@@ -390,7 +390,7 @@ describe('CrossReportEditView', () => {
         expect(props.onChange.calls.mostRecent().args[0].toJS()).toEqual([{
           county: 'gotham',
           agency_type: 'Law enforcement',
-          agency_name: null,
+          agency_code: null,
           reported_on: null,
           communication_method: 'Electronic Report',
         }])
@@ -411,7 +411,7 @@ describe('CrossReportEditView', () => {
         expect(props.onChange.calls.mostRecent().args[0].toJS()).toEqual([{
           county: 'gotham',
           agency_type: 'Law enforcement',
-          agency_name: null,
+          agency_code: null,
           reported_on: '2011-05-09',
           communication_method: null,
         }])
@@ -433,7 +433,7 @@ describe('CrossReportEditView', () => {
         expect(props.onChange.calls.mostRecent().args[0].toJS()).toEqual([{
           county: 'gotham',
           agency_type: 'Law enforcement',
-          agency_name: null,
+          agency_code: null,
           reported_on: '2011-05-09',
           communication_method: 'Electronic Report',
         }])
@@ -494,22 +494,22 @@ describe('CrossReportEditView', () => {
     })
 
     it('renders DA agency field', () => {
-      const DAField = component.find('SelectField[id="DISTRICT_ATTORNEY-agency-name"]')
+      const DAField = component.find('SelectField[id="DISTRICT_ATTORNEY-agency-code"]')
       expect(DAField.props().value).toEqual('')
     })
 
     it('renders law enforcement agency field', () => {
-      const lawEnforcementAgencyField = component.find('SelectField[id="LAW_ENFORCEMENT-agency-name"]')
+      const lawEnforcementAgencyField = component.find('SelectField[id="LAW_ENFORCEMENT-agency-code"]')
       expect(lawEnforcementAgencyField.props().value).toEqual('')
     })
 
     it('renders DoJ agency field', () => {
-      const dojField = component.find('SelectField[id="DEPARTMENT_OF_JUSTICE-agency-name"]')
+      const dojField = component.find('SelectField[id="DEPARTMENT_OF_JUSTICE-agency-code"]')
       expect(dojField.props().value).toEqual('')
     })
 
     it('renders Licensing agency field', () => {
-      const licensingAgencyField = component.find('SelectField[id="LICENSING-agency-name"]')
+      const licensingAgencyField = component.find('SelectField[id="LICENSING-agency-code"]')
       expect(licensingAgencyField.props().value).toEqual('')
     })
   })
@@ -518,8 +518,8 @@ describe('CrossReportEditView', () => {
     expect(component.find('CheckboxField[value="District attorney"]').props().checked).toEqual(true)
     expect(component.find('CheckboxField[value="Department of justice"]').props().checked).toEqual(true)
     expect(component.find('SelectField').length).toEqual(3)
-    expect(component.find('SelectField[id="DISTRICT_ATTORNEY-agency-name"]').props().value).toEqual('SCDA Office')
-    expect(component.find('SelectField[id="DEPARTMENT_OF_JUSTICE-agency-name"]').props().value).toEqual('')
+    expect(component.find('SelectField[id="DISTRICT_ATTORNEY-agency-code"]').props().value).toEqual('SCDAOFFCODE')
+    expect(component.find('SelectField[id="DEPARTMENT_OF_JUSTICE-agency-code"]').props().value).toEqual('')
   })
 
   it('calls onSave', () => {

--- a/spec/javascripts/components/screenings/crossReports/CrossReportShowViewSpec.jsx
+++ b/spec/javascripts/components/screenings/crossReports/CrossReportShowViewSpec.jsx
@@ -10,8 +10,8 @@ describe('CrossReportShowView', () => {
   beforeEach(() => {
     onEdit = jasmine.createSpy()
     const props = {
+      agencyCodeToName: {code123: 'Name of Agency'},
       crossReports: Immutable.List(),
-      countyAgencies: {},
       onEdit: onEdit,
       errors: Immutable.Map(),
     }
@@ -33,20 +33,19 @@ describe('CrossReportShowView', () => {
   describe('when cross reports are present', () => {
     let component
     beforeEach(() => {
-      const crossReports = Immutable.List([
-        {county: '123', agency_type: 'District attorney', agency_code: 'AGENCYCODE', reported_on: '2017-01-15'},
-        {county: '123', agency_type: 'Licensing'},
-      ])
-      const errors = Immutable.fromJS({
-        Licensing: {agency_code: ['Error 1'], communication_method: ['Error 2']},
-        'District of attorney': {reported_on: ['Error 3']},
-      })
-      const countyAgencies = {
-        DISTRICT_ATTORNEY: [
-          {id: 'AGENCYCODE', name: 'SCDA'},
-        ],
+      const props = {
+        crossReports: Immutable.List([
+          {county: '123', agency_type: 'District attorney', agency_code: 'AGENCYCODE', reported_on: '2017-01-15'},
+          {county: '123', agency_type: 'Licensing'},
+        ]),
+        errors: Immutable.fromJS({
+          Licensing: {agency_code: ['Error 1'], communication_method: ['Error 2']},
+          'District attorney': {reported_on: ['Error 3']},
+        }),
+        agencyCodeToName: {AGENCYCODE: 'District attorney - SCDA'},
+        onEdit: onEdit,
       }
-      component = shallow(<CrossReportShowView countyAgencies={countyAgencies} crossReports={crossReports} errors={errors} onEdit={onEdit} />)
+      component = shallow(<CrossReportShowView {...props} />)
     })
 
     it('renders the cross report agencies', () => {

--- a/spec/javascripts/components/screenings/crossReports/CrossReportShowViewSpec.jsx
+++ b/spec/javascripts/components/screenings/crossReports/CrossReportShowViewSpec.jsx
@@ -35,12 +35,12 @@ describe('CrossReportShowView', () => {
     beforeEach(() => {
       const props = {
         crossReports: Immutable.List([
-          {county: '123', agency_type: 'District attorney', agency_code: 'AGENCYCODE', reported_on: '2017-01-15'},
-          {county: '123', agency_type: 'Licensing'},
+          {county: '123', agency_type: 'DISTRICT_ATTORNEY', agency_code: 'AGENCYCODE', reported_on: '2017-01-15'},
+          {county: '123', agency_type: 'COUNTY_LICENSING'},
         ]),
         errors: Immutable.fromJS({
-          Licensing: {agency_code: ['Error 1'], communication_method: ['Error 2']},
-          'District attorney': {reported_on: ['Error 3']},
+          COUNTY_LICENSING: {agency_code: ['Error 1'], communication_method: ['Error 2']},
+          DISTRICT_ATTORNEY: {reported_on: ['Error 3']},
         }),
         agencyCodeToName: {AGENCYCODE: 'District attorney - SCDA'},
         onEdit: onEdit,
@@ -51,7 +51,7 @@ describe('CrossReportShowView', () => {
     it('renders the cross report agencies', () => {
       expect(component.find('ShowField[label="This report has cross reported to:"]').length).toEqual(1)
       expect(component.html()).toContain('District attorney - SCDA')
-      expect(component.html()).toContain('Licensing')
+      expect(component.html()).toContain('County licensing')
     })
 
     it('renders the reported on field as required', () => {
@@ -65,7 +65,7 @@ describe('CrossReportShowView', () => {
       expect(field.props().required).toEqual(true)
     })
 
-    it('renders errors for Licensing.agency_code', () => {
+    it('renders errors for county licensing.agency_code', () => {
       expect(component.find('ShowField[label="This report has cross reported to:"]').html())
         .toContain('Error 1')
     })
@@ -84,7 +84,7 @@ describe('CrossReportShowView', () => {
   describe('when cross reports are not present', () => {
     it("doesn't render the cross report agencies", () => {
       expect(component.html()).not.toContain('District of attorney')
-      expect(component.html()).not.toContain('Licensing')
+      expect(component.html()).not.toContain('County licensing')
     })
 
     it("doesn't render the reported on field", () => {

--- a/spec/javascripts/components/screenings/crossReports/CrossReportShowViewSpec.jsx
+++ b/spec/javascripts/components/screenings/crossReports/CrossReportShowViewSpec.jsx
@@ -34,11 +34,11 @@ describe('CrossReportShowView', () => {
     let component
     beforeEach(() => {
       const crossReports = Immutable.List([
-        {county: '123', agency_type: 'District attorney', agency_name: 'AGENCYCODE', reported_on: '2017-01-15'},
+        {county: '123', agency_type: 'District attorney', agency_code: 'AGENCYCODE', reported_on: '2017-01-15'},
         {county: '123', agency_type: 'Licensing'},
       ])
       const errors = Immutable.fromJS({
-        Licensing: {agency_name: ['Error 1'], communication_method: ['Error 2']},
+        Licensing: {agency_code: ['Error 1'], communication_method: ['Error 2']},
         'District of attorney': {reported_on: ['Error 3']},
       })
       const countyAgencies = {
@@ -66,7 +66,7 @@ describe('CrossReportShowView', () => {
       expect(field.props().required).toEqual(true)
     })
 
-    it('renders errors for Licensing.agency_name', () => {
+    it('renders errors for Licensing.agency_code', () => {
       expect(component.find('ShowField[label="This report has cross reported to:"]').html())
         .toContain('Error 1')
     })

--- a/spec/javascripts/selectors/countyAgenciesSelectorsSpec.js
+++ b/spec/javascripts/selectors/countyAgenciesSelectorsSpec.js
@@ -4,31 +4,31 @@ import {fromJS} from 'immutable'
 describe('getAgencyCodeToName', () => {
   it('returns nothing when no agnecy_code', () => {
     const countyAgencies = [{id: 'A324ad', name: 'County Agency'}]
-    const crossReports = [{agency_type: 'District attorney'}]
+    const crossReports = [{agency_type: 'DISTRICT_ATTORNEY'}]
     const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
     expect(getAgencyCodeToName(state)).toEqual({})
   })
   it('returns the name and type when all data present', () => {
     const countyAgencies = [{id: 'A324ad', name: 'County Agency'}]
-    const crossReports = [{agency_type: 'District attorney', agency_code: 'A324ad'}]
+    const crossReports = [{agency_type: 'DISTRICT_ATTORNEY', agency_code: 'A324ad'}]
     const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
     expect(getAgencyCodeToName(state)).toEqual({A324ad: 'District attorney - County Agency'})
   })
   it('returns agency type and id when county agency does not have a name', () => {
     const countyAgencies = [{id: 'A324ad'}]
-    const crossReports = [{agency_type: 'District attorney', agency_code: 'A324ad'}]
+    const crossReports = [{agency_type: 'COUNTY_LICENSING', agency_code: 'A324ad'}]
     const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
-    expect(getAgencyCodeToName(state)).toEqual({A324ad: 'District attorney - A324ad'})
+    expect(getAgencyCodeToName(state)).toEqual({A324ad: 'County licensing - A324ad'})
   })
   it('returns agency type and id when county agnecies empty', () => {
     const countyAgencies = [{id: 'B525ad', name: 'Other Agency'}]
-    const crossReports = [{agency_type: 'District attorney', agency_code: 'A324ad'}]
+    const crossReports = [{agency_type: 'LAW_ENFORCEMENT', agency_code: 'A324ad'}]
     const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
-    expect(getAgencyCodeToName(state)).toEqual({A324ad: 'District attorney - A324ad'})
+    expect(getAgencyCodeToName(state)).toEqual({A324ad: 'Law enforcement - A324ad'})
   })
   it('returns only types when no county agencies', () => {
     const countyAgencies = []
-    const crossReports = [{agency_type: 'District attorney', agency_code: 'A324ad'}]
+    const crossReports = [{agency_type: 'DISTRICT_ATTORNEY', agency_code: 'A324ad'}]
     const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
     expect(getAgencyCodeToName(state)).toEqual({A324ad: 'District attorney - A324ad'})
   })

--- a/spec/javascripts/selectors/countyAgenciesSelectorsSpec.js
+++ b/spec/javascripts/selectors/countyAgenciesSelectorsSpec.js
@@ -1,0 +1,49 @@
+import {getAgencyCodeToName} from 'selectors/countyAgenciesSelectors'
+import {fromJS} from 'immutable'
+
+describe('getAgencyCodeToName', () => {
+  it('returns nothing when no agnecy_code', () => {
+    const countyAgencies = [{id: 'A324ad', name: 'County Agency'}]
+    const crossReports = [{agency_type: 'District attorney'}]
+    const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
+    expect(getAgencyCodeToName(state)).toEqual({})
+  })
+  it('returns the name and type when all data present', () => {
+    const countyAgencies = [{id: 'A324ad', name: 'County Agency'}]
+    const crossReports = [{agency_type: 'District attorney', agency_code: 'A324ad'}]
+    const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
+    expect(getAgencyCodeToName(state)).toEqual({A324ad: 'District attorney - County Agency'})
+  })
+  it('returns agency type and id when county agency does not have a name', () => {
+    const countyAgencies = [{id: 'A324ad'}]
+    const crossReports = [{agency_type: 'District attorney', agency_code: 'A324ad'}]
+    const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
+    expect(getAgencyCodeToName(state)).toEqual({A324ad: 'District attorney - A324ad'})
+  })
+  it('returns agency type and id when county agnecies empty', () => {
+    const countyAgencies = [{id: 'B525ad', name: 'Other Agency'}]
+    const crossReports = [{agency_type: 'District attorney', agency_code: 'A324ad'}]
+    const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
+    expect(getAgencyCodeToName(state)).toEqual({A324ad: 'District attorney - A324ad'})
+  })
+  it('returns only types when no county agencies', () => {
+    const countyAgencies = []
+    const crossReports = [{agency_type: 'District attorney', agency_code: 'A324ad'}]
+    const state = fromJS({countyAgencies, screening: {cross_reports: crossReports}})
+    expect(getAgencyCodeToName(state)).toEqual({A324ad: 'District attorney - A324ad'})
+  })
+  it('returns empty map when cross reports is undefined', () => {
+    const countyAgencies = [{id: 'A324ad', name: 'County Agency'}]
+    const state = fromJS({countyAgencies, screening: {}})
+    expect(getAgencyCodeToName(state)).toEqual({})
+  })
+  it('returns empty map when cross reports are empty', () => {
+    const countyAgencies = [{id: 'A324ad', name: 'County Agency'}]
+    const state = fromJS({countyAgencies, screening: {cross_reports: []}})
+    expect(getAgencyCodeToName(state)).toEqual({})
+  })
+  it('returns empty map when cross reports and county agencies are empty', () => {
+    const state = fromJS({countyAgencies: [], screening: {cross_reports: []}})
+    expect(getAgencyCodeToName(state)).toEqual({})
+  })
+})

--- a/spec/models/screening_spec.rb
+++ b/spec/models/screening_spec.rb
@@ -64,11 +64,11 @@ describe Screening do
         cross_reports: [
           {
             agency_type: 'District attorney',
-            agency_name: 'SCDA Office'
+            agency_code: 'SCDAOFFCODE'
           },
           {
             agency_type: 'Law enforcement',
-            agency_name: nil
+            agency_code: nil
           }
         ],
         allegations: [
@@ -129,11 +129,11 @@ describe Screening do
         cross_reports: array_including(
           a_hash_including(
             agency_type: 'District attorney',
-            agency_name: 'SCDA Office'
+            agency_code: 'SCDAOFFCODE'
           ),
           a_hash_including(
             agency_type: 'Law enforcement',
-            agency_name: nil
+            agency_code: nil
           )
         ),
         address: a_hash_including(


### PR DESCRIPTION
### Pivotal Story

- [Name of Story 152011067](https://www.pivotaltracker.com/story/show/152011067)

### Purpose
As a screener, I want to be able to save 2 separate agencies for community care licensing & county licensing that I need to cross report to from NS to Legacy.

### Background
In working on cross reports it was discovered that there were 5 agency types in legacy not just 4. To maintain being able to select all 5 we split the licensing type into the respective two types county licensing, and community care licensing.

### Questions for Reviewer


### Notes for Reviewer


### Testing Notes
Can be tested in preint.

