### PR TITLE
In 152463650 person search in its own view

### DIFF
--- a/app/javascript/containers/screenings/PersonSearchFormContainer.js
+++ b/app/javascript/containers/screenings/PersonSearchFormContainer.js
@@ -1,0 +1,31 @@
+import {connect} from 'react-redux'
+import PersonSearchForm from 'views/people/PersonSearchForm'
+import {getScreeningIdValueSelector} from 'selectors/screeningSelectors'
+import {createPerson} from 'actions/personCardActions'
+import * as IntakeConfig from 'common/config'
+
+const mapStateToProps = (state) => (
+  {
+    screeningId: getScreeningIdValueSelector(state),
+    canCreateNewPerson: IntakeConfig.isFeatureInactive('release_two'),
+    hasAddSensitivePerson: state.getIn(['staff', 'add_sensitive_people']),
+  }
+)
+
+const mergeProps = (stateProps, {dispatch}) => {
+  const {screeningId, hasAddSensitivePerson, canCreateNewPerson} = stateProps
+  const isSelectable = (person) => (person.sensitive === false || hasAddSensitivePerson)
+  const onSelect = (person) => {
+    const personOnScreening = {
+      ...person,
+      screening_id: screeningId,
+      legacy_id: person.id,
+      id: null,
+    }
+    dispatch(createPerson(personOnScreening))
+  }
+
+  return {canCreateNewPerson, isSelectable, onSelect}
+}
+
+export default connect(mapStateToProps, null, mergeProps)(PersonSearchForm)

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -3,8 +3,6 @@ import * as screeningActions from 'actions/screeningActions'
 import * as personCardActions from 'actions/personCardActions'
 import {checkStaffPermission} from 'actions/staffActions'
 import AllegationsCardView from 'screenings/AllegationsCardView'
-import Autocompleter from 'common/Autocompleter'
-import CreateUnknownParticipant from 'screenings/CreateUnknownParticipant'
 import CrossReportCardView from 'screenings/crossReports/CrossReportCardView'
 import DecisionCardView from 'screenings/DecisionCardView'
 import IncidentInformationCardView from 'screenings/IncidentInformationCardView'
@@ -23,18 +21,12 @@ import {connect} from 'react-redux'
 import HistoryOfInvolvementContainer from 'containers/screenings/HistoryOfInvolvementContainer'
 import HistoryTableContainer from 'containers/screenings/HistoryTableContainer'
 import EmptyHistory from 'views/history/EmptyHistory'
+import PersonSearchFormContainer from 'containers/screenings/PersonSearchFormContainer'
 
 export class ScreeningPage extends React.Component {
   constructor(props, context) {
     super(props, context)
-    const methods = [
-      'createParticipant',
-      'canCreateParticipant',
-      'renderMode',
-    ]
-    methods.forEach((method) => {
-      this[method] = this[method].bind(this)
-    })
+    this.renderMode = this.renderMode.bind(this)
   }
 
   componentDidMount() {
@@ -49,20 +41,6 @@ export class ScreeningPage extends React.Component {
       return 'show'
     }
     return this.props.mode
-  }
-
-  canCreateParticipant(person) {
-    return (person.sensitive === false || this.props.hasAddSensitivePerson)
-  }
-
-  createParticipant(person) {
-    const {params} = this.props
-    const participant = Object.assign({}, person, {
-      screening_id: params.id,
-      legacy_id: person.id,
-      id: null,
-    })
-    this.props.actions.createPerson(participant)
   }
 
   render() {
@@ -101,28 +79,7 @@ export class ScreeningPage extends React.Component {
               </div>
           }
           {releaseTwoInactive && <ScreeningInformationCardView editable={editable} mode={mode} />}
-          {this.renderMode() === 'edit' &&
-            <div className='card edit double-gap-top' id='search-card'>
-              <div className='card-header'>
-                <span>Search</span>
-              </div>
-              <div className='card-body'>
-                <div className='row'>
-                  <div className='col-md-12'>
-                    <label className='pull-left' htmlFor='screening_participants'>Search for any person(Children, parents, collaterals, reporters, alleged perpetrators...)</label>
-                    <Autocompleter id='screening_participants'
-                      onSelect={this.createParticipant}
-                      isSelectable={this.canCreateParticipant}
-                      footer={
-                        IntakeConfig.isFeatureInactive('release_two') &&
-                        <CreateUnknownParticipant saveCallback={this.createParticipant}/>
-                      }
-                    />
-                  </div>
-                </div>
-              </div>
-            </div>
-          }
+          {this.renderMode() === 'edit' && <PersonSearchFormContainer />}
           {this.props.participants.map((participant) =>
             <ParticipantCardView
               key={participant.get('id')}

--- a/app/javascript/views/people/PersonSearchForm.jsx
+++ b/app/javascript/views/people/PersonSearchForm.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import Autocompleter from 'common/Autocompleter'
+import CreateUnknownParticipant from 'screenings/CreateUnknownParticipant'
+
+const PersonSearchForm = ({canCreateNewPerson, isSelectable, onSelect}) => (
+  <div className='card edit double-gap-top' id='search-card'>
+    <div className='card-header'>
+      <span>Search</span>
+    </div>
+    <div className='card-body'>
+      <div className='row'>
+        <div className='col-md-12'>
+          <label className='pull-left' htmlFor='screening_participants'>Search for any person(Children, parents, collaterals, reporters, alleged perpetrators...)</label>
+          <Autocompleter id='screening_participants'
+            onSelect={onSelect}
+            isSelectable={isSelectable}
+            footer={canCreateNewPerson && <CreateUnknownParticipant saveCallback={onSelect}/>}
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+)
+
+PersonSearchForm.propTypes = {
+  canCreateNewPerson: PropTypes.bool,
+  isSelectable: PropTypes.func,
+  onSelect: PropTypes.func,
+}
+
+export default PersonSearchForm

--- a/spec/javascripts/components/screenings/ScreeningPageReleaseTwoSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageReleaseTwoSpec.jsx
@@ -38,10 +38,9 @@ describe('ScreeningPage when release two is active', () => {
       expect(component.find('ScreeningSubmitButton').length).toEqual(0)
     })
 
-    it('does not show the create new person button', () => {
+    it('renders the person search form', () => {
       const component = shallow(<ScreeningPage {...requiredProps} loaded={true} />)
-      expect(component.find('Autocompleter').length).toBe(1)
-      expect(component.find('Autocompleter').props().footer).toEqual(false)
+      expect(component.find('Connect(PersonSearchForm)').exists()).toBe(true)
     })
 
     it('renders the snapshot copy', () => {
@@ -77,22 +76,6 @@ describe('ScreeningPage when release two is active', () => {
         ])
         const props = {...requiredProps, participants, loaded: true, editable: true}
         component = shallow(<ScreeningPage {...props} />)
-      })
-
-      it('renders the card header', () => {
-        expect(component.find('#search-card .card-header').text()).toContain('Search')
-      })
-
-      it('renders the search card', () => {
-        expect(component.find('#search-card label').text()).toContain('Search for any person')
-        expect(component.text()).toContain('(Children, parents, collaterals, reporters, alleged perpetrators...)')
-      })
-
-      it('renders the autocompleter', () => {
-        expect(component.find('Autocompleter').props().id).toEqual('screening_participants')
-        expect(component.find('Autocompleter').props().onSelect).toEqual(
-          component.instance().createParticipant
-        )
       })
 
       it('renders the participants card for each participant in show mode', () => {

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -388,43 +388,8 @@ describe('ScreeningPage', () => {
           component = shallow(<ScreeningPage {...props} />)
         })
 
-        it('renders the card header', () => {
-          expect(component.find('#search-card .card-header').text()).toContain('Search')
-        })
-
         it('renders the search card', () => {
-          const searchCard = component.find('#search-card')
-          const label = searchCard.children('.card-body').children('div').children('div').children('label')
-          expect(label.text()).toContain('Search for any person')
-          expect(label.text()).toContain('(Children, parents, collaterals, reporters, alleged perpetrators...)')
-        })
-
-        describe('autocompleter', () => {
-          let autocompleter
-          beforeEach(() => {
-            autocompleter = component.find('Autocompleter')
-          })
-          it('is rendered', () => {
-            expect(autocompleter.length).toBe(1)
-          })
-          it('is passed an id', () => {
-            expect(autocompleter.props().id).toEqual('screening_participants')
-          })
-          it('is pass the correct isSelectable callback', () => {
-            expect(autocompleter.props().isSelectable).toEqual(
-              component.instance().canCreateParticipant
-            )
-          })
-          it('is pass the correct onSelect callback', () => {
-            expect(autocompleter.props().onSelect).toEqual(
-              component.instance().createParticipant
-            )
-          })
-          it('is passed a footer component', () => {
-            const footer = autocompleter.props().footer
-            expect(footer.type.name).toEqual('CreateUnknownParticipant')
-            expect(footer.props.saveCallback).toEqual(component.instance().createParticipant)
-          })
+          expect(component.find('Connect(PersonSearchForm)').exists()).toEqual(true)
         })
 
         it('renders the participants card for each participant', () => {
@@ -442,40 +407,6 @@ describe('ScreeningPage', () => {
       const component = shallow(<ScreeningPage {...requiredProps} loaded={true}/>)
       expect(component.find('ScreeningSubmitButton').exists()).toEqual(false)
       expect(component.find('ScreeningSubmitButtonWithModal').exists()).toEqual(true)
-    })
-  })
-
-  describe('canCreateParticipant', () => {
-    let instance
-    const sensitive = {sensitive: true}
-    const insensitive = {sensitive: false}
-
-    describe('with permission', () => {
-      beforeEach(() => {
-        instance = shallow(<ScreeningPage {...requiredProps} hasAddSensitivePerson={true} />).instance()
-      })
-
-      it('returns true for sensitive participant', () => {
-        expect(instance.canCreateParticipant(sensitive)).toBe(true)
-      })
-
-      it('returns true for insensitive participant', () => {
-        expect(instance.canCreateParticipant(insensitive)).toBe(true)
-      })
-    })
-
-    describe('without permission', () => {
-      beforeEach(() => {
-        instance = shallow(<ScreeningPage {...requiredProps} hasAddSensitivePerson={false} />).instance()
-      })
-
-      it('returns true for sensitive participant', () => {
-        expect(instance.canCreateParticipant(sensitive)).toBe(false)
-      })
-
-      it('returns true for insensitive participant', () => {
-        expect(instance.canCreateParticipant(insensitive)).toBe(true)
-      })
     })
   })
 })

--- a/spec/javascripts/views/people/PersonSearchFormSpec.jsx
+++ b/spec/javascripts/views/people/PersonSearchFormSpec.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import {shallow} from 'enzyme'
+import PersonSearchForm from 'views/people/PersonSearchForm'
+import CreateUnknownParticipant from 'screenings/CreateUnknownParticipant'
+
+describe('PersonSearchForm', () => {
+  const renderPersonSearchForm = ({...props}) => (
+    shallow(<PersonSearchForm {...props}/>)
+  )
+
+  it('renders the autocompleter', () => {
+    const component = renderPersonSearchForm({})
+    const autocompleter = component.find('Autocompleter')
+    expect(autocompleter.exists()).toEqual(true)
+    expect(autocompleter.props().id).toEqual('screening_participants')
+  })
+
+  it('passes isSelectable from props to the autocompleter', () => {
+    const isSelectable = () => {}
+    const component = renderPersonSearchForm({isSelectable})
+    const autocompleter = component.find('Autocompleter')
+    expect(autocompleter.props().isSelectable).toEqual(isSelectable)
+  })
+
+  it('passes the onSelect prop to the autocompleter', () => {
+    const onSelect = jasmine.createSpy('onSelect')
+    const component = renderPersonSearchForm({onSelect})
+    const autocompleter = component.find('Autocompleter')
+    expect(autocompleter.props().onSelect).toEqual(onSelect)
+  })
+
+  it('passes the footer if we can create new people', () => {
+    const onSelect = () => {}
+    const component = renderPersonSearchForm({canCreateNewPerson: true, onSelect})
+    const autocompleter = component.find('Autocompleter')
+    expect(autocompleter.props().footer).toEqual(<CreateUnknownParticipant saveCallback={onSelect}/>)
+  })
+
+  it('does not pass a footer if we cannot create new people', () => {
+    const component = renderPersonSearchForm({canCreateNewPerson: false})
+    const autocompleter = component.find('Autocompleter')
+    expect(autocompleter.props().footer).toEqual(false)
+  })
+
+  it('renders the card header', () => {
+    const component = renderPersonSearchForm({})
+    expect(component.children('.card-header').children('span').text()).toContain('Search')
+  })
+
+  it('renders the search card', () => {
+    const component = renderPersonSearchForm({})
+    const searchCard = component.find('#search-card')
+    const label = searchCard.children('.card-body').children('div').children('div').children('label')
+    expect(label.text()).toContain('Search for any person')
+    expect(label.text()).toContain('(Children, parents, collaterals, reporters, alleged perpetrators...)')
+  })
+})


### PR DESCRIPTION
### Pivotal Story

- [Redux refactor #152463650](https://www.pivotaltracker.com/story/show/152463650)

### Purpose
Put the person search card in its own view, which removes the two remaining callbacks defined on the screening page. Some further refactoring could likely be done, but this is mainly to free up the screening page to become a container.

### Background


### Questions for Reviewer


### Notes for Reviewer


### Testing Notes

