### PR TITLE
Int 35 show error detail preventing submit

### DIFF
--- a/app/javascript/common/ErrorDetail.jsx
+++ b/app/javascript/common/ErrorDetail.jsx
@@ -1,0 +1,21 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const ErrorDetail = ({errors}) => (
+  <div className='alert-message error-message' role='alert'>
+    <div className='alert-icon'>
+      <i className='fa fa-warning' />
+    </div>
+    <div className='alert-text'>
+      <ul>
+        { errors.map((error, index) => (<li key={index}>{error}</li>)) }
+      </ul>
+    </div>
+  </div>
+)
+
+ErrorDetail.propTypes = {
+  errors: PropTypes.array.isRequired,
+}
+
+export default ErrorDetail

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -23,6 +23,8 @@ import HistoryOfInvolvementContainer from 'containers/screenings/HistoryOfInvolv
 import HistoryTableContainer from 'containers/screenings/HistoryTableContainer'
 import EmptyHistory from 'views/history/EmptyHistory'
 import PersonSearchFormContainer from 'containers/screenings/PersonSearchFormContainer'
+import ErrorDetail from 'common/ErrorDetail'
+import {getScreeningSubmissionErrorsSelector, getTotalScreeningSubmissionErrorValueSelector} from 'selectors/errorsSelectors'
 
 export class ScreeningPage extends React.Component {
   constructor(props, context) {
@@ -54,7 +56,7 @@ export class ScreeningPage extends React.Component {
   }
 
   render() {
-    const {referralId, reference, editable, mode, loaded} = this.props
+    const {referralId, reference, editable, mode, loaded, hasErrors, submitReferralErrors} = this.props
     const releaseTwoInactive = IntakeConfig.isFeatureInactive('release_two')
     const releaseTwo = IntakeConfig.isFeatureActive('release_two')
 
@@ -87,6 +89,7 @@ export class ScreeningPage extends React.Component {
                 </div>
               </div>
           }
+          {releaseTwoInactive && hasErrors && <ErrorDetail errors={submitReferralErrors} />}
           {releaseTwoInactive && <ScreeningInformationCardView editable={editable} mode={mode} />}
           {mode === 'edit' && <PersonSearchFormContainer />}
           {this.props.participants.map((participant) =>
@@ -142,12 +145,14 @@ ScreeningPage.propTypes = {
   actions: PropTypes.object.isRequired,
   editable: PropTypes.bool,
   hasAddSensitivePerson: PropTypes.bool,
+  hasErrors: PropTypes.bool,
   loaded: PropTypes.bool,
   mode: PropTypes.string.isRequired,
   params: PropTypes.object.isRequired,
   participants: PropTypes.object.isRequired,
   reference: PropTypes.string,
   referralId: PropTypes.string,
+  submitReferralErrors: PropTypes.array,
 }
 
 ScreeningPage.defaultProps = {
@@ -164,6 +169,8 @@ export function mapStateToProps(state, _ownProps) {
     participants: state.get('participants'),
     reference: state.getIn(['screening', 'reference']),
     referralId: state.getIn(['screening', 'referral_id']),
+    hasErrors: Boolean(getTotalScreeningSubmissionErrorValueSelector(state)),
+    submitReferralErrors: getScreeningSubmissionErrorsSelector(state).toJS(),
   }
 }
 

--- a/app/javascript/selectors/errorsSelectors.js
+++ b/app/javascript/selectors/errorsSelectors.js
@@ -1,4 +1,4 @@
-import {Map} from 'immutable'
+import {Map, List} from 'immutable'
 import {createSelector} from 'reselect'
 import {SUBMIT_SCREENING_COMPLETE} from 'actions/actionTypes'
 
@@ -14,6 +14,18 @@ export const getTotalScreeningSubmissionErrorValueSelector = createSelector(
       return errors.get(SUBMIT_SCREENING_COMPLETE).size
     } else {
       return 0
+    }
+  }
+)
+export const getScreeningSubmissionErrorsSelector = createSelector(
+  getErrors,
+  (errors) => {
+    if (errors.has(SUBMIT_SCREENING_COMPLETE)) {
+      return errors.get(SUBMIT_SCREENING_COMPLETE).map((error) =>
+        (`${error.get('property')} ${error.get('user_message')} (Incident Id: ${error.get('incident_id')})`)
+      )
+    } else {
+      return List()
     }
   }
 )

--- a/spec/features/screening/submit_screening_spec.rb
+++ b/spec/features/screening/submit_screening_spec.rb
@@ -37,6 +37,24 @@ feature 'Submit Screening' do
         ).and_return(json_body(screening_with_referral.to_json, status: 201))
       end
 
+      scenario 'does not display an error banner with count of errors' do
+        visit edit_screening_path(existing_screening.id)
+        click_button 'Submit'
+
+        expect(
+          page.find('.page-error')
+        ).to_not have_content(
+          'error(s) have been identified. Please fix them and try submitting again.'
+        )
+      end
+
+      scenario 'does not display an error alert with details of errors' do
+        visit edit_screening_path(existing_screening.id)
+        click_button 'Submit'
+
+        expect(page).to_not have_css('.error-message')
+      end
+
       scenario 'displays a success modal and submits a screening to the API' do
         visit edit_screening_path(existing_screening.id)
         click_button 'Submit'
@@ -55,55 +73,56 @@ feature 'Submit Screening' do
     end
 
     context 'when error submitting referral' do
+      let(:incident_id) { '0de2aea9-04f9-4fc4-bc16-75b6495839e0' }
       let(:errors) do
         {
           issue_details: [
             {
-              incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+              incident_id: incident_id,
               type: 'constraint_validation',
               user_message: 'may not be empty',
               property: 'screeningDecision'
             },
             {
-              incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+              incident_id: incident_id,
               type: 'constraint_validation',
-              user_message: 'must be a valid system code for category APV_STC',
+              user_message: 'must be a valid system code for ...',
               property: 'approvalStatus',
               invalid_value: 0
             },
             {
-              incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+              incident_id: incident_id,
               type: 'constraint_validation',
-              user_message: 'must be a valid system code for category CMM_MTHC',
+              user_message: 'must be a valid system code for ...',
               property: 'communicationMethod'
             },
             {
-              incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+              incident_id: incident_id,
               type: 'constraint_validation',
-              user_message: 'must be a valid system code for category RFR_RSPC',
+              user_message: 'must be a valid system code for ...',
               property: 'responseTime'
             },
             {
-              incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+              incident_id: incident_id,
               type: 'constraint_validation',
-              user_message: 'GVR_ENTC sys code is required',
+              user_message: 'GVR_ENTC sys code is ...',
               property: 'incidentCounty.GVR_ENTC'
             },
             {
-              incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+              incident_id: incident_id,
               type: 'constraint_validation',
-              user_message: 'must contain at least one victim, only one reporter, and ...',
+              user_message: 'must contain at least one victim, ...',
               property: 'participants'
             },
             {
-              incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+              incident_id: incident_id,
               type: 'constraint_validation',
               user_message: 'must be greater than or equal to 1',
               property: 'id',
               invalid_value: 0
             },
             {
-              incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+              incident_id: incident_id,
               type: 'constraint_validation',
               user_message: 'may not be null',
               property: 'responseTime'
@@ -136,21 +155,20 @@ feature 'Submit Screening' do
         )
       end
       scenario 'displays an error alert with details of errors' do
-        pending 'until completion of INT-35'
         expect(page).not_to have_content ' - Referral #'
-        expect(page.find('.error-message div.alert-icon')).to have_css('i.fa-info-circle')
+        expect(page.find('.error-message div.alert-icon')).to have_css('i.fa-warning')
         expect(
-          page.find('.error-message div.alert-text li').map(&:text)
+          page.all('.error-message div.alert-text li').map(&:text)
         ).to eq(
           [
-            'screeningDecision may not be empty',
-            'approvalStatus must be a valid system code for category APV_STC',
-            'communicationMethod must be a valid system code for category CMM_MTHC',
-            'responseTime must be a valid system code for category RFR_RSPC',
-            'incidentCounty.GVR_ENTC GVR_ENTC sys code is required',
-            'participants must contain at least one victim, only one reporter, and ...',
-            'id must be greater than or equal to 1',
-            'responseTime may not be null'
+            "screeningDecision may not be empty (Incident Id: #{incident_id})",
+            "approvalStatus must be a valid system code for ... (Incident Id: #{incident_id})",
+            "communicationMethod must be a valid system code for ... (Incident Id: #{incident_id})",
+            "responseTime must be a valid system code for ... (Incident Id: #{incident_id})",
+            "incidentCounty.GVR_ENTC GVR_ENTC sys code is ... (Incident Id: #{incident_id})",
+            "participants must contain at least one victim, ... (Incident Id: #{incident_id})",
+            "id must be greater than or equal to 1 (Incident Id: #{incident_id})",
+            "responseTime may not be null (Incident Id: #{incident_id})"
           ]
         )
       end

--- a/spec/features/screening/submit_screening_spec.rb
+++ b/spec/features/screening/submit_screening_spec.rb
@@ -41,11 +41,11 @@ feature 'Submit Screening' do
         visit edit_screening_path(existing_screening.id)
         click_button 'Submit'
 
-        expect(
-          page.find('.page-error')
-        ).to_not have_content(
-          'error(s) have been identified. Please fix them and try submitting again.'
-        )
+        within '.page-error' do
+          expect(page).to_not have_content(
+            'error(s) have been identified. Please fix them and try submitting again.'
+          )
+        end
       end
 
       scenario 'does not display an error alert with details of errors' do

--- a/spec/javascripts/components/common/ErrorDetailSpec.jsx
+++ b/spec/javascripts/components/common/ErrorDetailSpec.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import {shallow} from 'enzyme'
+import ErrorDetail from 'common/ErrorDetail'
+
+describe('ErrorDetail', () => {
+  it('renders alert icon', () => {
+    const component = shallow(<ErrorDetail errors={[]}/>)
+    const errorMessageDiv = component.find('div.error-message')
+    expect(errorMessageDiv.props().className).toEqual('alert-message error-message')
+    expect(errorMessageDiv.props().role).toEqual('alert')
+    expect(errorMessageDiv.find('div.alert-icon i.fa.fa-warning').exists()).toEqual(true)
+  })
+  it('renders alert text', () => {
+    const errors = [
+      'apple',
+      'banana',
+      'carrot',
+      'dragon fruit',
+    ]
+    const component = shallow(<ErrorDetail errors={errors}/>)
+    const errorDetails = component.find('div.error-message').find('div.alert-text ul')
+    expect(errorDetails.exists()).toEqual(true)
+    expect(errorDetails.childAt(0).text()).toEqual('apple')
+    expect(errorDetails.childAt(1).text()).toEqual('banana')
+    expect(errorDetails.childAt(2).text()).toEqual('carrot')
+    expect(errorDetails.childAt(3).text()).toEqual('dragon fruit')
+  })
+})

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -22,6 +22,8 @@ describe('ScreeningPage', () => {
     participants = List(),
     reference,
     referralId,
+    hasErrors = false,
+    submitReferralErrors = List(),
   }) {
     const props = {
       actions,
@@ -32,6 +34,8 @@ describe('ScreeningPage', () => {
       participants,
       reference,
       referralId,
+      hasErrors,
+      submitReferralErrors,
     }
     return shallow(<ScreeningPage {...props} />)
   }
@@ -131,6 +135,33 @@ describe('ScreeningPage', () => {
   })
 
   describe('render', () => {
+    describe('with errors', () => {
+      it('renders the error detail card', () => {
+        const submitReferralErrors = ['a', 'b', 'c']
+        const component = renderScreeningPage({
+          loaded: true,
+          mode: 'edit',
+          submitReferralErrors,
+          hasErrors: true,
+        })
+        const card = component.find('ErrorDetail')
+        expect(card.exists()).toEqual(true)
+        expect(card.props().errors).toEqual(submitReferralErrors)
+      })
+    })
+    describe('without errors', () => {
+      it('does not render the error detail card', () => {
+        const submitReferralErrors = []
+        const component = renderScreeningPage({
+          loaded: true,
+          mode: 'edit',
+          submitReferralErrors,
+          hasErrors: false,
+        })
+        const card = component.find('ErrorDetail')
+        expect(card.exists()).toEqual(false)
+      })
+    })
     describe('in edit mode', () => {
       let component
       beforeEach(() => {

--- a/spec/javascripts/selectors/errorsSelectorsSpec.js
+++ b/spec/javascripts/selectors/errorsSelectorsSpec.js
@@ -1,6 +1,7 @@
-import {fromJS} from 'immutable'
+import {fromJS, List} from 'immutable'
 import {
   getHasGenericErrorValueSelector,
+  getScreeningSubmissionErrorsSelector,
   getTotalScreeningSubmissionErrorValueSelector,
 } from 'selectors/errorsSelectors'
 import {SUBMIT_SCREENING_COMPLETE} from 'actions/actionTypes'
@@ -23,13 +24,81 @@ describe('errorsSelectors', () => {
   })
   describe('getTotalScreeningSubmissionErrorValueSelector', () => {
     it('returns count of screening submission errors', () => {
-      const errors = {[SUBMIT_SCREENING_COMPLETE]: ['error one', 'error two']}
+      const errors = {[SUBMIT_SCREENING_COMPLETE]: [
+        {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'GVR_ENTC sys code is required',
+          property: 'incidentCounty.GVR_ENTC',
+        },
+        {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'must contain at least one victim, only one reporter, and ...',
+          property: 'participants',
+        },
+        {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'must be greater than or equal to 1',
+          property: 'id',
+          invalid_value: 0,
+        },
+        {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'may not be null',
+          property: 'responseTime',
+        },
+      ]}
       const state = fromJS({errors})
-      expect(getTotalScreeningSubmissionErrorValueSelector(state)).toEqualImmutable(2)
+      expect(getTotalScreeningSubmissionErrorValueSelector(state)).toEqualImmutable(4)
     })
     it('returns 0 when no screening submission errors exist', () => {
       const state = fromJS({errors: {}})
       expect(getTotalScreeningSubmissionErrorValueSelector(state)).toEqualImmutable(0)
+    })
+  })
+  describe('getScreeningSubmissionErrorsSelector', () => {
+    it('returns count of screening submission errors', () => {
+      const errors = {[SUBMIT_SCREENING_COMPLETE]: [
+        {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'GVR_ENTC sys code is required',
+          property: 'incidentCounty.GVR_ENTC',
+        },
+        {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'must contain at least one victim, only one reporter, and ...',
+          property: 'participants',
+        },
+        {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'must be greater than or equal to 1',
+          property: 'id',
+          invalid_value: 0,
+        },
+        {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'may not be null',
+          property: 'responseTime',
+        },
+      ]}
+      const state = fromJS({errors})
+      expect(getScreeningSubmissionErrorsSelector(state)).toEqualImmutable(fromJS([
+        'incidentCounty.GVR_ENTC GVR_ENTC sys code is required (Incident Id: 0de2aea9-04f9-4fc4-bc16-75b6495839e0)',
+        'participants must contain at least one victim, only one reporter, and ... (Incident Id: 0de2aea9-04f9-4fc4-bc16-75b6495839e0)',
+        'id must be greater than or equal to 1 (Incident Id: 0de2aea9-04f9-4fc4-bc16-75b6495839e0)',
+        'responseTime may not be null (Incident Id: 0de2aea9-04f9-4fc4-bc16-75b6495839e0)',
+      ]))
+    })
+    it('returns 0 when no screening submission errors exist', () => {
+      const state = fromJS({errors: {}})
+      expect(getScreeningSubmissionErrorsSelector(state)).toEqualImmutable(List())
     })
   })
 })


### PR DESCRIPTION
### Jira Story

- [Name of Story INT-35](https://osi-cwds.atlassian.net/browse/INT-35)

### Purpose

Display error detail above the ScreeningInformation Card when errors occur on submitting a screening to referral

### Background

This is the other half of the story which has already been reviewed and on master.

### Notes

The error messages displayed are crude at the moment but from discussions I've had we will probably have stories later to improve that. Also the story didn't layout how the text was to look so I picked one that made sense to me.
