### PR TITLE
Int 549 update intake rails for hoi ferb call

### DIFF
--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -55,6 +55,10 @@ class ExternalRoutes
       "/investigations/#{investigation_id}/contacts/#{contact_id}"
     end
 
+    def ferb_api_screening_history_of_involvements_path(id)
+      "/screenings/#{id}/history_of_involvements"
+    end
+
     def ferb_api_lov_path
       '/lov'
     end

--- a/app/repositories/screening_repository.rb
+++ b/app/repositories/screening_repository.rb
@@ -45,9 +45,9 @@ class ScreeningRepository
   end
 
   def self.history_of_involvements(security_token, id)
-    response = IntakeAPI.make_api_call(
+    response = FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.intake_api_history_of_involvements_path(id),
+      ExternalRoutes.ferb_api_screening_history_of_involvements_path(id),
       :get
     )
     response.body

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -32,6 +32,7 @@ feature 'error pages' do
     scenario 'renders not found error page' do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(1)))
         .and_return(json_body('Screening is not found!!', status: 404))
+      stub_empty_history_for_screening(id: 1)
       visit edit_screening_path(id: 1)
       expect(page).to have_text('Sorry, this is not the page you want.')
       expect(page).to have_text(
@@ -45,6 +46,7 @@ feature 'error pages' do
     scenario 'renders not found error page' do
       stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(1)))
         .and_return(json_body('Investigation is not found!!', status: 404))
+      stub_empty_history_for_screening(id: 1)
       visit investigation_path(id: 1)
       expect(page).to have_text('Sorry, this is not the page you want.')
       expect(page).to have_text(
@@ -71,6 +73,7 @@ feature 'error pages' do
     scenario 'renders 403 page' do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(1)))
         .and_return(json_body('Forbidden!!', status: 403))
+      stub_empty_history_for_screening(id: 1)
       visit edit_screening_path(id: 1)
       expect(page).to have_current_path('/forbidden')
       expect(page).to have_text('This page is restricted.')

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -112,12 +112,13 @@ feature 'login' do
   scenario 'user uses session token when communicating to API' do
     Feature.run_with_activated(:authentication) do
       screening = FactoryGirl.create(:screening, name: 'My Screening')
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(1)))
+      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
         .and_return(json_body(screening.to_json, status: 200))
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .and_return(json_body([].to_json, status: 200))
       stub_request(:get, auth_validation_url)
         .and_return(json_body(auth_artifact.to_json, status: 200))
+      stub_empty_history_for_screening(screening)
 
       bobs_token = 'BOBS_TOKEN'
       Capybara.using_session(:bob) do
@@ -134,19 +135,19 @@ feature 'login' do
       end
 
       Capybara.using_session(:bob) do
-        visit screening_path(1)
+        visit screening_path(screening.id)
         expect(page).to have_content 'My Screening'
         expect(
-          a_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(1)))
+          a_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
           .with(headers: { 'Authorization' => bobs_token })
         ).to have_been_made
       end
 
       Capybara.using_session(:alex) do
-        visit screening_path(1)
+        visit screening_path(screening.id)
         expect(page).to have_content 'My Screening'
         expect(
-          a_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(1)))
+          a_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
           .with(headers: { 'Authorization' => alexs_token })
         ).to have_been_made
       end

--- a/spec/features/screening/decision_spec.rb
+++ b/spec/features/screening/decision_spec.rb
@@ -15,6 +15,7 @@ feature 'decision card' do
   end
 
   before(:each) do
+    stub_empty_history_for_screening(screening)
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
 

--- a/spec/features/screening/history_of_involvement_spec.rb
+++ b/spec/features/screening/history_of_involvement_spec.rb
@@ -37,11 +37,14 @@ feature 'History card' do
     let(:screenings) do
       [
         {
+          id: '1234',
           start_date: '2016-09-10',
-          county_name: 'el_dorado',
-          # until we have users, TPT is saving the entire name in the last_name field
-          assigned_social_worker: { first_name: nil, last_name: 'Bob Smith' },
-          reporter: { first_name: 'Alex', last_name: 'Hanson' },
+          county: {
+            id: '1101',
+            description: 'El Dorado'
+          },
+          assigned_social_worker: { id: 'wrk1234', first_name: 'Bob', last_name: 'Smith' },
+          reporter: { id: 'rpt1234', first_name: 'Alex', last_name: 'Hanson' },
           all_people: [
             { first_name: 'Bob', last_name: 'Bob Smith', roles: ['Assigned Social Worker'] },
             { first_name: 'Alex', last_name: 'Hanson', roles: ['Reporter'] },
@@ -53,7 +56,10 @@ feature 'History card' do
         {
           start_date: '2016-08-10',
           end_date: '2016-11-12',
-          county_name: 'el_dorado',
+          county: {
+            id: '1101',
+            description: 'El Dorado'
+          },
           reporter: { first_name: nil, last_name: nil },
           assigned_social_worker: { first_name: nil, last_name: nil },
           all_people: []
@@ -64,10 +70,17 @@ feature 'History card' do
     let(:referrals) do
       [
         {
+          id: '1234',
           start_date: '2016-11-14',
           end_date: '2016-12-14',
-          response_time: 'Immediate',
-          county_name: 'Madera',
+          county: {
+            id: '1234',
+            description: 'Madera'
+          },
+          response_time: {
+            id: '1518',
+            description: 'Immediate'
+          },
           reporter: {
             first_name: 'Reporter1',
             last_name: 'r1LastName'
@@ -78,24 +91,34 @@ feature 'History card' do
           },
           allegations: [
             {
-              allegation_description: 'General Neglect',
-              disposition_description: 'Entered in Error',
-              perpetrator_first_name: 'Perpetrator1',
-              perpetrator_last_name: 'p1LastName',
-              victim_first_name: 'Victim1',
-              victim_last_name: 'v1LastName'
+              description: 'General Neglect',
+              disposition: {
+                id: '45',
+                description: 'Entered in Error'
+              },
+              victim: {
+                first_name: 'Victim1',
+                last_name: 'v1LastName'
+              },
+              perpetrator: {
+                first_name: 'Perpetrator1',
+                last_name: 'p1LastName'
+              }
             }
           ],
           legacy_descriptor: {
             legacy_ui_id: '0853-2115-5670-6000802'
           },
           access_limitation: {
-            limited_access_code: 'R'
+            limited_access_code: 'SEALED'
           }
         },
         {
           start_date: '2016-05-06',
-          county_name: 'San Francisco',
+          county: {
+            id: '415',
+            description: 'San Francisco'
+          },
           reporter: {
             first_name: 'Reporter2',
             last_name: 'r2LastName'
@@ -106,18 +129,22 @@ feature 'History card' do
           },
           allegations: [
             {
-              allegation_description: 'Severe Neglect',
-              perpetrator_first_name: 'Perpetrator2',
-              perpetrator_last_name: 'p2LastName',
-              victim_first_name: 'Victim2',
-              victim_last_name: 'v2LastName'
+              description: 'Severe Neglect',
+              victim: {
+                first_name: 'Victim2',
+                last_name: 'v2LastName'
+              },
+              perpetrator: {
+                first_name: 'Perpetrator2',
+                last_name: 'p2LastName'
+              }
             }
           ],
           legacy_descriptor: {
             legacy_ui_id: '0202-9769-1248-2000283'
           },
           access_limitation: {
-            limited_access_code: 'S'
+            limited_access_code: 'SENSETIVE'
           }
         }
       ]
@@ -133,18 +160,32 @@ feature 'History card' do
             id: '0rumtwQ0Bn',
             first_name: 'fChild1'
           },
-          county_name: 'El Dorado',
-          service_component: 'Family Reunification',
+          county: {
+            id: '1101',
+            description: 'El Dorado'
+          },
+          service_component: {
+            id: '1695',
+            description: 'Family Reunification'
+          },
           parents: [
             {
               last_name: 'p1Last',
               id: 'AbiQA5q0Bo',
-              first_name: 'Parent1'
+              first_name: 'Parent1',
+              relationship: {
+                id: 'p1234',
+                description: 'Father/Son (Step)'
+              }
             },
             {
               last_name: 'p2Last',
               id: 'CaTvuzq0Bo',
-              first_name: 'Parent2'
+              first_name: 'Parent2',
+              relationship: {
+                id: 'p1234',
+                description: 'Mother/Son (Adoptive)'
+              }
             }
           ],
           assigned_social_worker: {
@@ -155,7 +196,7 @@ feature 'History card' do
             legacy_ui_id: '0393-5909-1798-6027230'
           },
           access_limitation: {
-            limited_access_code: 'R'
+            limited_access_code: 'SEALED'
           }
         },
         {
@@ -165,17 +206,28 @@ feature 'History card' do
             id: '1234567',
             first_name: 'fChild2'
           },
-          county_name: 'Plumas',
+          county: {
+            id: 'p123',
+            description: 'Plumas'
+          },
           parents: [
             {
               last_name: 'p3Last',
               id: 'ABC123',
-              first_name: 'Parent3'
+              first_name: 'Parent3',
+              relationship: {
+                id: 'p1234',
+                description: 'Father/Son (Adoptive)'
+              }
             },
             {
               last_name: 'p4Last',
               id: 'ABCDEFG',
-              first_name: 'Parent4'
+              first_name: 'Parent4',
+              relationship: {
+                id: 'p1234',
+                description: 'Mother/Son (Adoptive)'
+              }
             }
           ],
           assigned_social_worker: {
@@ -186,7 +238,7 @@ feature 'History card' do
             legacy_ui_id: '0208-9997-9274-0000863'
           },
           access_limitation: {
-            limited_access_code: 'N'
+            limited_access_code: 'NONE'
           }
         }
       ]
@@ -201,6 +253,7 @@ feature 'History card' do
     end
 
     before do
+      pending 'Completion of HOI frontend'
       existing_screening.participants = [FactoryGirl.create(:participant)]
 
       stub_request(

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -272,6 +272,7 @@ feature 'Create participant' do
     end
 
     it 'hides the create new person button' do
+      stub_empty_history_for_screening(existing_screening)
       visit edit_screening_path(id: existing_screening.id)
       within '#search-card', text: 'Search' do
         fill_in_autocompleter 'Search for clients', with: 'Marge'
@@ -345,6 +346,7 @@ feature 'Create participant' do
   end
 
   scenario 'adding a participant from search on edit screening page' do
+    stub_empty_history_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
     homer_attributes = build_participant_from_person_and_screening(homer, existing_screening)
     participant_homer = FactoryGirl.build(:participant, homer_attributes)
@@ -436,6 +438,7 @@ feature 'Create participant' do
     context 'with NO privileges to add sensitive' do
       scenario 'cannot add sensitive' do
         Feature.run_with_activated(:authentication) do
+          stub_empty_history_for_screening(existing_screening)
           visit edit_screening_path(id: existing_screening.id, token: insensitive_token)
           sensitive_marge_attributes = build_participant_from_person_and_screening(
             marge,
@@ -466,6 +469,7 @@ feature 'Create participant' do
 
       scenario 'can add insensitive' do
         Feature.run_with_activated(:authentication) do
+          stub_empty_history_for_screening(existing_screening)
           visit edit_screening_path(id: existing_screening.id, token: insensitive_token)
           homer_attributes = build_participant_from_person_and_screening(
             homer,
@@ -500,6 +504,7 @@ feature 'Create participant' do
     context 'with privileges to add sensitive' do
       scenario 'can add sensitive person' do
         Feature.run_with_activated(:authentication) do
+          stub_empty_history_for_screening(existing_screening)
           visit edit_screening_path(id: existing_screening.id, token: sensitive_token)
           sensitive_marge_attributes = build_participant_from_person_and_screening(
             marge,
@@ -547,6 +552,7 @@ feature 'Create participant' do
       end
       scenario 'can add sensitive person' do
         Feature.run_with_activated(:authentication) do
+          stub_empty_history_for_screening(existing_screening)
           visit edit_screening_path(id: existing_screening.id, token: sensitive_token)
           homer_attributes = build_participant_from_person_and_screening(
             homer,
@@ -586,6 +592,7 @@ feature 'Create participant' do
     end
 
     scenario 'creating a participant from search adds participant in show mode' do
+      stub_empty_history_for_screening(existing_screening)
       visit edit_screening_path(id: existing_screening.id)
       homer_attributes = build_participant_from_person_and_screening(homer, existing_screening)
       participant_homer = FactoryGirl.build(:participant, homer_attributes)

--- a/spec/features/screening/relationships_card_spec.rb
+++ b/spec/features/screening/relationships_card_spec.rb
@@ -113,6 +113,7 @@ feature 'Relationship card' do
 
     describe 'editing a screening' do
       scenario 'loads relationships on initial page load' do
+        stub_empty_history_for_screening(participants_screening)
         visit edit_screening_path(id: participants_screening.id)
 
         within '#relationships-card.card.show', text: 'Relationships' do

--- a/spec/features/screening/submit_screening_spec.rb
+++ b/spec/features/screening/submit_screening_spec.rb
@@ -31,6 +31,7 @@ feature 'Submit Screening' do
         )
       end
       before do
+        stub_empty_history_for_screening(existing_screening)
         stub_request(
           :post,
           intake_api_url(ExternalRoutes.intake_api_screening_submit_path(existing_screening.id))
@@ -131,6 +132,8 @@ feature 'Submit Screening' do
         }
       end
       before do
+        stub_empty_history_for_screening(existing_screening)
+        visit edit_screening_path(existing_screening.id)
         stub_request(
           :post,
           intake_api_url(ExternalRoutes.intake_api_screening_submit_path(existing_screening.id))
@@ -190,6 +193,7 @@ feature 'Submit Screening' do
   context 'when referral submit is deactivated' do
     around do |example|
       Feature.run_with_deactivated(:referral_submit) do
+        stub_empty_history_for_screening(existing_screening)
         example.run
       end
     end

--- a/spec/features/screening/validations/screening_information_validations_spec.rb
+++ b/spec/features/screening/validations/screening_information_validations_spec.rb
@@ -188,6 +188,7 @@ feature 'Screening Information Validations' do
     before do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
         .and_return(json_body(screening.to_json, status: 200))
+      stub_empty_history_for_screening(screening)
 
       visit screening_path(id: screening.id)
     end

--- a/spec/lib/external_routes_spec.rb
+++ b/spec/lib/external_routes_spec.rb
@@ -73,6 +73,14 @@ describe ExternalRoutes do
     end
   end
 
+  describe '.ferb_api_screening_history_of_involvements_path' do
+    it 'returns /screenings/:id/history_of_involvements' do
+      expect(described_class.ferb_api_screening_history_of_involvements_path(82)).to eq(
+        '/screenings/82/history_of_involvements'
+      )
+    end
+  end
+
   describe '.ferb_api_investigations_contacts_path' do
     it 'returns /investigations/:id/contacts' do
       expect(described_class.ferb_api_investigations_contacts_path(33)).to eq(

--- a/spec/repositories/screening_repository_spec.rb
+++ b/spec/repositories/screening_repository_spec.rb
@@ -108,21 +108,30 @@ describe ScreeningRepository do
 
   describe '.history_of_involvements' do
     let(:screening_id) { '11' }
-    let(:response) { double(:response, body: screenings.to_json) }
-    let(:screening_one) { { id: '123456789' } }
-    let(:screening_two) { { id: '987654321' } }
-    let(:screenings) { [screening_one, screening_two] }
+    let(:cases) { [{ legacy_descriptor: '1234' }, { legacy_descriptor: '1235' }] }
+    let(:referrals) { [{ legacy_descriptor: '1236' }, { legacy_descriptor: '1237' }] }
+    let(:screenings) { [{ legacy_descriptor: '1238' }, { legacy_descriptor: '1239' }] }
+    let(:response) do
+      double(
+        :response,
+        body: { screenings: screenings, cases: cases, referrals: referrals }.to_json
+      )
+    end
 
     before do
-      expect(IntakeAPI).to receive(:make_api_call)
-        .with(security_token, "/api/v1/screenings/#{screening_id}/history_of_involvements", :get)
+      expect(FerbAPI).to receive(:make_api_call)
+        .with(security_token, "/screenings/#{screening_id}/history_of_involvements", :get)
         .and_return(response)
     end
 
     it 'returns the history of involvements' do
-      screenings = JSON.parse described_class.history_of_involvements(security_token, screening_id)
-      expect(screenings[0]['id']).to eq('123456789')
-      expect(screenings[1]['id']).to eq('987654321')
+      hoi = JSON.parse described_class.history_of_involvements(security_token, screening_id)
+      expect(hoi['cases'].first['legacy_descriptor']).to eq('1234')
+      expect(hoi['cases'].last['legacy_descriptor']).to eq('1235')
+      expect(hoi['referrals'].first['legacy_descriptor']).to eq('1236')
+      expect(hoi['referrals'].last['legacy_descriptor']).to eq('1237')
+      expect(hoi['screenings'].first['legacy_descriptor']).to eq('1238')
+      expect(hoi['screenings'].last['legacy_descriptor']).to eq('1239')
     end
   end
 

--- a/spec/support/helpers/screening_helpers.rb
+++ b/spec/support/helpers/screening_helpers.rb
@@ -53,10 +53,15 @@ module ScreeningHelpers
   end
 
   def stub_empty_history_for_screening(screening)
+    screening_id = if screening.is_a?(Hash)
+                     screening[:id]
+                   else
+                     screening.id
+                   end
     stub_request(
       :get,
-      intake_api_url(ExternalRoutes.intake_api_history_of_involvements_path(screening.id))
-    ).and_return(json_body([].to_json, status: 200))
+      ferb_api_url(ExternalRoutes.ferb_api_screening_history_of_involvements_path(screening_id))
+    ).and_return(json_body({ cases: [], referrals: [], screenings: [] }.to_json, status: 200))
   end
 
   def validate_message_as_user_interacts_with_date_field(


### PR DESCRIPTION
### Jira Story

- [Referral Implement referral HOI front-end INT-549](https://osi-cwds.atlassian.net/browse/INT-549)
- EPIC: [Retrieve HOI from Legacy via API, not ES. INT-548](https://osi-cwds.atlassian.net/browse/INT-548)

### Purpose

Update the controllers to call ferb screening hoi end point.

### Background

There are 3 stories part of this epic to update the front end display for screening, referral, and cases display in HOI. All three depend on the controller getting the content back from the api. Updates were made the test for screening HOI was marked pending until the front end can be complete.

### Notes for Reviewer

This is being merged into an epic branch until the front end changes are complete. The stub is up and running in ferb in preint, so after the front end changes are complete we will be able to merge and deploy this code.
