### PR TITLE
remove null from getSystemErrorIncidentIdsSelector

### DIFF
--- a/app/javascript/selectors/errorsSelectors.js
+++ b/app/javascript/selectors/errorsSelectors.js
@@ -23,7 +23,7 @@ export const getScreeningSubmissionErrorsSelector = createSelector(
 )
 export const getSystemErrorIncidentIdsSelector = createSelector(
   getSystemErrorsSelector,
-  (systemErrors) => (systemErrors.map((error) => (error.get('incident_id'))))
+  (systemErrors) => (systemErrors.map((error) => (error.get('incident_id'))).filter((item) => item))
 )
 export const getPageErrorMessageValueSelector = createSelector(
   getErrors,

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -81,8 +81,8 @@ feature 'error pages' do
 
   context 'server has error' do
     scenario 'renders error banner' do
-      expect(ScreeningRepository).to receive(:find).and_raise(StandardError)
-      visit '/screenings/2'
+      expect(ScreeningRepository).to receive(:search).and_raise(StandardError)
+      visit root_path
 
       expect(page).to have_text(
         /Something went wrong, sorry! Please try your last action again. \(Ref #:.*\)/

--- a/spec/javascripts/selectors/errorsSelectorsSpec.js
+++ b/spec/javascripts/selectors/errorsSelectorsSpec.js
@@ -156,6 +156,19 @@ describe('errorsSelectors', () => {
       const state = fromJS({errors})
       expect(getSystemErrorIncidentIdsSelector(state)).toEqualImmutable(fromJS(['1', '2']))
     })
+    it('remove errors that do not include an incident id', () => {
+      const errors = {[SUBMIT_SCREENING_COMPLETE]: [
+        {
+          type: 'not_constraint_validation',
+        },
+        {
+          incident_id: '2',
+          type: 'not_constraint_validation',
+        },
+      ]}
+      const state = fromJS({errors})
+      expect(getSystemErrorIncidentIdsSelector(state)).toEqualImmutable(fromJS(['2']))
+    })
   })
   describe('getPageErrorMessageSelector', () => {
     it('returns apiValidationErrors if it exists', () => {


### PR DESCRIPTION
[#545]

### Jira Story

- [Error messages include a unique reference ID for Intake (Rails) FE app INT-545](https://osi-cwds.atlassian.net/browse/INT-545)

### Purpose

Fixes a display bug in the original commit by removing null from the dataset so that it does not show an empty "Ref #"