### PR TITLE
Show alert when adding a person returns a 403

### DIFF
--- a/app/javascript/sagas/createParticipantSaga.js
+++ b/app/javascript/sagas/createParticipantSaga.js
@@ -1,5 +1,5 @@
 import {takeEvery, put, call, select} from 'redux-saga/effects'
-import {post} from 'utils/http'
+import {STATUS_CODES, post} from 'utils/http'
 import {
   CREATE_PERSON,
   createPersonSuccess,
@@ -29,7 +29,11 @@ export function* createParticipant({payload: {person}}) {
     yield put(fetchRelationships(screeningId))
     yield put(fetchHistoryOfInvolvements(screeningId))
   } catch (error) {
-    yield put(createPersonFailure(error.responseJSON))
+    if (error.status === STATUS_CODES.forbidden) {
+      yield call(alert, 'You are not authorized to add this person.')
+    } else {
+      yield put(createPersonFailure(error.responseJSON))
+    }
   }
 }
 export function* createParticipantSaga() {

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -178,6 +178,21 @@ feature 'Create participant' do
     end
   end
 
+  scenario 'API returns a 403 response when trying to add a person' do
+    visit edit_screening_path(id: existing_screening.id)
+
+    stub_request(:post,
+      intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
+      .and_return(json_body('', status: 403))
+
+    within '#search-card', text: 'Search' do
+      fill_in_autocompleter 'Search for any person', with: 'Marge'
+      click_button 'Create a new person'
+    end
+
+    expect(accept_alert).to eq('You are not authorized to add this person.')
+  end
+
   context 'release_two enabled' do
     around do |example|
       Feature.run_with_activated(:release_two) do

--- a/spec/javascripts/sagas/createParticipantSagaSpec.js
+++ b/spec/javascripts/sagas/createParticipantSagaSpec.js
@@ -40,12 +40,21 @@ describe('createParticipant', () => {
     )
   })
 
-  it('puts errors when errors are thrown', () => {
+  it('puts errors when non-403 errors are thrown', () => {
     const gen = createParticipant(action)
     expect(gen.next().value).toEqual(call(post, '/api/v1/participants', {participant: params}))
     const error = {responseJSON: 'some error'}
     expect(gen.throw(error).value).toEqual(
       put(personCardActions.createPersonFailure('some error'))
+    )
+  })
+
+  it('calls an alert when the error status is 403', () => {
+    const gen = createParticipant(action)
+    expect(gen.next().value).toEqual(call(post, '/api/v1/participants', {participant: params}))
+    const error = {responseJSON: 'some error', status: 403}
+    expect(gen.throw(error).value).toEqual(
+      call(alert, 'You are not authorized to add this person.')
     )
   })
 })


### PR DESCRIPTION
### Jira Story
- [Unable to select sensitive person record even with USERID that has that privilege INT-966](https://osi-cwds.atlassian.net/browse/INT-966)

### Purpose
- Let the user know that they are not authorized to add that person to
the screening
- Should be replaced with a better error/modal pattern at a later date
