### PR TITLE
Use Sagas to Fetch Relationships on the Screening Page

### DIFF
--- a/app/javascript/sagas/createParticipantSaga.js
+++ b/app/javascript/sagas/createParticipantSaga.js
@@ -1,15 +1,19 @@
-import {takeEvery, put, call} from 'redux-saga/effects'
+import {takeEvery, put, call, select} from 'redux-saga/effects'
 import {post} from 'utils/http'
 import {
   createParticipantSuccess,
   createParticipantFailure,
+  fetchRelationships,
 } from 'actions/screeningActions'
+import {getScreeningIdValueSelector} from 'selectors/screeningSelectors'
 import {CREATE_PARTICIPANT} from 'actions/actionTypes'
 
 export function* createParticipant({participant}) {
   try {
     const response = yield call(post, '/api/v1/participants', participant)
     yield put(createParticipantSuccess(response))
+    const screeningId = yield select(getScreeningIdValueSelector)
+    yield put(fetchRelationships(screeningId))
   } catch (error) {
     yield put(createParticipantFailure(error.responseJSON))
   }

--- a/app/javascript/sagas/deleteParticipantSaga.js
+++ b/app/javascript/sagas/deleteParticipantSaga.js
@@ -4,6 +4,7 @@ import {
   deleteParticipantSuccess,
   deleteParticipantFailure,
   fetchScreening,
+  fetchRelationships,
 } from 'actions/screeningActions'
 import {getScreeningIdValueSelector} from 'selectors/screeningSelectors'
 import {DELETE_PARTICIPANT} from 'actions/actionTypes'
@@ -14,6 +15,7 @@ export function* deleteParticipant({id}) {
     yield put(deleteParticipantSuccess(id))
     const screeningId = yield select(getScreeningIdValueSelector)
     yield put(fetchScreening(screeningId))
+    yield put(fetchRelationships(screeningId))
   } catch (error) {
     yield put(deleteParticipantFailure(error.responseJSON))
   }

--- a/app/javascript/screenings/RelationshipsCard.jsx
+++ b/app/javascript/screenings/RelationshipsCard.jsx
@@ -3,20 +3,6 @@ import React from 'react'
 import nameFormatter from 'utils/nameFormatter'
 
 export default class RelationshipsCard extends React.Component {
-  componentDidMount() {
-    const {actions, participants, screeningId} = this.props
-    if (!participants.isEmpty()) {
-      actions.fetchRelationships(screeningId)
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const {participants, actions, screeningId} = this.props
-    if (participants !== nextProps.participants) {
-      actions.fetchRelationships(screeningId)
-    }
-  }
-
   renderParticipantRelationships(participant) {
     const relationships = participant.get('relationships')
 
@@ -102,8 +88,6 @@ export default class RelationshipsCard extends React.Component {
 }
 
 RelationshipsCard.propTypes = {
-  actions: PropTypes.object.isRequired,
   participants: PropTypes.object.isRequired,
   relationships: PropTypes.object.isRequired,
-  screeningId: PropTypes.string.isRequired,
 }

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -54,6 +54,7 @@ export class ScreeningPage extends React.Component {
 
   componentDidMount() {
     this.props.actions.fetchScreening(this.props.params.id)
+    this.props.actions.fetchRelationships(this.props.params.id)
     this.props.actions.checkStaffPermission('add_sensitive_people')
   }
 
@@ -311,11 +312,9 @@ export class ScreeningPage extends React.Component {
           {
             releaseTwoInactive &&
             <RelationshipsCard
-              actions={this.props.actions}
               editable={editable}
               participants={this.props.participants}
               relationships={this.props.relationships}
-              screeningId={this.props.params.id}
             />
           }
           {

--- a/spec/features/api_response_spec.rb
+++ b/spec/features/api_response_spec.rb
@@ -45,6 +45,7 @@ feature 'api responses' do
   scenario 'API returns a 500 and display an error message' do
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
       .and_return(json_body('I failed', status: 500))
+    stub_empty_relationships_for_screening(screening)
     visit root_path
     expect(page).to have_content 'Something went wrong, sorry! Please try your last action again.'
   end
@@ -52,6 +53,7 @@ feature 'api responses' do
   scenario 'API returns a success' do
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(screening)
     visit screening_path(id: screening.id)
     expect(page.current_url).to have_content screening_path(screening.id)
   end

--- a/spec/features/screening/cross_reports_spec.rb
+++ b/spec/features/screening/cross_reports_spec.rb
@@ -16,6 +16,7 @@ feature 'cross reports' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
 
     reported_on = Date.today
@@ -75,6 +76,7 @@ feature 'cross reports' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
 
     within '#cross-report-card' do
@@ -131,6 +133,7 @@ feature 'cross reports' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit screening_path(id: existing_screening.id)
 
     within '#cross-report-card', text: 'Cross Report' do
@@ -162,6 +165,7 @@ feature 'cross reports' do
       :get,
       intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit screening_path(id: existing_screening.id)
 
     within '#cross-report-card', text: 'Cross Report' do
@@ -176,6 +180,7 @@ feature 'cross reports' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
 
     reported_on = Date.today
@@ -217,6 +222,7 @@ feature 'cross reports' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
 
     reported_on = Date.today
@@ -266,6 +272,7 @@ feature 'cross reports' do
     stub_request(
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
 
     reported_on = Date.today

--- a/spec/features/screening/edit_screening_spec.rb
+++ b/spec/features/screening/edit_screening_spec.rb
@@ -50,6 +50,7 @@ feature 'Edit Screening' do
       stub_request(
         :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
       ).and_return(json_body(existing_screening.to_json, status: 200))
+      stub_empty_relationships_for_screening(existing_screening)
       visit edit_screening_path(id: existing_screening.id)
       expect(page).to have_content 'Edit Screening #My Bad!'
     end
@@ -181,6 +182,7 @@ feature 'Edit Screening' do
       stub_request(
         :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
       ).and_return(json_body(existing_screening.to_json, status: 200))
+      stub_empty_relationships_for_screening(existing_screening)
       visit edit_screening_path(id: existing_screening.id)
 
       within '#snapshot-card' do
@@ -241,6 +243,7 @@ feature 'individual card save' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
     within '#screening-information-card' do
       fill_in 'Title/Name of Screening', with: 'This should not save'
@@ -256,6 +259,7 @@ feature 'individual card save' do
         :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
       ).with(json_body(as_json_without_root_id(updated_screening)))
         .and_return(json_body(updated_screening.to_json))
+      stub_empty_relationships_for_screening(existing_screening)
       fill_in_datepicker 'Incident Date', with: '02/12/1996'
       click_button 'Save'
       expect(
@@ -274,6 +278,7 @@ feature 'individual card save' do
       stub_request(
         :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
       ).with(json_body(updated_screening))
+      stub_empty_relationships_for_screening(existing_screening)
         .and_return(json_body(updated_screening))
       fill_in 'Report Narrative', with: 'This is the updated narrative'
       click_button 'Save'
@@ -300,6 +305,7 @@ feature 'individual card save' do
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).with(json_body(as_json_without_root_id(existing_screening)))
       .and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     within '#cross-report-card' do
       select 'State of California', from: 'County'
@@ -341,6 +347,7 @@ feature 'individual card save' do
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).with(json_body(as_json_without_root_id(existing_screening)))
       .and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     within '#cross-report-card' do
       click_button 'Save'
@@ -360,6 +367,7 @@ feature 'individual card save' do
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).with(json_body(as_json_without_root_id(existing_screening)))
       .and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     within '#worker-safety-card' do
       fill_in_react_select 'Worker safety alerts', with: 'Dangerous Animal on Premises'
@@ -388,6 +396,7 @@ feature 'individual card save' do
         :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
       ).with(json_body(as_json_without_root_id(existing_screening)))
         .and_return(json_body(existing_screening.to_json))
+      stub_empty_relationships_for_screening(existing_screening)
 
       fill_in_datepicker 'Incident Date', with: '02-12-1996'
       fill_in 'Address', with: '33 Whatever Rd'

--- a/spec/features/screening/incident_information_spec.rb
+++ b/spec/features/screening/incident_information_spec.rb
@@ -26,6 +26,7 @@ feature 'screening incident information card' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
   end
 
@@ -37,6 +38,7 @@ feature 'screening incident information card' do
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).with(json_body(as_json_without_root_id(existing_screening)))
       .and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
     within '#incident-information-card.edit' do
       fill_in 'Address', with: '33 Whatever'
       click_button 'Save'
@@ -78,6 +80,7 @@ feature 'screening incident information card' do
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).with(json_body(as_json_without_root_id(existing_screening)))
       .and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     within '#incident-information-card.edit' do
       click_button 'Save'

--- a/spec/features/screening/narrative_spec.rb
+++ b/spec/features/screening/narrative_spec.rb
@@ -13,6 +13,7 @@ feature 'screening narrative card' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     visit screening_path(id: existing_screening.id)
     click_link 'Edit narrative'
@@ -42,6 +43,7 @@ feature 'screening narrative card' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     visit edit_screening_path(id: existing_screening.id)
 
@@ -64,6 +66,7 @@ feature 'screening narrative card' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     visit screening_path(id: existing_screening.id)
     click_link 'Edit narrative'
@@ -78,6 +81,7 @@ feature 'screening narrative card' do
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).with(json_body(as_json_without_root_id(existing_screening)))
       .and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     within '#narrative-card.edit' do
       click_button 'Save'
@@ -88,6 +92,7 @@ feature 'screening narrative card' do
         :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
       ).with(json_body(as_json_without_root_id(existing_screening)))
     ).to have_been_made
+    stub_empty_relationships_for_screening(existing_screening)
 
     within '#narrative-card.show' do
       expect(page).to have_content 'Trying to fill in with changes'
@@ -102,6 +107,7 @@ feature 'screening narrative card' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     visit edit_screening_path(id: existing_screening.id)
 
@@ -115,6 +121,7 @@ feature 'screening narrative card' do
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).with(json_body(as_json_without_root_id(existing_screening)))
       .and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     within '#narrative-card.edit' do
       click_button 'Save'

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -9,6 +9,7 @@ feature 'searching a person' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
     stub_request(
       :get,
@@ -78,6 +79,7 @@ feature 'searching a participant in autocompleter' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
   end
 

--- a/spec/features/screening/relationships_card_spec.rb
+++ b/spec/features/screening/relationships_card_spec.rb
@@ -22,15 +22,6 @@ feature 'Relationship card' do
       within '#relationships-card', text: 'Relationships' do
         expect(page).to have_content('Search for people and add them to see their relationships.')
       end
-
-      expect(
-        a_request(
-          :get,
-          intake_api_url(
-            ExternalRoutes.intake_api_relationships_by_screening_path(existing_screening.id)
-          )
-        )
-      ).to_not have_been_made
     end
 
     scenario 'view an existing screening' do
@@ -48,15 +39,6 @@ feature 'Relationship card' do
       within '#relationships-card', text: 'Relationships' do
         expect(page).to have_content('Search for people and add them to see their relationships.')
       end
-
-      expect(
-        a_request(
-          :get,
-          intake_api_url(
-            ExternalRoutes.intake_api_relationships_by_screening_path(existing_screening.id)
-          )
-        )
-      ).to_not have_been_made
     end
   end
 

--- a/spec/features/screening/screening_information_spec.rb
+++ b/spec/features/screening/screening_information_spec.rb
@@ -21,6 +21,7 @@ feature 'screening information card' do
   before(:each) do
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(screening)
 
     visit edit_screening_path(id: screening.id)
   end
@@ -60,6 +61,7 @@ feature 'screening information card' do
     stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .with(json_body(as_json_without_root_id(screening)))
       .and_return(json_body(screening.to_json))
+    stub_empty_relationships_for_screening(screening)
 
     expect(
       a_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))

--- a/spec/features/screening/show_screening_spec.rb
+++ b/spec/features/screening/show_screening_spec.rb
@@ -49,6 +49,7 @@ feature 'Show Screening' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
 
     visit screening_path(id: existing_screening.id)
 
@@ -127,6 +128,7 @@ feature 'Show Screening' do
       stub_request(
         :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
       ).and_return(json_body(existing_screening.to_json))
+      stub_empty_relationships_for_screening(existing_screening)
       visit screening_path(id: existing_screening.id)
 
       expect(page.status_code).to_not eq 200

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -170,8 +170,6 @@ describe('ScreeningPage', () => {
       expect(component.find('RelationshipsCard').length).toEqual(1)
       expect(component.find('RelationshipsCard').props().participants).toEqual(Immutable.fromJS([]))
       expect(component.find('RelationshipsCard').props().relationships).toEqual(props.relationships)
-      expect(component.find('RelationshipsCard').props().screeningId).toEqual(props.params.id)
-      expect(component.find('RelationshipsCard').props().actions).toEqual(props.actions)
     })
 
     it('renders the worker safety card', () => {
@@ -217,13 +215,14 @@ describe('ScreeningPage', () => {
 
   describe('componentDidMount', () => {
     const fetchScreening = jasmine.createSpy('fetchScreening')
+    const fetchRelationships = jasmine.createSpy('fetchRelationships')
     const checkStaffPermission = jasmine.createSpy('checkStaffPermission')
     const fetchHistoryOfInvolvements = () => Promise.resolve()
     const promiseSpyObj = jasmine.createSpyObj('promiseSpyObj', ['then'])
     beforeEach(() => {
       const props = {
         ...requiredProps,
-        actions: {fetchScreening, fetchHistoryOfInvolvements, checkStaffPermission},
+        actions: {fetchScreening, fetchRelationships, fetchHistoryOfInvolvements, checkStaffPermission},
         params: {id: '222'},
       }
       fetchScreening.and.returnValue(promiseSpyObj)
@@ -233,6 +232,10 @@ describe('ScreeningPage', () => {
 
     it('GETs the screening from the server', () => {
       expect(fetchScreening).toHaveBeenCalledWith('222')
+    })
+
+    it('GETs the felationships from the server', () => {
+      expect(fetchRelationships).toHaveBeenCalledWith('222')
     })
 
     it('GETs the staff permission from the server', () => {
@@ -247,13 +250,14 @@ describe('ScreeningPage', () => {
 
     beforeEach(() => {
       const fetchScreening = jasmine.createSpy('fetchScreening')
+      const fetchRelationships = jasmine.createSpy('fetchRelationships')
       const checkStaffPermission = jasmine.createSpy('checkStaffPermission')
       fetchScreening.and.returnValue(Promise.resolve())
       checkStaffPermission.and.returnValue(Promise.resolve())
       const fetchHistoryOfInvolvements = () => Promise.resolve()
       props = {
         ...requiredProps,
-        actions: {fetchScreening, fetchHistoryOfInvolvements, checkStaffPermission},
+        actions: {fetchScreening, fetchRelationships, fetchHistoryOfInvolvements, checkStaffPermission},
         params: {id: '222'},
         screening: Immutable.fromJS({
           report_narrative: 'my narrative',
@@ -457,10 +461,8 @@ describe('ScreeningPage', () => {
 
       it('renders the relationships card', () => {
         expect(component.find('RelationshipsCard').props()).toEqual(jasmine.objectContaining({
-          actions: props.actions,
           participants: props.participants,
           relationships: props.relationships,
-          screeningId: props.params.id,
         }))
       })
 

--- a/spec/javascripts/components/screenings/relationships/RelationshipCardSpec.jsx
+++ b/spec/javascripts/components/screenings/relationships/RelationshipCardSpec.jsx
@@ -21,21 +21,6 @@ describe('RelationshipsCard', () => {
       fetchRelationships = jasmine.createSpy('fetchRelationships')
     })
 
-    describe('when participants are not empty', () => {
-      it('fetch relationships', () => {
-        const props = {
-          ...requiredProps,
-          actions: {fetchRelationships},
-          participants: Immutable.fromJS([
-            {id: 1},
-            {id: 2},
-          ]),
-        }
-        component = mount(<RelationshipsCard {...props}/>)
-        expect(fetchRelationships).toHaveBeenCalledWith(props.screeningId)
-      })
-    })
-
     describe('when participants are empty', () => {
       it('does not fetch relationships', () => {
         const props = {
@@ -58,20 +43,6 @@ describe('RelationshipsCard', () => {
         actions: {fetchRelationships},
       }
       component = shallow(<RelationshipsCard {...updatedProps}/>)
-    })
-
-    describe('when participants change', () => {
-      it('fetch relationships', () => {
-        const newProps = {
-          ...requiredProps,
-          participants: Immutable.fromJS([
-            {id: 1},
-            {id: 2},
-          ]),
-        }
-        component.setProps(newProps)
-        expect(fetchRelationships).toHaveBeenCalledWith(newProps.screeningId)
-      })
     })
 
     describe('when participants are the same', () => {

--- a/spec/javascripts/sagas/createParticipantSagaSpec.js
+++ b/spec/javascripts/sagas/createParticipantSagaSpec.js
@@ -1,5 +1,5 @@
 import 'babel-polyfill'
-import {takeEvery, put, call} from 'redux-saga/effects'
+import {takeEvery, put, call, select} from 'redux-saga/effects'
 import {post} from 'utils/http'
 import {
   createParticipant,
@@ -9,7 +9,9 @@ import {CREATE_PARTICIPANT} from 'actions/actionTypes'
 import {
   createParticipantSuccess,
   createParticipantFailure,
+  fetchRelationships,
 } from 'actions/screeningActions'
+import {getScreeningIdValueSelector} from 'selectors/screeningSelectors'
 
 describe('createParticipantSaga', () => {
   it('creates participant on CREATE_PARTICIPANT', () => {
@@ -19,12 +21,19 @@ describe('createParticipantSaga', () => {
 })
 
 describe('createParticipant', () => {
-  it('creates and puts participant', () => {
+  it('creates and puts participant and fetches relationships', () => {
     const participant = {first_name: 'Michael'}
     const gen = createParticipant({participant})
     expect(gen.next().value).toEqual(call(post, '/api/v1/participants', participant))
     expect(gen.next(participant).value).toEqual(
       put(createParticipantSuccess(participant))
+    )
+    expect(gen.next().value).toEqual(
+      select(getScreeningIdValueSelector)
+    )
+    const screeningId = '444'
+    expect(gen.next(screeningId).value).toEqual(
+      put(fetchRelationships(screeningId))
     )
   })
 

--- a/spec/javascripts/sagas/deleteParticipantSagaSpec.js
+++ b/spec/javascripts/sagas/deleteParticipantSagaSpec.js
@@ -11,6 +11,7 @@ import {
   deleteParticipantSuccess,
   deleteParticipantFailure,
   fetchScreening,
+  fetchRelationships,
 } from 'actions/screeningActions'
 
 describe('deleteParticipantSaga', () => {
@@ -21,7 +22,7 @@ describe('deleteParticipantSaga', () => {
 })
 
 describe('deleteParticipant', () => {
-  it('deletes and puts participant and fetches a screening', () => {
+  it('deletes and puts participant, fetches a screening, and fetches relationships', () => {
     const id = '123'
     const gen = deleteParticipant({id})
     expect(gen.next().value).toEqual(call(destroy, '/api/v1/participants/123'))
@@ -31,6 +32,9 @@ describe('deleteParticipant', () => {
     expect(gen.next().value).toEqual(select(getScreeningIdValueSelector))
     expect(gen.next('444').value).toEqual(
       put(fetchScreening('444'))
+    )
+    expect(gen.next('444').value).toEqual(
+      put(fetchRelationships('444'))
     )
   })
 


### PR DESCRIPTION
### Pivotal Story
Prelimary work for:
- [Implement Redux validations and state management for **Relationships** card 152464347](https://www.pivotaltracker.com/story/show/152464347)

### Purpose
Refactor the Relationships Card in Screening to not use lifecycle methods for retrieving relationships. This makes it easier to refactor the relationships card when porting the card from investigation.

### Background
The Relationships Card in Screening uses `componentDidMount` and `componentDidUpdate` to fire actions for fetching the relationships. We can remove these lifecycle methods by fetching the relationships within the sagas for adding and removing people from the screening and fetching the relationships when the screening page is first loaded.

### Notes for Reviewer

We talked about using React Router *somehow* when fetching relationships the first time and decided that should be a separate effort.

We also talked about standard practices around sagas dispatching to sagas and decided that we need to take one of two approaches. The first approach is taken with this PR:
1. Standardize by not letting sagas dispatch to sagas
2. Let sagas dispatch to sagas, but ensure that there are saga integration tests to catch event loops and other problems.

### Testing Notes
I also realized that there are a lot of tests that fail when adding a new api call from the screening page, but its simple enough as stubbing that call for the appropriate tests.

