### PR TITLE
Int 25 screening sidebar

### DIFF
--- a/app/assets/stylesheets/shame_overrides.scss
+++ b/app/assets/stylesheets/shame_overrides.scss
@@ -8,7 +8,7 @@ $react-wood-duck-warning-red: #ad2213;
 
 .anchor {
   display: block;
-  height: 8rem;
-  margin-top: -8rem;
+  height: 13rem;
+  margin-top: -13rem;
   visibility: hidden;
 }

--- a/app/assets/stylesheets/shame_overrides.scss
+++ b/app/assets/stylesheets/shame_overrides.scss
@@ -5,3 +5,10 @@ $react-wood-duck-warning-red: #ad2213;
   button.btn-warning { background-color: $react-wood-duck-warning-red; }
   button.btn.pull-right { margin-left: 15px; }
 }
+
+.anchor {
+  display: block;
+  height: 8rem;
+  margin-top: -8rem;
+  visibility: hidden;
+}

--- a/app/javascript/screenings/RelationshipsCard.jsx
+++ b/app/javascript/screenings/RelationshipsCard.jsx
@@ -4,11 +4,14 @@ import {EmptyRelationships} from 'investigations/Relationships'
 import RelationshipsContainer from 'screenings/RelationshipsContainer'
 
 const RelationshipsCard = ({areRelationshipsEmpty}) => (
-  <div id='relationships-card' className='card show double-gap-top'>
-    <div className='card-header'>
-      <span>Relationships</span>
+  <div>
+    <span className='anchor' id='relationships-card-anchor'/>
+    <div id='relationships-card' className='card show double-gap-top'>
+      <div className='card-header'>
+        <span>Relationships</span>
+      </div>
+      {areRelationshipsEmpty ? <EmptyRelationships /> : <RelationshipsContainer />}
     </div>
-    {areRelationshipsEmpty ? <EmptyRelationships /> : <RelationshipsContainer />}
   </div>
 )
 

--- a/app/javascript/screenings/RelationshipsCard.jsx
+++ b/app/javascript/screenings/RelationshipsCard.jsx
@@ -6,7 +6,7 @@ import RelationshipsContainer from 'screenings/RelationshipsContainer'
 const RelationshipsCard = ({areRelationshipsEmpty}) => (
   <div>
     <span className='anchor' id='relationships-card-anchor'/>
-    <div id='relationships-card' className='card show double-gap-top'>
+    <div id='relationships-card' className='card show double-gap-bottom'>
       <div className='card-header'>
         <span>Relationships</span>
       </div>

--- a/app/javascript/screenings/RelationshipsCard.jsx
+++ b/app/javascript/screenings/RelationshipsCard.jsx
@@ -2,17 +2,15 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import {EmptyRelationships} from 'investigations/Relationships'
 import RelationshipsContainer from 'screenings/RelationshipsContainer'
+import CardView from 'views/CardView'
 
 const RelationshipsCard = ({areRelationshipsEmpty}) => (
-  <div>
-    <span className='anchor' id='relationships-card-anchor'/>
-    <div id='relationships-card' className='card show double-gap-bottom'>
-      <div className='card-header'>
-        <span>Relationships</span>
-      </div>
-      {areRelationshipsEmpty ? <EmptyRelationships /> : <RelationshipsContainer />}
-    </div>
-  </div>
+  <CardView
+    id='relationships-card'
+    title='Relationships'
+    mode='show'
+    show={areRelationshipsEmpty ? <EmptyRelationships /> : <RelationshipsContainer />}
+  />
 )
 
 RelationshipsCard.propTypes = {

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -18,6 +18,7 @@ import PersonSearchFormContainer from 'containers/screenings/PersonSearchFormCon
 import ErrorDetail from 'common/ErrorDetail'
 import ScreeningInformationFormContainer from 'containers/screenings/ScreeningInformationFormContainer'
 import ScreeningInformationShowContainer from 'containers/screenings/ScreeningInformationShowContainer'
+import ScreeningSideBar from 'screenings/ScreeningSideBar'
 import NarrativeFormContainer from 'containers/screenings/NarrativeFormContainer'
 import NarrativeShowContainer from 'containers/screenings/NarrativeShowContainer'
 import IncidentInformationFormContainer from 'containers/screenings/IncidentInformationFormContainer'
@@ -56,7 +57,7 @@ export class ScreeningPage extends React.Component {
     checkStaffPermission('add_sensitive_people')
   }
 
-  render() {
+  renderScreeningPage() {
     const {referralId, editable, mode, loaded, hasApiValidationErrors, submitReferralErrors} = this.props
     const releaseTwoInactive = IntakeConfig.isFeatureInactive('release_two')
     const releaseTwo = IntakeConfig.isFeatureActive('release_two')
@@ -167,6 +168,19 @@ export class ScreeningPage extends React.Component {
       )
     } else {
       return (<div />)
+    }
+  }
+
+  render() {
+    if (IntakeConfig.isFeatureActive('release_two')) {
+      return this.renderScreeningPage()
+    } else {
+      return (
+        <div className='row'>
+          <ScreeningSideBar />
+          <div className='col-md-10'>{this.renderScreeningPage()}</div>
+        </div>
+      )
     }
   }
 }

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -71,7 +71,7 @@ export class ScreeningPage extends React.Component {
           }
           {
             releaseTwo &&
-              <div className='card edit double-gap-top' id='snapshot-card'>
+              <div className='card edit double-gap-bottom' id='snapshot-card'>
                 <div className='card-body'>
                   <div className='row'>
                     <div className='col-md-12'>

--- a/app/javascript/screenings/ScreeningSideBar.jsx
+++ b/app/javascript/screenings/ScreeningSideBar.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import {SideBar, NavLinks, NavLink} from 'react-wood-duck'
+
+const ScreeningSideBar = () => (
+  <div className='col-md-2 hide-mobile'>
+    <SideBar>
+      <NavLinks>
+        <NavLink text='Screening Information' href='#screening-information-card' />
+        <NavLink text='People & Roles' href='#search-card' />
+        <NavLink text='Narrative' href='#narrative-card' />
+        <NavLink text='Incident Information' href='#incident-information-card' />
+        <NavLink text='Allegations' href='#allegations-card' />
+        <NavLink text='Relationships' href='#relationships-card' />
+        <NavLink text='Worker Safety' href='#worker-safety-card' />
+        <NavLink text='History' href='#history-card' />
+        <NavLink text='Cross Report' href='#cross-report-card' />
+        <NavLink text='Decision' href='#decision-card' />
+      </NavLinks>
+    </SideBar>
+  </div>
+)
+
+export default ScreeningSideBar

--- a/app/javascript/screenings/ScreeningSideBar.jsx
+++ b/app/javascript/screenings/ScreeningSideBar.jsx
@@ -5,16 +5,16 @@ const ScreeningSideBar = () => (
   <div className='col-md-2 hide-mobile'>
     <SideBar>
       <NavLinks>
-        <NavLink text='Screening Information' href='#screening-information-card' />
-        <NavLink text='People & Roles' href='#search-card' />
-        <NavLink text='Narrative' href='#narrative-card' />
-        <NavLink text='Incident Information' href='#incident-information-card' />
-        <NavLink text='Allegations' href='#allegations-card' />
-        <NavLink text='Relationships' href='#relationships-card' />
-        <NavLink text='Worker Safety' href='#worker-safety-card' />
-        <NavLink text='History' href='#history-card' />
-        <NavLink text='Cross Report' href='#cross-report-card' />
-        <NavLink text='Decision' href='#decision-card' />
+        <NavLink text='Screening Information' href='#screening-information-card-anchor' />
+        <NavLink text='People & Roles' href='#search-card-anchor' />
+        <NavLink text='Narrative' href='#narrative-card-anchor' />
+        <NavLink text='Incident Information' href='#incident-information-card-anchor' />
+        <NavLink text='Allegations' href='#allegations-card-anchor' />
+        <NavLink text='Relationships' href='#relationships-card-anchor' />
+        <NavLink text='Worker Safety' href='#worker-safety-card-anchor' />
+        <NavLink text='History' href='#history-card-anchor' />
+        <NavLink text='Cross Report' href='#cross-report-card-anchor' />
+        <NavLink text='Decision' href='#decision-card-anchor' />
       </NavLinks>
     </SideBar>
   </div>

--- a/app/javascript/views/CardView.jsx
+++ b/app/javascript/views/CardView.jsx
@@ -4,21 +4,24 @@ import ClassNames from 'classnames'
 import EditLink from 'common/EditLink'
 
 const CardView = ({edit, id, mode, onEdit, show, title}) => (
-  <div className={ClassNames('card', mode, 'double-gap-top')} id={id}>
-    <div className='card-header'>
-      <span>{title}</span>
-      {onEdit &&
-        <EditLink
-          ariaLabel={`Edit ${title && title.toLowerCase()}`}
-          onClick={(event) => {
-            event.preventDefault()
-            onEdit()
-          }}
-        />
-      }
+  <div>
+    <span className='anchor' id={`${id}-anchor`}/>
+    <div className={ClassNames('card', mode, 'double-gap-top')} id={id}>
+      <div className='card-header'>
+        <span>{title}</span>
+        {onEdit &&
+          <EditLink
+            ariaLabel={`Edit ${title && title.toLowerCase()}`}
+            onClick={(event) => {
+              event.preventDefault()
+              onEdit()
+            }}
+          />
+        }
+      </div>
+      {mode === 'edit' && edit}
+      {mode === 'show' && show}
     </div>
-    {mode === 'edit' && edit}
-    {mode === 'show' && show}
   </div>
 )
 

--- a/app/javascript/views/CardView.jsx
+++ b/app/javascript/views/CardView.jsx
@@ -5,7 +5,7 @@ import EditLink from 'common/EditLink'
 
 const CardView = ({edit, id, mode, onEdit, show, title}) => (
   <div>
-    <span className='anchor' id={`${id}-anchor`}/>
+    <a className='anchor' id={`${id}-anchor`}/>
     <div className={ClassNames('card', mode, 'double-gap-bottom')} id={id}>
       <div className='card-header'>
         <span>{title}</span>

--- a/app/javascript/views/CardView.jsx
+++ b/app/javascript/views/CardView.jsx
@@ -6,7 +6,7 @@ import EditLink from 'common/EditLink'
 const CardView = ({edit, id, mode, onEdit, show, title}) => (
   <div>
     <span className='anchor' id={`${id}-anchor`}/>
-    <div className={ClassNames('card', mode, 'double-gap-top')} id={id}>
+    <div className={ClassNames('card', mode, 'double-gap-bottom')} id={id}>
       <div className='card-header'>
         <span>{title}</span>
         {onEdit &&

--- a/app/javascript/views/history/HistoryOfInvolvement.jsx
+++ b/app/javascript/views/history/HistoryOfInvolvement.jsx
@@ -7,7 +7,7 @@ class HistoryOfInvolvement extends React.Component {
     return (
       <div>
         <span className='anchor' id='history-card-anchor'/>
-        <div className='card show double-gap-top' id='history-card'>
+        <div className='card show double-gap-bottom' id='history-card'>
           <div className='card-header'>
             <span>History</span>
           </div>

--- a/app/javascript/views/history/HistoryOfInvolvement.jsx
+++ b/app/javascript/views/history/HistoryOfInvolvement.jsx
@@ -1,20 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import CardView from 'views/CardView'
 
 class HistoryOfInvolvement extends React.Component {
   render() {
     const {historyIsEmpty, empty, notEmpty} = this.props
     return (
-      <div>
-        <span className='anchor' id='history-card-anchor'/>
-        <div className='card show double-gap-bottom' id='history-card'>
-          <div className='card-header'>
-            <span>History</span>
-          </div>
-          {historyIsEmpty && empty}
-          {!historyIsEmpty && notEmpty}
-        </div>
-      </div>
+      <CardView
+        id='history-card'
+        title='History'
+        mode='show'
+        show={historyIsEmpty ? empty : notEmpty}
+      />
     )
   }
 }

--- a/app/javascript/views/history/HistoryOfInvolvement.jsx
+++ b/app/javascript/views/history/HistoryOfInvolvement.jsx
@@ -5,12 +5,15 @@ class HistoryOfInvolvement extends React.Component {
   render() {
     const {historyIsEmpty, empty, notEmpty} = this.props
     return (
-      <div className='card show double-gap-top' id='history-card'>
-        <div className='card-header'>
-          <span>History</span>
+      <div>
+        <span className='anchor' id='history-card-anchor'/>
+        <div className='card show double-gap-top' id='history-card'>
+          <div className='card-header'>
+            <span>History</span>
+          </div>
+          {historyIsEmpty && empty}
+          {!historyIsEmpty && notEmpty}
         </div>
-        {historyIsEmpty && empty}
-        {!historyIsEmpty && notEmpty}
       </div>
     )
   }

--- a/app/javascript/views/people/PersonSearchForm.jsx
+++ b/app/javascript/views/people/PersonSearchForm.jsx
@@ -26,7 +26,7 @@ const PersonSearchForm = ({
   )
   return (
     <div>
-      <span className='anchor' id='search-card-anchor'/>
+      <a className='anchor' id='search-card-anchor'/>
       <div className='card edit double-gap-top' id='search-card'>
         <div className='card-header'>
           <span>Search</span>

--- a/app/javascript/views/people/PersonSearchForm.jsx
+++ b/app/javascript/views/people/PersonSearchForm.jsx
@@ -25,33 +25,36 @@ const PersonSearchForm = ({
     />
   )
   return (
-    <div className='card edit double-gap-top' id='search-card'>
-      <div className='card-header'>
-        <span>Search</span>
-      </div>
-      <div className='card-body'>
-        <div className='row'>
-          <div className='col-md-12'>
-            {
-              IntakeConfig.isFeatureActive('release_two') &&
-                <label className='pull-left' htmlFor='screening_participants'>Search for clients</label>
-            }
-            {
-              IntakeConfig.isFeatureInactive('release_two') &&
-                <label className='pull-left' htmlFor='screening_participants'>Search for any person(Children, parents, collaterals, reporters, alleged perpetrators...)</label>
-            }
-            <Autocompleter
-              id='screening_participants'
-              onSelect={onSelect}
-              isSelectable={isSelectable}
-              footer={footer}
-              onClear={onClear}
-              onSearch={onSearch}
-              onChange={onChange}
-              searchTerm={searchTerm}
-              total={total}
-              results={results}
-            />
+    <div>
+      <span className='anchor' id='search-card-anchor'/>
+      <div className='card edit double-gap-top' id='search-card'>
+        <div className='card-header'>
+          <span>Search</span>
+        </div>
+        <div className='card-body'>
+          <div className='row'>
+            <div className='col-md-12'>
+              {
+                IntakeConfig.isFeatureActive('release_two') &&
+                  <label className='pull-left' htmlFor='screening_participants'>Search for clients</label>
+              }
+              {
+                IntakeConfig.isFeatureInactive('release_two') &&
+                  <label className='pull-left' htmlFor='screening_participants'>Search for any person(Children, parents, collaterals, reporters, alleged perpetrators...)</label>
+              }
+              <Autocompleter
+                id='screening_participants'
+                onSelect={onSelect}
+                isSelectable={isSelectable}
+                footer={footer}
+                onClear={onClear}
+                onSearch={onSearch}
+                onChange={onChange}
+                searchTerm={searchTerm}
+                total={total}
+                results={results}
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -88,6 +88,7 @@ feature 'Create Screening' do
         )
 
         stub_empty_history_for_screening(new_screening)
+        stub_empty_relationships_for_screening(new_screening)
         stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
           .with(body: as_json_without_root_id(new_screening))
           .and_return(json_body(new_screening.to_json, status: 201))
@@ -144,6 +145,7 @@ feature 'Create Screening' do
           assignee_staff_id: '1234'
         )
         stub_empty_history_for_screening(new_screening)
+        stub_empty_relationships_for_screening(new_screening)
         stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
           .with(body: as_json_without_root_id(new_screening))
           .and_return(json_body(new_screening.to_json, status: 201))
@@ -187,6 +189,7 @@ feature 'Create Screening' do
           assignee_staff_id: nil
         )
         stub_empty_history_for_screening(new_screening)
+        stub_empty_relationships_for_screening(new_screening)
         stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
           .with(body: as_json_without_root_id(new_screening))
           .and_return(json_body(new_screening.to_json, status: 201))
@@ -223,6 +226,8 @@ feature 'Create Screening' do
       address: { city: nil },
       assignee: nil
     )
+    stub_empty_history_for_screening(new_screening)
+    stub_empty_relationships_for_screening(new_screening)
     stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
       .with(body: as_json_without_root_id(new_screening))
       .and_return(json_body(new_screening.to_json, status: 201))

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -45,6 +45,8 @@ feature 'Create Screening' do
           'The Child Welfare History Snapshot allows you to search CWS/CMS for people and their'
         )
       end
+
+      expect(page).not_to have_css('.side-bar')
     end
   end
 

--- a/spec/features/screening/relationships_card_spec.rb
+++ b/spec/features/screening/relationships_card_spec.rb
@@ -123,12 +123,7 @@ feature 'Relationship card' do
       end
 
       scenario 'removing a person updates relationships' do
-        stub_request(
-          :get,
-          intake_api_url(
-            ExternalRoutes.intake_api_relationships_by_screening_path(participants_screening.id)
-          )
-        ).and_return(json_body([].to_json, status: 200))
+        stub_empty_relationships_for_screening(participants_screening)
         stub_request(
           :delete, intake_api_url(ExternalRoutes.intake_api_participant_path(participant.id))
         )

--- a/spec/features/screening/show_screening_spec.rb
+++ b/spec/features/screening/show_screening_spec.rb
@@ -44,6 +44,56 @@ feature 'Show Screening' do
     )
   end
 
+  scenario 'showing screening side bar' do
+    stub_county_agencies('c41')
+    stub_request(
+      :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+    ).and_return(json_body(existing_screening.to_json))
+    stub_empty_relationships_for_screening(existing_screening)
+    stub_empty_history_for_screening(existing_screening)
+
+    visit screening_path(id: existing_screening.id)
+
+    within '.side-bar' do
+      expect(page.find('a.link', text: 'Screening Information')[:href])
+        .to include('#screening-information-card-anchor')
+      expect(page.find('a.link', text: 'Narrative')[:href])
+        .to include('#narrative-card-anchor')
+      expect(page.find('a.link', text: 'Incident Information')[:href])
+        .to include('#incident-information-card-anchor')
+      expect(page.find('a.link', text: 'Allegations')[:href])
+        .to include('#allegations-card-anchor')
+      expect(page.find('a.link', text: 'Relationships')[:href])
+        .to include('#relationships-card-anchor')
+      expect(page.find('a.link', text: 'Worker Safety')[:href])
+        .to include('#worker-safety-card-anchor')
+      expect(page.find('a.link', text: 'History')[:href])
+        .to include('#history-card-anchor')
+      expect(page.find('a.link', text: 'Cross Report')[:href])
+        .to include('#cross-report-card-anchor')
+      expect(page.find('a.link', text: 'Decision')[:href])
+        .to include('#decision-card-anchor')
+    end
+
+    within '.col-md-10' do
+      expect(page).to have_css('span.anchor#screening-information-card-anchor', visible: false)
+      expect(page).to have_css('span.anchor#narrative-card-anchor', visible: false)
+      expect(page).to have_css('span.anchor#incident-information-card-anchor', visible: false)
+      expect(page).to have_css('span.anchor#allegations-card-anchor', visible: false)
+      expect(page).to have_css('span.anchor#relationships-card-anchor', visible: false)
+      expect(page).to have_css('span.anchor#worker-safety-card-anchor', visible: false)
+      expect(page).to have_css('span.anchor#history-card-anchor', visible: false)
+      expect(page).to have_css('span.anchor#cross-report-card-anchor', visible: false)
+      expect(page).to have_css('span.anchor#decision-card-anchor', visible: false)
+    end
+
+    expect(page).to have_selector('#decision-card', visible: false)
+    click_link 'Decision'
+    expect(page).to have_selector('#decision-card', visible: true)
+    click_link 'Screening Information'
+    expect(page).to have_selector('#screening-information-card', visible: true)
+  end
+
   scenario 'showing existing screening' do
     stub_county_agencies('c41')
     stub_request(

--- a/spec/features/screening/show_screening_spec.rb
+++ b/spec/features/screening/show_screening_spec.rb
@@ -76,15 +76,15 @@ feature 'Show Screening' do
     end
 
     within '.col-md-10' do
-      expect(page).to have_css('span.anchor#screening-information-card-anchor', visible: false)
-      expect(page).to have_css('span.anchor#narrative-card-anchor', visible: false)
-      expect(page).to have_css('span.anchor#incident-information-card-anchor', visible: false)
-      expect(page).to have_css('span.anchor#allegations-card-anchor', visible: false)
-      expect(page).to have_css('span.anchor#relationships-card-anchor', visible: false)
-      expect(page).to have_css('span.anchor#worker-safety-card-anchor', visible: false)
-      expect(page).to have_css('span.anchor#history-card-anchor', visible: false)
-      expect(page).to have_css('span.anchor#cross-report-card-anchor', visible: false)
-      expect(page).to have_css('span.anchor#decision-card-anchor', visible: false)
+      expect(page).to have_css('a.anchor#screening-information-card-anchor', visible: false)
+      expect(page).to have_css('a.anchor#narrative-card-anchor', visible: false)
+      expect(page).to have_css('a.anchor#incident-information-card-anchor', visible: false)
+      expect(page).to have_css('a.anchor#allegations-card-anchor', visible: false)
+      expect(page).to have_css('a.anchor#relationships-card-anchor', visible: false)
+      expect(page).to have_css('a.anchor#worker-safety-card-anchor', visible: false)
+      expect(page).to have_css('a.anchor#history-card-anchor', visible: false)
+      expect(page).to have_css('a.anchor#cross-report-card-anchor', visible: false)
+      expect(page).to have_css('a.anchor#decision-card-anchor', visible: false)
     end
 
     expect(page).to have_selector('#decision-card', visible: false)

--- a/spec/javascripts/components/screenings/RelationshipsCardSpec.jsx
+++ b/spec/javascripts/components/screenings/RelationshipsCardSpec.jsx
@@ -16,6 +16,11 @@ describe('RelationshipsCard', () => {
     })
   })
 
+  it('renders a card anchor', () => {
+    const component = renderRelationshipsCard({areRelationshipsEmpty: true})
+    expect(component.find('.anchor').exists()).toBe(true)
+  })
+
   it('renders a relationships component when there are relationships', () => {
     const component = renderRelationshipsCard({areRelationshipsEmpty: false})
     expect(component.find(RelationshipsContainer).exists()).toEqual(true)

--- a/spec/javascripts/components/screenings/RelationshipsCardSpec.jsx
+++ b/spec/javascripts/components/screenings/RelationshipsCardSpec.jsx
@@ -9,20 +9,13 @@ describe('RelationshipsCard', () => {
     shallow(<RelationshipsCard {...props}/>)
   )
 
-  describe('EmptyRelationships', () => {
-    it('renders an empty relationships component', () => {
-      const component = renderRelationshipsCard({areRelationshipsEmpty: true})
-      expect(component.find(EmptyRelationships).exists()).toEqual(true)
-    })
-  })
-
-  it('renders a card anchor', () => {
+  it('renders an empty relationships component when there are no relationships', () => {
     const component = renderRelationshipsCard({areRelationshipsEmpty: true})
-    expect(component.find('.anchor').exists()).toBe(true)
+    expect(component.find('CardView').props().show).toEqual(<EmptyRelationships />)
   })
 
-  it('renders a relationships component when there are relationships', () => {
+  it('renders a relationships container when there are relationships', () => {
     const component = renderRelationshipsCard({areRelationshipsEmpty: false})
-    expect(component.find(RelationshipsContainer).exists()).toEqual(true)
+    expect(component.find('CardView').props().show).toEqual(<RelationshipsContainer />)
   })
 })

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -6,17 +6,18 @@ import {mount, shallow} from 'enzyme'
 
 describe('ScreeningPage', () => {
   const sdmPath = 'https://ca.sdmdata.org'
+  let isFeatureActiveSpy
 
   beforeEach(() => {
     spyOn(IntakeConfig, 'isFeatureInactive').and.returnValue(true)
-    spyOn(IntakeConfig, 'isFeatureActive').and.returnValue(false)
+    isFeatureActiveSpy = spyOn(IntakeConfig, 'isFeatureActive').and.returnValue(false)
     spyOn(IntakeConfig, 'sdmPath').and.returnValue(sdmPath)
   })
 
   function renderScreeningPage({
     actions = {},
     editable = true,
-    loaded,
+    loaded = true,
     mode,
     params = {},
     participants = List(),
@@ -129,7 +130,6 @@ describe('ScreeningPage', () => {
       it('renders the error detail card', () => {
         const submitReferralErrors = ['a', 'b', 'c']
         const component = renderScreeningPage({
-          loaded: true,
           mode: 'edit',
           submitReferralErrors,
           hasApiValidationErrors: true,
@@ -143,7 +143,6 @@ describe('ScreeningPage', () => {
       it('does not render the error detail card', () => {
         const submitReferralErrors = []
         const component = renderScreeningPage({
-          loaded: true,
           mode: 'edit',
           submitReferralErrors,
           hasApiValidationErrors: false,
@@ -155,7 +154,7 @@ describe('ScreeningPage', () => {
     describe('in edit mode', () => {
       let component
       beforeEach(() => {
-        component = renderScreeningPage({loaded: true, mode: 'edit'})
+        component = renderScreeningPage({mode: 'edit'})
       })
 
       it('does not render home and edit links', () => {
@@ -177,7 +176,6 @@ describe('ScreeningPage', () => {
         const heading = renderScreeningPage({
           mode: 'show',
           referralId: '123456',
-          loaded: true,
         }).find('h1')
         expect(heading.text()).toEqual('Referral #123456')
       })
@@ -191,7 +189,6 @@ describe('ScreeningPage', () => {
       let component
       beforeEach(() => {
         component = renderScreeningPage({
-          loaded: true,
           mode: 'show',
           participants: fromJS([{id: 'id-1'}, {id: 'id-2'}]),
           params: {id: '1'},
@@ -258,7 +255,21 @@ describe('ScreeningPage', () => {
 
   describe('when screening is not loaded', () => {
     it('renders an empty div', () => {
+      isFeatureActiveSpy.and.returnValue(true)
       expect(renderScreeningPage({loaded: false}).html()).toEqual('<div></div>')
+    })
+  })
+
+  describe('in snapshot', () => {
+    it('does not render a sidebar', () => {
+      isFeatureActiveSpy.and.returnValue(true)
+      expect(renderScreeningPage({loaded: false}).find('ScreeningSideBar').exists()).toBe(false)
+    })
+  })
+
+  describe('in hotline', () => {
+    it('renders a sidebar', () => {
+      expect(renderScreeningPage({loaded: false}).find('ScreeningSideBar').exists()).toBe(true)
     })
   })
 })

--- a/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import {shallow} from 'enzyme'
+import ScreeningSideBar from 'screenings/ScreeningSideBar'
+
+describe('ScreeningSideBar', () => {
+  let component
+  beforeEach(() => {
+    component = shallow(<ScreeningSideBar />)
+  })
+
+  it('renders the div wrapper', () => {
+    expect(component.find('div.col-md-2').exists()).toBe(true)
+  })
+
+  it('renders the SideBar component', () => {
+    expect(component.find('SideBar').exists()).toBe(true)
+  })
+
+  it('renders a link to the Screening Information card', () => {
+    expect(component.find('NavLink[text="Screening Information"]').props().href)
+      .toBe('#screening-information-card')
+  })
+
+  describe('People & Roles', () => {
+    it('renders a link to the People Search card', () => {
+      expect(component.find('NavLink[text="People & Roles"]').props().href
+      ).toBe('#search-card')
+    })
+  })
+
+  it('renders a link to the Narrative card', () => {
+    expect(component.find('NavLink[text="Narrative"]').props().href)
+      .toBe('#narrative-card')
+  })
+
+  it('renders a link to the Incident Information card', () => {
+    expect(component.find('NavLink[text="Incident Information"]').props().href)
+      .toBe('#incident-information-card')
+  })
+
+  it('renders a link to the Allegations card', () => {
+    expect(component.find('NavLink[text="Allegations"]').props().href)
+      .toBe('#allegations-card')
+  })
+
+  it('renders a link to the Relationships card', () => {
+    expect(component.find('NavLink[text="Relationships"]').props().href)
+      .toBe('#relationships-card')
+  })
+
+  it('renders a link to the Worker Safety card', () => {
+    expect(component.find('NavLink[text="Worker Safety"]').props().href)
+      .toBe('#worker-safety-card')
+  })
+
+  it('renders a link to the History card', () => {
+    expect(component.find('NavLink[text="History"]').props().href)
+      .toBe('#history-card')
+  })
+
+  it('renders a link to the Cross Report card', () => {
+    expect(component.find('NavLink[text="Cross Report"]').props().href)
+      .toBe('#cross-report-card')
+  })
+
+  it('renders a link to the Decision card', () => {
+    expect(component.find('NavLink[text="Decision"]').props().href)
+      .toBe('#decision-card')
+  })
+})

--- a/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
@@ -18,53 +18,53 @@ describe('ScreeningSideBar', () => {
 
   it('renders a link to the Screening Information card', () => {
     expect(component.find('NavLink[text="Screening Information"]').props().href)
-      .toBe('#screening-information-card')
+      .toBe('#screening-information-card-anchor')
   })
 
   describe('People & Roles', () => {
     it('renders a link to the People Search card', () => {
       expect(component.find('NavLink[text="People & Roles"]').props().href
-      ).toBe('#search-card')
+      ).toBe('#search-card-anchor')
     })
   })
 
   it('renders a link to the Narrative card', () => {
     expect(component.find('NavLink[text="Narrative"]').props().href)
-      .toBe('#narrative-card')
+      .toBe('#narrative-card-anchor')
   })
 
   it('renders a link to the Incident Information card', () => {
     expect(component.find('NavLink[text="Incident Information"]').props().href)
-      .toBe('#incident-information-card')
+      .toBe('#incident-information-card-anchor')
   })
 
   it('renders a link to the Allegations card', () => {
     expect(component.find('NavLink[text="Allegations"]').props().href)
-      .toBe('#allegations-card')
+      .toBe('#allegations-card-anchor')
   })
 
   it('renders a link to the Relationships card', () => {
     expect(component.find('NavLink[text="Relationships"]').props().href)
-      .toBe('#relationships-card')
+      .toBe('#relationships-card-anchor')
   })
 
   it('renders a link to the Worker Safety card', () => {
     expect(component.find('NavLink[text="Worker Safety"]').props().href)
-      .toBe('#worker-safety-card')
+      .toBe('#worker-safety-card-anchor')
   })
 
   it('renders a link to the History card', () => {
     expect(component.find('NavLink[text="History"]').props().href)
-      .toBe('#history-card')
+      .toBe('#history-card-anchor')
   })
 
   it('renders a link to the Cross Report card', () => {
     expect(component.find('NavLink[text="Cross Report"]').props().href)
-      .toBe('#cross-report-card')
+      .toBe('#cross-report-card-anchor')
   })
 
   it('renders a link to the Decision card', () => {
     expect(component.find('NavLink[text="Decision"]').props().href)
-      .toBe('#decision-card')
+      .toBe('#decision-card-anchor')
   })
 })

--- a/spec/javascripts/views/CardViewSpec.jsx
+++ b/spec/javascripts/views/CardViewSpec.jsx
@@ -7,6 +7,11 @@ describe('Card View', () => {
     shallow(<CardView {...props} />)
   )
 
+  it('renders a card anchor', () => {
+    const card = renderCardView()
+    expect(card.find('.anchor').exists()).toBe(true)
+  })
+
   it('renders a card', () => {
     const card = renderCardView()
     expect(card.find('.card').exists()).toEqual(true)

--- a/spec/javascripts/views/history/HistoryOfInvolvementSpec.jsx
+++ b/spec/javascripts/views/history/HistoryOfInvolvementSpec.jsx
@@ -7,6 +7,11 @@ describe('HistoryOfInvolvement', () => {
     return shallow(<HistoryOfInvolvement historyIsEmpty={historyIsEmpty} />)
   }
 
+  it('renders a card anchor', () => {
+    const component = renderHistoryOfInvolvement({})
+    expect(component.find('.anchor').exists()).toBe(true)
+  })
+
   it('displays a card header', () => {
     const component = renderHistoryOfInvolvement({})
     const cardHead = component.find('.card-header')
@@ -21,7 +26,7 @@ describe('HistoryOfInvolvement', () => {
         notEmpty={<p>Goodbye!</p>}
       />
     )
-    expect(component.children('p').at(0).text()).toEqual('Hello!')
+    expect(component.find('p').text()).toEqual('Hello!')
     expect(component.text()).not.toContain('Goodbye!')
   })
 
@@ -33,7 +38,7 @@ describe('HistoryOfInvolvement', () => {
         notEmpty={<p>Goodbye!</p>}
       />
     )
-    expect(component.children('p').at(0).text()).toEqual('Goodbye!')
+    expect(component.find('p').text()).toEqual('Goodbye!')
     expect(component.text()).not.toContain('Hello!')
   })
 })

--- a/spec/javascripts/views/history/HistoryOfInvolvementSpec.jsx
+++ b/spec/javascripts/views/history/HistoryOfInvolvementSpec.jsx
@@ -3,21 +3,6 @@ import React from 'react'
 import {shallow} from 'enzyme'
 
 describe('HistoryOfInvolvement', () => {
-  function renderHistoryOfInvolvement({historyIsEmpty = true}) {
-    return shallow(<HistoryOfInvolvement historyIsEmpty={historyIsEmpty} />)
-  }
-
-  it('renders a card anchor', () => {
-    const component = renderHistoryOfInvolvement({})
-    expect(component.find('.anchor').exists()).toBe(true)
-  })
-
-  it('displays a card header', () => {
-    const component = renderHistoryOfInvolvement({})
-    const cardHead = component.find('.card-header')
-    expect(cardHead.html()).toContain('History')
-  })
-
   it('renders an empty history card when history is not present', () => {
     const component = shallow(
       <HistoryOfInvolvement
@@ -26,8 +11,8 @@ describe('HistoryOfInvolvement', () => {
         notEmpty={<p>Goodbye!</p>}
       />
     )
-    expect(component.find('p').text()).toEqual('Hello!')
-    expect(component.text()).not.toContain('Goodbye!')
+    expect(component.html()).toContain('<p>Hello!</p>')
+    expect(component.html()).not.toContain('Goodbye!')
   })
 
   it('renders a history table when history is present', () => {
@@ -38,7 +23,7 @@ describe('HistoryOfInvolvement', () => {
         notEmpty={<p>Goodbye!</p>}
       />
     )
-    expect(component.find('p').text()).toEqual('Goodbye!')
-    expect(component.text()).not.toContain('Hello!')
+    expect(component.html()).toContain('<p>Goodbye!</p>')
+    expect(component.html()).not.toContain('Hello!')
   })
 })

--- a/spec/javascripts/views/people/PersonSearchFormSpec.jsx
+++ b/spec/javascripts/views/people/PersonSearchFormSpec.jsx
@@ -34,6 +34,11 @@ describe('PersonSearchForm', () => {
     )
   }
 
+  it('renders a card anchor', () => {
+    const component = renderPersonSearchForm({})
+    expect(component.find('.anchor').exists()).toBe(true)
+  })
+
   it('renders the autocompleter', () => {
     const component = renderPersonSearchForm({})
     const autocompleter = component.find('Autocompleter')
@@ -79,7 +84,7 @@ describe('PersonSearchForm', () => {
 
   it('renders the card header', () => {
     const component = renderPersonSearchForm({})
-    expect(component.children('.card-header').children('span').text()).toContain('Search')
+    expect(component.find('.card-header').children('span').text()).toContain('Search')
   })
 
   describe('search card', () => {


### PR DESCRIPTION
### Jira Story

- [Integrate Left Side Navigation from DesignOps into Intake INT-25](https://osi-cwds.atlassian.net/browse/INT-25)

### Purpose
Implement react-wood-duck Sidebar for Hotline screenings

### Notes for Reviewer
- Displaying individuals under People and roles is out of scope for this story.
- Changes to be done on the react-wood-duck component is out of scope for this stor
- Displaying validation notification is out of scope of this story.

### Testing Notes
- A number of bugs has been reported. See original story.

Passed CI testing:
https://ci.mycasebook.org/job/intake_test_phase/job/int_25_screening_sidebar/