### PR TITLE
IE search footers buttons use different case

### DIFF
--- a/app/javascript/common/ReactAutosuggest.jsx
+++ b/app/javascript/common/ReactAutosuggest.jsx
@@ -273,11 +273,8 @@ export default class Autosuggest extends Component {
       event.target;
 
     while (node !== null && node !== document) {
-      if (event.target.innerText === 'SHOW MORE RESULTS') {
-        event.preventDefault();
-      }
-
-      if (event.target.innerText === ' CREATE A NEW PERSON') {
+      const targetText = event.target.innerText
+      if (['show more results', 'create a new person'].includes(targetText.trim().toLowerCase())) {
         event.preventDefault();
       }
 


### PR DESCRIPTION
[#INT-7]

### Jira Story

- [Name of Story INT-7](https://osi-cwds.atlassian.net/browse/INT-7)

### Purpose

IE uses different case for button text, we are currently matching on button text in react-autosuggest which is less than ideal. As part of finishing this story I will be creating another story to replace react-autosuggest so this code is not necessary.

### Background


### Questions for Reviewer


### Notes for Reviewer


### Testing Notes

