### PR TITLE
Fix person search address type

### DIFF
--- a/app/javascript/common/Autocompleter.jsx
+++ b/app/javascript/common/Autocompleter.jsx
@@ -115,7 +115,7 @@ export default class Autocompleter extends React.Component {
         city: address.city,
         state: address.state,
         streetAddress: address.street_address,
-        type: address.type,
+        type: '',
         zip: address.zip,
       },
       phoneNumber: phoneNumber && {

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -33,9 +33,9 @@ feature 'searching a participant in autocompleter' do
               'street_number' => 123,
               'street_name' => 'Fake St',
               'state_code' => 'NY',
-              city: 'Springfield',
-              zip: '12345',
-              'type' => 'Work'
+              'city' => 'Springfield',
+              'zip' => '12345',
+              'type' => ''
             }],
             date_of_birth: date_of_birth.to_s(:db),
             legacy_descriptor: {
@@ -139,7 +139,6 @@ feature 'searching a participant in autocompleter' do
         expect(page).to have_content 'SSN'
         expect(page).to have_content '1234'
         expect(page).to have_content '123-23-1234'
-        expect(page).to have_content 'Work'
         expect(page).to have_content '123 Fake St, Springfield, NY 12345'
         expect(page).to have_content 'Sensitive'
         expect(page).to_not have_content 'Sealed'

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -185,7 +185,6 @@ describe('<Autocompleter />', () => {
           city: 'Flushing',
           state: 'NM',
           zip: '11344',
-          type: 'School',
         }],
         phone_numbers: [{
           id: '2',
@@ -225,7 +224,7 @@ describe('<Autocompleter />', () => {
         city: 'Flushing',
         state: 'NM',
         zip: '11344',
-        type: 'School',
+        type: '',
       })
       expect(attributes.phoneNumber).toEqual({
         number: '994-907-6774',
@@ -266,7 +265,7 @@ describe('<Autocompleter />', () => {
         city: 'Flushing',
         state: 'NM',
         zip: '11344',
-        type: 'School',
+        type: '',
       })
     })
 
@@ -400,7 +399,7 @@ describe('<Autocompleter />', () => {
           city: 'Flushing',
           state: 'NM',
           zip: '11344',
-          type: 'School',
+          type: '',
         },
         phoneNumber: {
           number: '994-907-6774',


### PR DESCRIPTION
person search address type is currently being returned
as a JSON object. This will be rendered as an empty string
and resolved in story #INT-537.

[#INT-716]

### Jira Story

- [Name of Story INT-NNN](https://osi-cwds.atlassian.net/browse/INT-537)

### Purpose


### Background


### Questions for Reviewer


### Notes for Reviewer


### Testing Notes

