### PR TITLE
Int 409 additional information required if screen_out and evaluate_out are selected

### DIFF
--- a/.pairs
+++ b/.pairs
@@ -8,6 +8,7 @@ pairs:
   tc: Tyler Clemens; Tyler.Clemens
   tr: Thomas Ramirez; Thomas.Ramirez
   vp: Vinh Pham; Vinh.Pham
+  npg: Naga Pradeep Gajula; Pradeep.Gajula
 email:
   prefix: pair
   domain: OSI.ca.gov

--- a/app/javascript/containers/screenings/DecisionFormContainer.jsx
+++ b/app/javascript/containers/screenings/DecisionFormContainer.jsx
@@ -11,6 +11,7 @@ import {
   getResetValuesSelector,
   getRestrictionRationaleSelector,
   getScreeningWithEditsSelector,
+  getAdditionalInfoRequiredSelector,
 } from 'selectors/screening/decisionFormSelectors'
 import {save as saveScreening} from 'actions/screeningActions'
 import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
@@ -35,6 +36,7 @@ const mapStateToProps = (state) => (
     restrictionRationale: getRestrictionRationaleSelector(state).toJS(),
     screeningWithEdits: getScreeningWithEditsSelector(state).toJS(),
     sdmPath: sdmPath(),
+    isAdditionalInfoRequired: getAdditionalInfoRequiredSelector(state),
   }
 )
 
@@ -52,6 +54,7 @@ const mergeProps = (stateProps, dispatchProps) => {
     restrictionRationale,
     screeningWithEdits,
     sdmPath,
+    isAdditionalInfoRequired,
   } = stateProps
 
   const onSave = () => {
@@ -73,6 +76,9 @@ const mergeProps = (stateProps, dispatchProps) => {
     if (field === 'access_restrictions' && value === '') {
       dispatch(setField({field: 'restrictions_rationale', value: null}))
     }
+    if (field === 'additional_information' && value === '') {
+      dispatch(setField({field: 'additional_information', value: null}))
+    }
   }
   const onBlur = (field) => dispatch(touchField({field}))
 
@@ -90,6 +96,7 @@ const mergeProps = (stateProps, dispatchProps) => {
     onSave,
     restrictionRationale,
     sdmPath,
+    isAdditionalInfoRequired,
   }
 }
 

--- a/app/javascript/containers/screenings/DecisionFormContainer.jsx
+++ b/app/javascript/containers/screenings/DecisionFormContainer.jsx
@@ -76,9 +76,6 @@ const mergeProps = (stateProps, dispatchProps) => {
     if (field === 'access_restrictions' && value === '') {
       dispatch(setField({field: 'restrictions_rationale', value: null}))
     }
-    if (field === 'additional_information' && value === '') {
-      dispatch(setField({field: 'additional_information', value: null}))
-    }
   }
   const onBlur = (field) => dispatch(touchField({field}))
 

--- a/app/javascript/containers/screenings/DecisionShowContainer.jsx
+++ b/app/javascript/containers/screenings/DecisionShowContainer.jsx
@@ -4,6 +4,8 @@ import {
   getDecisionSelector,
   getDecisionDetailSelector,
   getRestrictionRationaleSelector,
+  getAdditionalInfoRequiredSelector,
+  getAdditionalInformationSelector,
 } from 'selectors/screening/decisionShowSelectors'
 import {getScreeningSelector} from 'selectors/screeningSelectors'
 import * as IntakeConfig from 'common/config'
@@ -15,13 +17,12 @@ const mapStateToProps = (state, ownProps) => {
     accessRestriction: {
       value: _.capitalize(getScreeningSelector(state).get('access_restrictions')),
     },
-    additionalInformation: {
-      value: getScreeningSelector(state).get('additional_information'),
-    },
+    additionalInformation: getAdditionalInformationSelector(state).toJS(),
     decision: getDecisionSelector(state).toJS(),
     decisionDetail: getDecisionDetailSelector(state).toJS(),
     restrictionRationale: getRestrictionRationaleSelector(state).toJS(),
     sdmPath: IntakeConfig.sdmPath(),
+    isAdditionalInfoRequired: getAdditionalInfoRequiredSelector(state),
   }
   if (!getScreeningIsReadOnlySelector(state)) {
     props = {

--- a/app/javascript/selectors/screening/decisionFormSelectors.js
+++ b/app/javascript/selectors/screening/decisionFormSelectors.js
@@ -112,7 +112,7 @@ export const getDecisionSelector = createSelector(
 export const getAdditionalInfoRequiredSelector = createSelector(
   getDecisionValueSelector,
   getDecisionDetailValueSelector,
-  (decision, decisionDetail) => (decision && decisionDetail && decision === 'screen_out' && decisionDetail === 'evaluate_out')
+  (decision, decisionDetail) => (decision && decision === 'screen_out' && decisionDetail && decisionDetail === 'evaluate_out')
 )
 
 export const getAdditionalInformationSelector = createSelector(

--- a/app/javascript/selectors/screening/decisionShowSelectors.js
+++ b/app/javascript/selectors/screening/decisionShowSelectors.js
@@ -35,7 +35,7 @@ export const getErrorsSelector = createSelector(
         }
       ),
       additional_information: combineCompact(
-        isRequiredIfCreate(additionalInformation, 'Please enter Additional Information', () => (
+        isRequiredIfCreate(additionalInformation, 'Please enter additional information', () => (
           decision === 'screen_out' && decisionDetail === 'evaluate_out'
         ))
       ),

--- a/app/javascript/selectors/screening/decisionShowSelectors.js
+++ b/app/javascript/selectors/screening/decisionShowSelectors.js
@@ -11,7 +11,8 @@ export const getErrorsSelector = createSelector(
   (state) => state.getIn(['screening', 'access_restrictions']) || '',
   (state) => state.getIn(['screening', 'restrictions_rationale']) || '',
   (state) => state.get('allegationsForm', List()),
-  (decision, decisionDetail, accessRestrictions, restrictionsRationale, allegations) => (
+  (state) => state.getIn(['screening', 'additional_information']) || '',
+  (decision, decisionDetail, accessRestrictions, restrictionsRationale, allegations, additionalInformation) => (
     fromJS({
       screening_decision: combineCompact(
         isRequiredCreate(decision, 'Please enter a decision'),
@@ -33,11 +34,26 @@ export const getErrorsSelector = createSelector(
           }
         }
       ),
+      additional_information: combineCompact(
+        isRequiredIfCreate(additionalInformation, 'Please enter Additional Information', () => (
+          decision === 'screen_out' && decisionDetail === 'evaluate_out'
+        ))
+      ),
       restrictions_rationale: combineCompact(
         isRequiredIfCreate(restrictionsRationale, 'Please enter an access restriction reason', () => (accessRestrictions))
       ),
     })
   )
+)
+
+export const getAdditionalInfoRequiredSelector = createSelector(
+  getScreeningSelector,
+  (screening) => {
+    const decision = screening.get('screening_decision')
+    const decisionDetail = screening.get('screening_decision_detail')
+    return (decision && decisionDetail && decision === 'screen_out' && decisionDetail === 'evaluate_out')
+  }
+
 )
 
 export const getDecisionSelector = createSelector(
@@ -73,5 +89,11 @@ export const getDecisionDetailSelector = createSelector(
 export const getRestrictionRationaleSelector = createSelector(
   (state) => state.getIn(['screening', 'restrictions_rationale']),
   (state) => getErrorsSelector(state).get('restrictions_rationale'),
+  (value, errors) => Map({value: value || '', errors})
+)
+
+export const getAdditionalInformationSelector = createSelector(
+  (state) => state.getIn(['screening', 'additional_information']),
+  (state) => getErrorsSelector(state).get('additional_information'),
   (value, errors) => Map({value: value || '', errors})
 )

--- a/app/javascript/selectors/screening/decisionShowSelectors.js
+++ b/app/javascript/selectors/screening/decisionShowSelectors.js
@@ -47,13 +47,9 @@ export const getErrorsSelector = createSelector(
 )
 
 export const getAdditionalInfoRequiredSelector = createSelector(
-  getScreeningSelector,
-  (screening) => {
-    const decision = screening.get('screening_decision')
-    const decisionDetail = screening.get('screening_decision_detail')
-    return (decision && decisionDetail && decision === 'screen_out' && decisionDetail === 'evaluate_out')
-  }
-
+  (state) => state.getIn(['screening', 'screening_decision']),
+  (state) => state.getIn(['screening', 'screening_decision_detail']),
+  (decision, decisionDetail) => (decision && decisionDetail && decision === 'screen_out' && decisionDetail === 'evaluate_out')
 )
 
 export const getDecisionSelector = createSelector(

--- a/app/javascript/views/ScreeningDecisionForm.jsx
+++ b/app/javascript/views/ScreeningDecisionForm.jsx
@@ -18,6 +18,7 @@ const ScreeningDecisionForm = ({
   onSave,
   restrictionRationale,
   sdmPath,
+  isAdditionalInfoRequired,
 }) => (
   <div className='card-body'>
     <div className='row'>
@@ -65,12 +66,20 @@ const ScreeningDecisionForm = ({
               </SelectField>
         }
         <div>
-          <label htmlFor='additional_information'>Additional information</label>
-          <textarea
-            id='additional_information'
-            onChange={({target: {value}}) => onChange('additional_information', value)}
-            value={additionalInformation.value}
-          />
+          <FormField
+            htmlFor='additional_information'
+            label='Additional information'
+            errors={additionalInformation.errors}
+            required = {isAdditionalInfoRequired}
+          >
+            <textarea
+              id='additional_information'
+              onChange={({target: {value}}) => onChange('additional_information', value)}
+              value={additionalInformation.value}
+              onBlur={() => onBlur('additional_information')}
+              maxLength='255'
+            />
+          </FormField>
         </div>
         <SelectField
           id='access_restrictions'
@@ -84,22 +93,22 @@ const ScreeningDecisionForm = ({
           ))}
         </SelectField>
         {accessRestriction.value &&
-                    <div>
-                      <FormField
-                        htmlFor='restrictions_rationale'
-                        label='Restrictions Rationale'
-                        errors={restrictionRationale.errors}
-                        required
-                      >
-                        <textarea
-                          id='restrictions_rationale'
-                          onChange={({target: {value}}) => onChange('restrictions_rationale', value)}
-                          value={restrictionRationale.value}
-                          onBlur={() => onBlur('restrictions_rationale')}
-                          maxLength='255'
-                        />
-                      </FormField>
-                    </div>
+          <div>
+            <FormField
+              htmlFor='restrictions_rationale'
+              label='Restrictions Rationale'
+              errors={restrictionRationale.errors}
+              required
+            >
+              <textarea
+                id='restrictions_rationale'
+                onChange={({target: {value}}) => onChange('restrictions_rationale', value)}
+                value={restrictionRationale.value}
+                onBlur={() => onBlur('restrictions_rationale')}
+                maxLength='255'
+              />
+            </FormField>
+          </div>
         }
       </div>
       <div className='col-md-6'>
@@ -146,6 +155,7 @@ ScreeningDecisionForm.propTypes = {
     value: PropTypes.string,
     label: PropTypes.string,
   })),
+  isAdditionalInfoRequired: PropTypes.bool,
   onBlur: PropTypes.func,
   onCancel: PropTypes.func,
   onChange: PropTypes.func,

--- a/app/javascript/views/ScreeningDecisionShow.jsx
+++ b/app/javascript/views/ScreeningDecisionShow.jsx
@@ -9,6 +9,7 @@ const ScreeningDecisionShow = ({
   decisionDetail,
   restrictionRationale,
   sdmPath,
+  isAdditionalInfoRequired,
 }) => (
   <div className='card-body'>
     <div className='row'>
@@ -31,7 +32,7 @@ const ScreeningDecisionShow = ({
       </div>
       <div className='row'>
         <div className='col-md-12'>
-          <ShowField label='Additional information'>
+          <ShowField label='Additional information' errors={additionalInformation.errors} required={isAdditionalInfoRequired}>
             {additionalInformation.value}
           </ShowField>
           {accessRestriction.value &&
@@ -67,6 +68,7 @@ ScreeningDecisionShow.propTypes = {
     required: PropTypes.bool,
     value: PropTypes.string,
   }),
+  isAdditionalInfoRequired: PropTypes.bool,
   restrictionRationale: PropTypes.shape({
     value: PropTypes.string,
   }),

--- a/spec/features/screening/validations/screening_decision_validations_spec.rb
+++ b/spec/features/screening/validations/screening_decision_validations_spec.rb
@@ -156,7 +156,7 @@ feature 'Screening Decision Validations' do
           error_message: error_message,
           screening_updates: { additional_information: 'My reason for evaluating out' }
         ) do
-          within '#decision-card.edit' do
+          within '.card', text: 'Decision' do
             fill_in 'Additional information', with: 'My reason for evaluating out'
           end
         end

--- a/spec/features/screening/validations/screening_decision_validations_spec.rb
+++ b/spec/features/screening/validations/screening_decision_validations_spec.rb
@@ -7,10 +7,14 @@ feature 'Screening Decision Validations' do
   let(:error_message) { 'Please enter at least one allegation to promote to referral.' }
   let(:perpetrator) { FactoryGirl.create(:participant, :perpetrator) }
   let(:victim) { FactoryGirl.create(:participant, :victim) }
+  let(:screening_decision_detail) { nil }
+  let(:additional_information) { nil }
   let(:screening) do
     FactoryGirl.create(
       :screening,
       participants: [perpetrator, victim],
+      screening_decision_detail: screening_decision_detail,
+      additional_information: additional_information,
       screening_decision: screening_decision
     )
   end
@@ -132,6 +136,35 @@ feature 'Screening Decision Validations' do
           within '#decision-card.edit' do
             select '3 days', from: 'Response time'
           end
+        end
+      end
+    end
+
+    context 'when screening decision is Screen Out and decision detail is Evaluate Out' do
+      let(:screening_decision) { 'screen_out' }
+      let(:screening_decision_detail) { 'evaluate_out' }
+      let(:error_message) { 'Please enter Additional Information' }
+
+      scenario 'displays no error on initial load' do
+        should_not_have_content error_message, inside: '#decision-card.edit'
+      end
+
+      scenario 'card displays errors until user enters additional information' do
+        validate_message_as_user_interacts_with_card(
+          invalid_screening: screening,
+          card_name: 'decision',
+          error_message: error_message,
+          screening_updates: { additional_information: 'My reason for evaluating out' }
+        ) do
+          within '#decision-card.edit' do
+            fill_in 'Additional information', with: 'My reason for evaluating out'
+          end
+        end
+      end
+
+      scenario 'additional information is required' do
+        within '.card', text: 'Decision' do
+          expect(page).to have_css 'label.required', text: 'Additional information'
         end
       end
     end
@@ -258,6 +291,25 @@ feature 'Screening Decision Validations' do
 
         within '#decision-card.show' do
           expect(page).to have_content(error_message)
+        end
+      end
+    end
+
+    context 'when screening decision is Screen Out and decision detail is Evaluate Out' do
+      let(:screening_decision) { 'screen_out' }
+      let(:screening_decision_detail) { 'evaluate_out' }
+      let(:error_message) { 'Please enter Additional Information' }
+
+      context 'displays no error' do
+        let(:additional_information) { 'not null' }
+        scenario 'when additional information is not null' do
+          should_not_have_content error_message, inside: '#decision-card.show'
+        end
+      end
+
+      context 'displays error' do
+        scenario 'when additional information is null' do
+          should_have_content error_message, inside: '#decision-card.show'
         end
       end
     end

--- a/spec/features/screening/validations/screening_decision_validations_spec.rb
+++ b/spec/features/screening/validations/screening_decision_validations_spec.rb
@@ -140,7 +140,7 @@ feature 'Screening Decision Validations' do
       end
     end
 
-    context 'when screening decision is Screen Out and decision detail is Evaluate Out' do
+    context 'when screening decision is ScreenOut, decision detail is EvaluateOut in edit mode' do
       let(:screening_decision) { 'screen_out' }
       let(:screening_decision_detail) { 'evaluate_out' }
       let(:error_message) { 'Please enter Additional Information' }
@@ -295,7 +295,7 @@ feature 'Screening Decision Validations' do
       end
     end
 
-    context 'when screening decision is Screen Out and decision detail is Evaluate Out' do
+    context 'when screening decision is ScreenOut, decision detail is EvaluateOut in show mode' do
       let(:screening_decision) { 'screen_out' }
       let(:screening_decision_detail) { 'evaluate_out' }
       let(:error_message) { 'Please enter Additional Information' }

--- a/spec/javascripts/selectors/screening/decisionFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/decisionFormSelectorsSpec.js
@@ -351,6 +351,13 @@ describe('screeningDecisionFormSelectors', () => {
         expect(getErrorsSelector(state).get('additional_information'))
           .toEqualImmutable(List())
       })
+
+      it('does not include an error message if decision is not screen out', () => {
+        const screeningDecisionForm = {screening_decision: 'not screen_out'}
+        const state = fromJS({screeningDecisionForm})
+        expect(getErrorsSelector(state).get('additional_information'))
+          .toEqualImmutable(List())
+      })
     })
 
     describe('restrictions rationale', () => {

--- a/spec/javascripts/selectors/screening/decisionFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/decisionFormSelectorsSpec.js
@@ -128,19 +128,19 @@ describe('screeningDecisionFormSelectors', () => {
   })
 
   describe('getAdditionalInfoRequiredSelector', () => {
-    it('returns the true if screening decision is screen_out and screening_decision_detail is evaluate_out', () => {
+    it('returns true if screening decision is screen_out and screening_decision_detail is evaluate_out', () => {
       const screeningDecisionForm = {screening_decision: {value: 'screen_out'}, screening_decision_detail: {value: 'evaluate_out'}}
       const state = fromJS({screeningDecisionForm})
       expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(true))
     })
 
-    it('returns the false if screening decision is screen_out and screening_decision_detail is not evaluate_out', () => {
+    it('returns false if screening decision is screen_out and screening_decision_detail is not evaluate_out', () => {
       const screeningDecisionForm = {screening_decision: {value: 'screen_out'}, screening_decision_detail: {value: 'not evaluate_out'}}
       const state = fromJS({screeningDecisionForm})
       expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(false))
     })
 
-    it('returns the false if screening decision is not screen_out', () => {
+    it('returns false if screening decision is not screen_out', () => {
       const screeningDecisionForm = {screening_decision: {value: 'not screen_out'}, screening_decision_detail: {value: 'evaluate_out'}}
       const state = fromJS({screeningDecisionForm})
       expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(false))

--- a/spec/javascripts/selectors/screening/decisionFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/decisionFormSelectorsSpec.js
@@ -15,6 +15,7 @@ import {
   getResetValuesSelector,
   getErrorsSelector,
   getVisibleErrorsSelector,
+  getAdditionalInfoRequiredSelector,
 } from 'selectors/screening/decisionFormSelectors'
 import * as matchers from 'jasmine-immutable-matchers'
 
@@ -123,6 +124,26 @@ describe('screeningDecisionFormSelectors', () => {
         value: 'screen_out',
         errors: [],
       }))
+    })
+  })
+
+  describe('getAdditionalInfoRequiredSelector', () => {
+    it('returns the true if screening decision is screen_out and screening_decision_detail is evaluate_out', () => {
+      const screeningDecisionForm = {screening_decision: {value: 'screen_out'}, screening_decision_detail: {value: 'evaluate_out'}}
+      const state = fromJS({screeningDecisionForm})
+      expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(true))
+    })
+
+    it('returns the false if screening decision is screen_out and screening_decision_detail is not evaluate_out', () => {
+      const screeningDecisionForm = {screening_decision: {value: 'screen_out'}, screening_decision_detail: {value: 'not evaluate_out'}}
+      const state = fromJS({screeningDecisionForm})
+      expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(false))
+    })
+
+    it('returns the false if screening decision is not screen_out', () => {
+      const screeningDecisionForm = {screening_decision: {value: 'not screen_out'}, screening_decision_detail: {value: 'evaluate_out'}}
+      const state = fromJS({screeningDecisionForm})
+      expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(false))
     })
   })
 
@@ -299,6 +320,35 @@ describe('screeningDecisionFormSelectors', () => {
         const screeningDecisionForm = {screening_decision: {value: 'screen_out'}}
         const state = fromJS({screeningDecisionForm})
         expect(getErrorsSelector(state).get('screening_decision_detail'))
+          .toEqualImmutable(List())
+      })
+    })
+
+    describe('additional information', () => {
+      it('includes an error message if decision is screen out and decision detail is evaluate out', () => {
+        const screeningDecisionForm = {
+          screening_decision: {value: 'screen_out'},
+          screening_decision_detail: {value: 'evaluate_out'},
+        }
+        const state = fromJS({screeningDecisionForm})
+        expect(getErrorsSelector(state).get('additional_information'))
+          .toEqualImmutable(List(['Please enter Additional Information']))
+      })
+
+      it('does not include an error message if decision is screen out and decision detail is anything other than evaluate out', () => {
+        const screeningDecisionForm = {
+          screening_decision: {value: 'screen_out'},
+          screening_decision_detail: {value: 'not evaluate_out'},
+        }
+        const state = fromJS({screeningDecisionForm})
+        expect(getErrorsSelector(state).get('additional_information'))
+          .toEqualImmutable(List())
+      })
+
+      it('does not include an error message if decision is screen out, and decision detail is empty', () => {
+        const screeningDecisionForm = {screening_decision: {value: 'screen_out'}}
+        const state = fromJS({screeningDecisionForm})
+        expect(getErrorsSelector(state).get('additional_information'))
           .toEqualImmutable(List())
       })
     })

--- a/spec/javascripts/selectors/screening/decisionShowSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/decisionShowSelectorsSpec.js
@@ -4,6 +4,8 @@ import {
   getDecisionDetailSelector,
   getErrorsSelector,
   getRestrictionRationaleSelector,
+  getAdditionalInfoRequiredSelector,
+  getAdditionalInformationSelector,
 } from 'selectors/screening/decisionShowSelectors'
 import * as matchers from 'jasmine-immutable-matchers'
 
@@ -153,6 +155,29 @@ describe('allegationShowSelectors', () => {
       })
     })
 
+    describe('additional information', () => {
+      it('includes an error message if decision is screen out and decision detail is evaluate out', () => {
+        const screening = {screening_decision: 'screen_out', screening_decision_detail: 'evaluate_out'}
+        const state = fromJS({screening})
+        expect(getErrorsSelector(state).get('additional_information'))
+          .toEqualImmutable(List(['Please enter Additional Information']))
+      })
+
+      it('does not include an error message if decision is screen out and decision detail is anything other than evaluate out', () => {
+        const screening = {screening_decision: 'screen_out', screening_decision_detail: 'consultation'}
+        const state = fromJS({screening})
+        expect(getErrorsSelector(state).get('additional_information'))
+          .toEqualImmutable(List())
+      })
+
+      it('does not include an error message if decision is screen out, and decision detail is empty', () => {
+        const screening = {screening_decision: 'screen_out'}
+        const state = fromJS({screening})
+        expect(getErrorsSelector(state).get('additional_information'))
+          .toEqualImmutable(List())
+      })
+    })
+
     describe('restrictions rationale', () => {
       it('returns an error if there is no rationale and access_restrictions is sensitive', () => {
         const screening = {access_restrictions: 'sensitive'}
@@ -170,6 +195,26 @@ describe('allegationShowSelectors', () => {
     })
   })
 
+  describe('getAdditionalInfoRequiredSelector', () => {
+    it('returns the true if screening decision is screen_out and screening_decision_detail is evaluate_out', () => {
+      const screening = {screening_decision: 'screen_out', screening_decision_detail: 'evaluate_out'}
+      const state = fromJS({screening})
+      expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(true))
+    })
+
+    it('returns the false if screening decision is screen_out and screening_decision_detail is not evaluate_out', () => {
+      const screening = {screening_decision: 'screen_out', screening_decision_detail: 'not evaluate_out'}
+      const state = fromJS({screening})
+      expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(false))
+    })
+
+    it('returns the false if screening decision is not screen_out', () => {
+      const screening = {screening_decision: 'not screen_out', screening_decision_detail: 'Immediate'}
+      const state = fromJS({screening})
+      expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(false))
+    })
+  })
+
   describe('getRestrictionRationaleSelector', () => {
     it('returns the proper value if one exists', () => {
       const screening = {restrictions_rationale: 'ABC'}
@@ -181,6 +226,26 @@ describe('allegationShowSelectors', () => {
       const screening = {restrictions_rationale: null}
       const state = fromJS({screening})
       expect(getRestrictionRationaleSelector(state).get('value')).toEqual('')
+    })
+  })
+
+  describe('getAdditionalInformationSelector', () => {
+    it('returns errors for screening decision', () => {
+      const screening = {additional_information: 'additional_information'}
+      const state = fromJS({screening})
+      expect(getAdditionalInformationSelector(state).get('errors')).toEqualImmutable(List())
+    })
+
+    it('returns the proper value if one exists', () => {
+      const screening = {additional_information: 'ABC'}
+      const state = fromJS({screening})
+      expect(getAdditionalInformationSelector(state).get('value')).toEqual('ABC')
+    })
+
+    it('returns an empty string if current value is null', () => {
+      const screening = {additional_information: null}
+      const state = fromJS({screening})
+      expect(getAdditionalInformationSelector(state).get('value')).toEqual('')
     })
   })
 })

--- a/spec/javascripts/selectors/screening/decisionShowSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/decisionShowSelectorsSpec.js
@@ -196,19 +196,19 @@ describe('allegationShowSelectors', () => {
   })
 
   describe('getAdditionalInfoRequiredSelector', () => {
-    it('returns the true if screening decision is screen_out and screening_decision_detail is evaluate_out', () => {
+    it('returns true if screening decision is screen_out and screening_decision_detail is evaluate_out', () => {
       const screening = {screening_decision: 'screen_out', screening_decision_detail: 'evaluate_out'}
       const state = fromJS({screening})
       expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(true))
     })
 
-    it('returns the false if screening decision is screen_out and screening_decision_detail is not evaluate_out', () => {
+    it('returns false if screening decision is screen_out and screening_decision_detail is not evaluate_out', () => {
       const screening = {screening_decision: 'screen_out', screening_decision_detail: 'not evaluate_out'}
       const state = fromJS({screening})
       expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(false))
     })
 
-    it('returns the false if screening decision is not screen_out', () => {
+    it('returns false if screening decision is not screen_out', () => {
       const screening = {screening_decision: 'not screen_out', screening_decision_detail: 'Immediate'}
       const state = fromJS({screening})
       expect(getAdditionalInfoRequiredSelector(state)).toEqualImmutable(fromJS(false))

--- a/spec/javascripts/selectors/screening/decisionShowSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/decisionShowSelectorsSpec.js
@@ -160,7 +160,7 @@ describe('allegationShowSelectors', () => {
         const screening = {screening_decision: 'screen_out', screening_decision_detail: 'evaluate_out'}
         const state = fromJS({screening})
         expect(getErrorsSelector(state).get('additional_information'))
-          .toEqualImmutable(List(['Please enter Additional Information']))
+          .toEqualImmutable(List(['Please enter additional information']))
       })
 
       it('does not include an error message if decision is screen out and decision detail is anything other than evaluate out', () => {
@@ -172,6 +172,13 @@ describe('allegationShowSelectors', () => {
 
       it('does not include an error message if decision is screen out, and decision detail is empty', () => {
         const screening = {screening_decision: 'screen_out'}
+        const state = fromJS({screening})
+        expect(getErrorsSelector(state).get('additional_information'))
+          .toEqualImmutable(List())
+      })
+
+      it('does not include an error message if decision is not screen out', () => {
+        const screening = {screening_decision: 'not screen_out'}
         const state = fromJS({screening})
         expect(getErrorsSelector(state).get('additional_information'))
           .toEqualImmutable(List())
@@ -227,6 +234,36 @@ describe('allegationShowSelectors', () => {
       const state = fromJS({screening})
       expect(getRestrictionRationaleSelector(state).get('value')).toEqual('')
     })
+
+    it('returns no error if access_restrictions is null and if restrictions_rationale is null', () => {
+      const screening = {access_restrictions: null, restrictions_rationale: null}
+      const state = fromJS({screening})
+      expect(getRestrictionRationaleSelector(state).get('errors')).toEqualImmutable(List())
+    })
+
+    it('returns error if access_restrictions is sealed and if restrictions_rationale is null', () => {
+      const screening = {access_restrictions: 'sealed', restrictions_rationale: null}
+      const state = fromJS({screening})
+      expect(getRestrictionRationaleSelector(state).get('errors')).toEqualImmutable(List(['Please enter an access restriction reason']))
+    })
+
+    it('returns no error if access_restrictions is sealed and if restrictions_rationale is not null', () => {
+      const screening = {access_restrictions: 'sealed', restrictions_rationale: 'My access restriction reason'}
+      const state = fromJS({screening})
+      expect(getRestrictionRationaleSelector(state).get('errors')).toEqualImmutable(List())
+    })
+
+    it('returns error if access_restrictions is sensitive and if restrictions_rationale is null', () => {
+      const screening = {access_restrictions: 'sensitive', restrictions_rationale: null}
+      const state = fromJS({screening})
+      expect(getRestrictionRationaleSelector(state).get('errors')).toEqualImmutable(List(['Please enter an access restriction reason']))
+    })
+
+    it('returns no error if access_restrictions is sensitive and if restrictions_rationale is not null', () => {
+      const screening = {access_restrictions: 'sensitive', restrictions_rationale: 'My access restriction reason'}
+      const state = fromJS({screening})
+      expect(getRestrictionRationaleSelector(state).get('errors')).toEqualImmutable(List())
+    })
   })
 
   describe('getAdditionalInformationSelector', () => {
@@ -246,6 +283,24 @@ describe('allegationShowSelectors', () => {
       const screening = {additional_information: null}
       const state = fromJS({screening})
       expect(getAdditionalInformationSelector(state).get('value')).toEqual('')
+    })
+
+    it('returns error if screening_decision is screen_out, screening_decision_detail is evaluate_out and additional_information is null', () => {
+      const screening = {screening_decision: 'screen_out', screening_decision_detail: 'evaluate_out', additional_information: null}
+      const state = fromJS({screening})
+      expect(getAdditionalInformationSelector(state).get('errors')).toEqualImmutable(List(['Please enter additional information']))
+    })
+
+    it('returns error if screening_decision is screen_out, screening_decision_detail is evaluate_out and additional_information is not null', () => {
+      const screening = {screening_decision: 'screen_out', screening_decision_detail: 'evaluate_out', additional_information: 'My additional information'}
+      const state = fromJS({screening})
+      expect(getAdditionalInformationSelector(state).get('errors')).toEqualImmutable(List())
+    })
+
+    it('returns error if screening_decision is screen_out, screening_decision_detail is not evaluate_out and additional_information is null', () => {
+      const screening = {screening_decision: 'screen_out', screening_decision_detail: 'not evaluate_out', additional_information: null}
+      const state = fromJS({screening})
+      expect(getAdditionalInformationSelector(state).get('errors')).toEqualImmutable(List())
     })
   })
 })

--- a/spec/javascripts/views/ScreeningDecisionFormSpec.jsx
+++ b/spec/javascripts/views/ScreeningDecisionFormSpec.jsx
@@ -307,6 +307,15 @@ describe('ScreeningDecisionForm', () => {
       additionalInformationTextArea.simulate('change', {target: {value: 'My new additional information'}})
       expect(onChange).toHaveBeenCalledWith('additional_information', 'My new additional information')
     })
+
+    it('calls the onBlur function when additional information is blurred', () => {
+      const additionalInformation = {value: 'My additional information about this screening!'}
+      const onBlur = jasmine.createSpy('onBlur')
+      const component = renderScreeningDecisionForm({additionalInformation, onBlur})
+      const additionalInformationTextArea = component.find('textarea[id="additional_information"]')
+      additionalInformationTextArea.simulate('blur')
+      expect(onBlur).toHaveBeenCalledWith('additional_information')
+    })
   })
 
   describe('access restriction select field', () => {

--- a/spec/javascripts/views/ScreeningDecisionFormSpec.jsx
+++ b/spec/javascripts/views/ScreeningDecisionFormSpec.jsx
@@ -12,6 +12,7 @@ describe('ScreeningDecisionForm', () => {
     decisionDetail = {label: ''},
     decisionDetailOptions = [],
     restrictionRationale = {},
+    isAdditionalInfoRequired = false,
     ...options
   }) => {
     const props = {
@@ -23,6 +24,7 @@ describe('ScreeningDecisionForm', () => {
       decisionDetail,
       decisionDetailOptions,
       restrictionRationale,
+      isAdditionalInfoRequired,
       ...options,
     }
     return shallow(<ScreeningDecisionForm {...props}/>)
@@ -273,10 +275,22 @@ describe('ScreeningDecisionForm', () => {
   describe('additional information text area', () => {
     it('renders the additional information text area with the proper default props', () => {
       const component = renderScreeningDecisionForm({})
-      const additionalInformationLabel = component.find('label[htmlFor="additional_information"]')
+      const additionalInformationLabel = component.find('FormField[htmlFor="additional_information"]')
       expect(additionalInformationLabel.exists()).toEqual(true)
       const additionalInformationTextArea = component.find('textarea[id="additional_information"]')
       expect(additionalInformationTextArea.exists()).toEqual(true)
+    })
+
+    it('renders the additional information label with required', () => {
+      const component = renderScreeningDecisionForm({isAdditionalInfoRequired: true})
+      const additionalInformationLabel = component.find('FormField[htmlFor="additional_information"]')
+      expect(additionalInformationLabel.props().required).toEqual(true)
+    })
+
+    it('renders the additional information label without required', () => {
+      const component = renderScreeningDecisionForm({isAdditionalInfoRequired: false})
+      const additionalInformationLabel = component.find('FormField[htmlFor="additional_information"]')
+      expect(additionalInformationLabel.props().required).toEqual(false)
     })
 
     it('passes the current value to the additional information text area', () => {

--- a/spec/javascripts/views/ScreeningDecisionShowSpec.jsx
+++ b/spec/javascripts/views/ScreeningDecisionShowSpec.jsx
@@ -92,6 +92,18 @@ describe('ScreeningDecisionShow', () => {
     expect(additionalInformation.children().text()).toEqual('My additional information')
   })
 
+  it('renders the additional information label with required', () => {
+    const component = renderScreeningDecisionShow({isAdditionalInfoRequired: true})
+    const additionalInformationLabel = component.find('ShowField[label="Additional information"]')
+    expect(additionalInformationLabel.props().required).toEqual(true)
+  })
+
+  it('renders the additional information label without required', () => {
+    const component = renderScreeningDecisionShow({isAdditionalInfoRequired: false})
+    const additionalInformationLabel = component.find('ShowField[label="Additional information"]')
+    expect(additionalInformationLabel.props().required).toEqual(false)
+  })
+
   it('renders access restrictions', () => {
     const component = renderScreeningDecisionShow({
       accessRestriction: {value: 'Sealed'},


### PR DESCRIPTION
### Jira Story

- [Additional Information field is required when Decision is `Screen out` AND Category is `Evaluate Out` INT-409](https://osi-cwds.atlassian.net/browse/INT-409)

### Purpose
additional information includes required if decision value is selected as screen_out and if decision_detail(category) value is selected as evaluate_out, throughs an error if additional information is left empty.
