### PR TITLE
Remove extra props from call to worker safety card

### DIFF
--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -275,15 +275,7 @@ export class ScreeningPage extends React.Component {
           }
           {releaseTwoInactive && <AllegationsCardView mode={mode} />}
           {releaseTwoInactive && <RelationshipsCardContainer />}
-          {
-            releaseTwoInactive &&
-              <WorkerSafetyCardView
-                {...cardCallbacks}
-                editable={editable}
-                mode={mode}
-                screening={mergedScreening}
-              />
-          }
+          {releaseTwoInactive && <WorkerSafetyCardView editable={editable} mode={mode} />}
           <HistoryOfInvolvementContainer empty={<EmptyHistory />} notEmpty={<HistoryTableContainer />} />
           {releaseTwoInactive && <CrossReportCardView editable={editable} mode={mode} />}
           {releaseTwoInactive && <DecisionCardView mode={mode}/>}

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -146,7 +146,6 @@ describe('ScreeningPage', () => {
       const safetyCard = component.find('WorkerSafetyCardView')
       expect(safetyCard.length).toEqual(1)
       expect(safetyCard.props().mode).toEqual('edit')
-      expect(safetyCard.props().onCancel).toEqual(component.instance().cancelEdit)
     })
 
     it('renders the screening reference', () => {
@@ -423,9 +422,6 @@ describe('ScreeningPage', () => {
       it('renders the worker safety card', () => {
         const safetyCard = component.find('WorkerSafetyCardView')
         expect(safetyCard.length).toEqual(1)
-        expect(safetyCard.props()).toEqual(
-          jasmine.objectContaining({...cardCallbacks, mode: 'show'})
-        )
       })
 
       it('renders the history card', () => {

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -422,6 +422,9 @@ describe('ScreeningPage', () => {
       it('renders the worker safety card', () => {
         const safetyCard = component.find('WorkerSafetyCardView')
         expect(safetyCard.length).toEqual(1)
+        expect(safetyCard.props()).toEqual(
+          jasmine.objectContaining({mode: 'show'})
+        )
       })
 
       it('renders the history card', () => {


### PR DESCRIPTION
[#152464345]

### Pivotal Story

- [Implement Redux validations and state management for **Worker Safety** card](https://www.pivotaltracker.com/story/show/152464345)

### Purpose
Remove props still provided by screening page but are not used by worker safety card.

### Background
Worker safety card has already been refactored.

### Questions for Reviewer


### Notes for Reviewer


### Testing Notes

