### PR TITLE
INT 17 Person Search Calls To The New Lighter ES Endpoint

### DIFF
--- a/app/javascript/reducers/peopleFormReducer.js
+++ b/app/javascript/reducers/peopleFormReducer.js
@@ -81,7 +81,7 @@ const buildPerson = ({
   gender: {value: gender},
   languages: {value: languages},
   last_name: {value: last_name},
-  legacy_descriptor: {value: legacy_descriptor},
+  legacy_descriptor: {value: legacy_descriptor || {}},
   middle_name: {value: middle_name},
   name_suffix: {value: name_suffix},
   phone_numbers: buildPhoneNumbers(phone_numbers),

--- a/app/javascript/sagas/createParticipantSaga.js
+++ b/app/javascript/sagas/createParticipantSaga.js
@@ -13,7 +13,17 @@ import {getScreeningIdValueSelector} from 'selectors/screeningSelectors'
 
 export function* createParticipant({payload: {person}}) {
   try {
-    const response = yield call(post, '/api/v1/participants', person)
+    const {screening_id, legacy_descriptor} = person
+    const {legacy_id, legacy_table_name} = legacy_descriptor || {}
+    const response = yield call(post, '/api/v1/participants', {
+      participant: {
+        screening_id,
+        legacy_descriptor: {
+          legacy_id,
+          legacy_table_name,
+        },
+      },
+    })
     yield put(createPersonSuccess(response))
     const screeningId = yield select(getScreeningIdValueSelector)
     yield put(fetchRelationships(screeningId))

--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -35,6 +35,10 @@ class ExternalRoutes
       "/api/v1/participants/#{id}"
     end
 
+    def intake_api_screening_people_path(id)
+      "/api/v1/screenings/#{id}/people"
+    end
+
     def intake_api_relationships_by_screening_path(id)
       "/api/v1/screenings/#{id}/relationships"
     end

--- a/app/repositories/participant_repository.rb
+++ b/app/repositories/participant_repository.rb
@@ -4,14 +4,23 @@
 # resource via the API
 class ParticipantRepository
   def self.create(security_token, participant)
-    participant_data = participant.as_json(except: :id)
     response = IntakeAPI.make_api_call(
       security_token,
-      ExternalRoutes.intake_api_participants_path,
+      ExternalRoutes.intake_api_screening_people_path(participant.screening_id.to_s),
       :post,
-      participant_data
+      post_data(participant).as_json
     )
     Participant.new(response.body)
+  end
+
+  def self.post_data(participant)
+    {
+      screening_id: participant.screening_id.to_s,
+      legacy_descriptor: {
+        legacy_id: participant.legacy_descriptor&.legacy_id,
+        legacy_table_name: participant.legacy_descriptor&.legacy_table_name
+      }
+    }
   end
 
   def self.delete(security_token, id)

--- a/app/repositories/person_search_repository.rb
+++ b/app/repositories/person_search_repository.rb
@@ -7,7 +7,7 @@ class PersonSearchRepository
     def search(security_token, search_term)
       response = DoraAPI.make_api_call(
         security_token,
-        Rails.application.routes.url_helpers.dora_people_path,
+        Rails.application.routes.url_helpers.dora_people_light_index_path,
         :post,
         PersonSearchQueryBuilder.new(search_term).build
       )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,7 @@ Rails.application.routes.draw do
   scope host: Rails.configuration.intake[:dora_api_url] do
     post '/dora/screenings/screening/_search' => 'dev#null', as: :dora_screenings
     post '/dora/people/person/_search' => 'dev#null', as: :dora_people
+    post '/dora/people-summary/person-summary/_search' => 'dev#null', as: :dora_people_light_index
   end
 
   resources :version, only: :index

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -45,7 +45,7 @@ feature 'home page' do
       expect(
         a_request(
           :post,
-          dora_api_url(Rails.application.routes.url_helpers.dora_people_path)
+          dora_api_url(Rails.application.routes.url_helpers.dora_people_light_index_path)
         )
       ).to have_been_made.times(1)
     end

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -237,15 +237,9 @@ feature 'Create participant' do
       :participant, :unpopulated,
       screening_id: existing_screening.id
     )
-    new_participant_request = {
-      screening_id: existing_screening.id,
-      legacy_id: nil,
-      legacy_source_table: nil,
-      legacy_descriptor: nil
-    }
 
-    stub_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
-      .with(body: created_participant_unknown.as_json(except: :id).merge(new_participant_request))
+    stub_request(:post,
+      intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
       .and_return(json_body(created_participant_unknown.to_json, status: 201))
 
     within '#search-card', text: 'Search' do
@@ -254,8 +248,8 @@ feature 'Create participant' do
       expect(page).to_not have_button('Create a new person')
     end
 
-    expect(a_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
-      .with(body: hash_including(new_participant_request)))
+    expect(a_request(:post,
+      intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id))))
       .to have_been_made
 
     within edit_participant_card_selector(created_participant_unknown.id) do
@@ -287,15 +281,17 @@ feature 'Create participant' do
     homer_attributes = build_participant_from_person_and_screening(homer, existing_screening)
     participant_homer = FactoryGirl.build(:participant, homer_attributes)
     created_participant_homer = FactoryGirl.create(:participant, participant_homer.as_json)
-    stub_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
+    stub_request(:post,
+      intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
       .and_return(json_body(created_participant_homer.to_json, status: 201))
 
     within '#search-card', text: 'Search' do
       fill_in_autocompleter 'Search for any person', with: 'Homer'
       find('li', text: 'Homer Simpson').click
     end
-    expect(a_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
-      .with(json_body(participant_homer.to_json(except: :id)))).to have_been_made
+    expect(a_request(:post,
+      intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id))))
+      .to have_been_made
 
     within edit_participant_card_selector(created_participant_homer.id) do
       within '.card-header' do
@@ -351,7 +347,8 @@ feature 'Create participant' do
     homer_attributes = build_participant_from_person_and_screening(homer, existing_screening)
     participant_homer = FactoryGirl.build(:participant, homer_attributes)
     created_participant_homer = FactoryGirl.create(:participant, participant_homer.as_json)
-    stub_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
+    stub_request(:post,
+      intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
       .and_return(json_body(created_participant_homer.to_json, status: 201))
 
     fill_in 'Title/Name of Screening', with: 'The Rocky Horror Picture Show'
@@ -360,8 +357,9 @@ feature 'Create participant' do
       fill_in_autocompleter 'Search for any person', with: 'Homer'
       find('li', text: 'Homer Simpson').click
     end
-    expect(a_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
-      .with(json_body(participant_homer.to_json(except: :id)))).to have_been_made
+    expect(a_request(:post,
+      intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id))))
+      .to have_been_made
 
     # adding participant doesnt change screening modifications
     expect(page).to have_field('Title/Name of Screening', with: 'The Rocky Horror Picture Show')
@@ -461,7 +459,8 @@ feature 'Create participant' do
             :participant,
             participant_homer.as_json
           )
-          stub_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
+          stub_request(:post,
+            intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
             .and_return(json_body(created_participant_homer.to_json, status: 201))
           within '#search-card', text: 'Search' do
             fill_in_autocompleter 'Search for any person', with: 'Ho'
@@ -487,14 +486,16 @@ feature 'Create participant' do
             :participant,
             sensitive_participant_marge.as_json
           )
-          stub_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
+          stub_request(:post,
+            intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
             .and_return(json_body(created_participant_marge.to_json, status: 201))
           within '#search-card', text: 'Search' do
             fill_in_autocompleter 'Search for any person', with: 'Ma'
             find('li', text: 'Marge Simpson').click
           end
-          expect(a_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
-            .with(json_body(sensitive_participant_marge.to_json(except: :id)))).to have_been_made
+          expect(a_request(:post,
+            intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id))))
+            .to have_been_made
           created_participant_selector = edit_participant_card_selector(
             created_participant_marge.id
           )
@@ -525,7 +526,8 @@ feature 'Create participant' do
             :participant,
             participant_homer.as_json
           )
-          stub_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
+          stub_request(:post,
+            intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
             .and_return(json_body(created_participant_homer.to_json, status: 201))
           within '#search-card', text: 'Search' do
             fill_in_autocompleter 'Search for any person', with: 'Ho'
@@ -550,15 +552,18 @@ feature 'Create participant' do
       homer_attributes = build_participant_from_person_and_screening(homer, existing_screening)
       participant_homer = FactoryGirl.build(:participant, homer_attributes)
       created_participant_homer = FactoryGirl.create(:participant, participant_homer.as_json)
-      stub_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
+      stub_request(:post,
+        intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
         .and_return(json_body(created_participant_homer.to_json, status: 201))
 
       within '#search-card', text: 'Search' do
         fill_in_autocompleter 'Search for clients', with: 'Ho'
         find('li', text: 'Homer Simpson').click
       end
-      expect(a_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
-        .with(json_body(participant_homer.to_json(except: :id)))).to have_been_made
+      expect(
+        a_request(:post,
+          intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
+      ).to have_been_made
 
       within show_participant_card_selector(created_participant_homer.id) do
         within '.card-header' do

--- a/spec/javascripts/sagas/createParticipantSagaSpec.js
+++ b/spec/javascripts/sagas/createParticipantSagaSpec.js
@@ -18,12 +18,13 @@ describe('createParticipantSaga', () => {
 })
 
 describe('createParticipant', () => {
-  const participant = {first_name: 'Michael'}
+  const params = {screening_id: '1', legacy_descriptor: {legacy_id: '1', legacy_table_name: 'table'}}
+  const participant = {first_name: 'Michael', ...params}
   const action = personCardActions.createPerson(participant)
 
   it('creates and puts participant and fetches relationships and history', () => {
     const gen = createParticipant(action)
-    expect(gen.next().value).toEqual(call(post, '/api/v1/participants', participant))
+    expect(gen.next().value).toEqual(call(post, '/api/v1/participants', {participant: params}))
     expect(gen.next(participant).value).toEqual(
       put(personCardActions.createPersonSuccess(participant))
     )
@@ -41,7 +42,7 @@ describe('createParticipant', () => {
 
   it('puts errors when errors are thrown', () => {
     const gen = createParticipant(action)
-    expect(gen.next().value).toEqual(call(post, '/api/v1/participants', participant))
+    expect(gen.next().value).toEqual(call(post, '/api/v1/participants', {participant: params}))
     const error = {responseJSON: 'some error'}
     expect(gen.throw(error).value).toEqual(
       put(personCardActions.createPersonFailure('some error'))

--- a/spec/lib/external_routes_spec.rb
+++ b/spec/lib/external_routes_spec.rb
@@ -53,6 +53,13 @@ describe ExternalRoutes do
     end
   end
 
+  describe '.intake_api_screening_people_path' do
+    it 'returns /api/v1/screenings/:id/people' do
+      route = '/api/v1/screenings/31/people'
+      expect(described_class.intake_api_screening_people_path(31)).to eq(route)
+    end
+  end
+
   describe '.intake_api_participant_path' do
     it 'returns /api/v1/participants/:id' do
       expect(described_class.intake_api_participant_path(31)).to eq('/api/v1/participants/31')

--- a/spec/repositories/participant_repository_spec.rb
+++ b/spec/repositories/participant_repository_spec.rb
@@ -10,13 +10,24 @@ describe ParticipantRepository do
     let(:response) do
       double(:response, body: { 'id' => participant_id, 'first_name' => 'New Participant' })
     end
+    let(:screening_id) { '1' }
     let(:participant) do
-      { id: nil, first_name: 'New Participant' }
+      Participant.new(id: nil, first_name: 'New Participant', screening_id: screening_id)
+    end
+
+    let(:payload) do
+      {
+        screening_id: screening_id,
+        legacy_descriptor: {
+          legacy_id: participant.legacy_descriptor&.legacy_id,
+          legacy_table_name: participant.legacy_descriptor&.legacy_table_name
+        }
+      }.as_json
     end
 
     before do
       expect(IntakeAPI).to receive(:make_api_call)
-        .with(security_token, '/api/v1/participants', :post, 'first_name' => 'New Participant')
+        .with(security_token, '/api/v1/screenings/1/people', :post, payload)
         .and_return(response)
     end
 

--- a/spec/repositories/person_search_repository_spec.rb
+++ b/spec/repositories/person_search_repository_spec.rb
@@ -76,7 +76,7 @@ describe PersonSearchRepository do
       let(:response) { double(:response, body: results, status: 200) }
       it 'returns the people search results' do
         expect(DoraAPI).to receive(:make_api_call)
-          .with(security_token, '/dora/people/person/_search', :post, query)
+          .with(security_token, '/dora/people-summary/person-summary/_search', :post, query)
           .and_return(response)
         expect(
           described_class.search(security_token, search_term)
@@ -108,7 +108,7 @@ describe PersonSearchRepository do
       let(:response) { double(:response, body: 'Some error payload', status: 401) }
       before do
         allow(DoraAPI).to receive(:make_api_call)
-          .with(security_token, '/dora/people/person/_search', :post, query)
+          .with(security_token, '/dora/people-summary/person-summary/_search', :post, query)
           .and_return(response)
       end
       it 'raises an error' do

--- a/spec/support/helpers/webmock_helpers.rb
+++ b/spec/support/helpers/webmock_helpers.rb
@@ -13,7 +13,7 @@ module WebmockHelpers
   def stub_person_search(search_term, person_response)
     stub_request(
       :post,
-      dora_api_url(Rails.application.routes.url_helpers.dora_people_path)
+      dora_api_url(Rails.application.routes.url_helpers.dora_people_light_index_path)
     )
       .with('body' => {
               'query' => {


### PR DESCRIPTION
### Jira Story

- [Person Search calls to the new, lighter ES endpoint INT-17](https://osi-cwds.atlassian.net/browse/INT-17)

### Purpose
To change intake to use the new light index for person search.

### Background
Person search doesn't need all the result details from elastic search. It only needs a subset, which is what the light index is for. We need to get the full result details when adding a person to the screening -- so that still uses the full index. To that end, we are using a new intake_api endpoint that returns the full result details for the front end when passing only the id. This new endpoint in intake_api uses the full index to get all the details.

### Notes for Reviewer
I Just now realized that I can change the front end to pass less information to intake when creating people on the screening, since we are using the new api endpoint. Will do that in this PR!