### PR TITLE
clean up the screening page and its spec

### DIFF
--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -44,12 +44,6 @@ export class ScreeningPage extends React.Component {
     this.props.actions.checkStaffPermission('add_sensitive_people')
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (!this.props.screening.equals(nextProps.screening)) {
-      this.setState({screening: nextProps.screening})
-    }
-  }
-
   renderMode() {
     if (!this.props.editable) {
       return 'show'
@@ -188,7 +182,6 @@ ScreeningPage.propTypes = {
   mode: PropTypes.string.isRequired,
   params: PropTypes.object.isRequired,
   participants: PropTypes.object.isRequired,
-  relationships: PropTypes.object.isRequired,
   screening: PropTypes.object.isRequired,
 }
 
@@ -203,7 +196,6 @@ export function mapStateToProps(state, ownProps) {
     hasAddSensitivePerson: state.getIn(['staff', 'add_sensitive_people']),
     loaded: state.getIn(['screening', 'fetch_status']) === 'FETCHED',
     participants: state.get('participants'),
-    relationships: state.get('relationships'),
     screening: state.get('screening'),
     mode: ownProps.params.mode,
   }

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -12,18 +12,10 @@ export const requiredScreeningAttributes = {
 }
 
 export const requiredProps = {
-  actions: {
-    checkStaffPermission: () => null,
-    fetchScreening: () => null,
-    fetchCountyAgencies: () => null,
-  },
-  counties: [{code: '123', value: 'county'}],
-  countyAgencies: {DEPARTMENT_OF_JUSTICE: []},
+  actions: {},
   params: {id: '1'},
   participants: Immutable.List(),
   screening: Immutable.fromJS(requiredScreeningAttributes),
-  involvements: Immutable.fromJS({screenings: []}),
-  relationships: Immutable.List(),
   mode: 'edit',
   editable: true,
 }


### PR DESCRIPTION
### Pivotal Story

No story -- bleed over work from the redux refactor

### Purpose
Clean up the screening spec and screening page

### Questions for Reviewer
If you notice additional cleanup work. shoot comments!

### Notes for Reviewer
the prop `actions` is defined as empty object in the screening page spec because karma will complain otherwise.

### Testing Notes
we can still do manual testing, but are having issues with development environment right now.
