### PR TITLE
Add plugin to guard against using wrong case

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -3,6 +3,7 @@
 const merge = require('webpack-merge')
 const sharedConfig = require('./shared.js')
 const { settings, output } = require('./configuration.js')
+const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
 
 module.exports = merge(sharedConfig, {
   devtool: 'source-map',
@@ -14,6 +15,10 @@ module.exports = merge(sharedConfig, {
   output: {
     pathinfo: true
   },
+
+  plugins: [
+    new CaseSensitivePathsPlugin()
+  ],
 
   devServer: {
     clientLogLevel: 'none',

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "babelify": "^7.3.0",
     "bootstrap-accessibility-plugin": "^1.0.2",
     "browserify": "^14.4.0",
+    "case-sensitive-paths-webpack-plugin": "^2.1.1",
     "cors": "^2.8.4",
     "enzyme": "2.9.1",
     "eslint": "4.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1415,6 +1415,10 @@ caniuse-lite@^1.0.30000697, caniuse-lite@^1.0.30000715:
   version "1.0.30000717"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30000717.tgz#4539b126af787c1d4851944de22b2bd8780d3612"
 
+case-sensitive-paths-webpack-plugin@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.1.1.tgz#3d29ced8c1f124bf6f53846fb3f5894731fdc909"
+
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"


### PR DESCRIPTION
### Pivotal Story

- None

### Purpose
- OSX doesn't care which file case you use
- Other 'nix systems do (like CI)
- This means that sometimes our tests will pass locally but fail on CI
- Add a plugin to our dev webpack config to help guard against this

### Background
This appears to be a well-maintained plugin, and my local test proves that it's working. Might as well give it a shot.

### Questions for Reviewer


### Notes for Reviewer


### Testing Notes

