### PR TITLE
Update to use new key name from API stub for

### DIFF
--- a/app/javascript/selectors/screeningSummarySelectors.js
+++ b/app/javascript/selectors/screeningSummarySelectors.js
@@ -4,7 +4,7 @@ import {getInvestigationSelector} from 'selectors/investigationSelectors'
 
 export const getScreeningSummarySelector = createSelector(
   getInvestigationSelector,
-  (investigation) => investigation.get('screening') || Map()
+  (investigation) => investigation.get('screening_summary') || Map()
 )
 export const getAllegationTypesSelector = createSelector(
   getScreeningSummarySelector,

--- a/spec/features/investigations/show_investigation_spec.rb
+++ b/spec/features/investigations/show_investigation_spec.rb
@@ -37,7 +37,7 @@ feature 'Show Investigation' do
       }
       stub_request(
         :get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
-      ).and_return(json_body({ screening: screening_summary }.to_json, status: 200))
+      ).and_return(json_body({ screening_summary: screening_summary }.to_json, status: 200))
       visit investigation_path(id: investigation_id)
       within '.card.show', text: 'Screening Summary' do
         within '.card-body' do

--- a/spec/javascripts/selectors/screeningSummarySelectorsSpec.js
+++ b/spec/javascripts/selectors/screeningSummarySelectorsSpec.js
@@ -7,22 +7,22 @@ import * as matchers from 'jasmine-immutable-matchers'
 describe('getAllegationTypesSelector', () => {
   beforeEach(() => jasmine.addMatchers(matchers))
   it('returns the unique set of allegation types on a screening summary', () => {
-    const screening = {
+    const screening_summary = {
       allegations: [
         {allegation_types: ['physical abuse', 'sexual abuse']},
         {allegation_types: ['sexual abuse', 'neglect']},
         {allegation_types: ['physical abuse']},
       ],
     }
-    const state = fromJS({investigation: {screening}})
+    const state = fromJS({investigation: {screening_summary}})
     expect(getAllegationTypesSelector(state)).toEqualImmutable(Set([
       'physical abuse', 'sexual abuse', 'neglect',
     ]))
   })
 
   it('returns empty immutable list when allegations are undefined', () => {
-    const screening = {allegations: undefined}
-    const state = fromJS({investigation: {screening}})
+    const screening_summary = {allegations: undefined}
+    const state = fromJS({investigation: {screening_summary}})
     expect(getAllegationTypesSelector(state)).toEqualImmutable(Set())
   })
 })


### PR DESCRIPTION
### Pivotal Story

- None

### Purpose
We decided `screening_summary` was a better field name than `screening` for the API. Change front-end code to match.

### Background


### Questions for Reviewer


### Notes for Reviewer


### Testing Notes

