### PR TITLE
Int 445 remove doj from cross reports

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,6 +2,7 @@
 --require spec_helper
 --format progress
 --format ParallelTests::RSpec::FailuresLogger --out tmp/failing_specs.log
+--format ParallelTests::RSpec::RuntimeLogger --out tmp/parallel_runtime_rspec.log
 <% if ENV['GENERATE_TEST_REPORTS'] == 'yes' %>
 --require rspec_junit_formatter
 --format RspecJunitFormatter --out <%= ENV['CI_REPORTS'] %>/TESTS-rspec-<%= ENV['TEST_ENV_NUMBER'] %>.xml

--- a/app/javascript/containers/screenings/CrossReportFormContainer.jsx
+++ b/app/javascript/containers/screenings/CrossReportFormContainer.jsx
@@ -1,14 +1,12 @@
 import {
   AGENCY_TYPES,
   DISTRICT_ATTORNEY,
-  DEPARTMENT_OF_JUSTICE,
   LAW_ENFORCEMENT,
   COUNTY_LICENSING,
   COMMUNITY_CARE_LICENSING,
 } from 'enums/CrossReport'
 import {
   getDistrictAttorneyAgenciesSelector,
-  getDepartmentOfJusticeAgenciesSelector,
   getLawEnforcementAgenciesSelector,
   getCountyLicensingAgenciesSelector,
   getCommunityCareLicensingAgenciesSelector,
@@ -37,7 +35,6 @@ import {
   getVisibleErrorsSelector,
   getScreeningWithEditsSelector,
   getDistrictAttorneyFormSelector,
-  getDepartmentOfJusticeFormSelector,
   getLawEnforcementFormSelector,
   getCountyLicensingFormSelector,
   getCommunityCareLicensingFormSelector,
@@ -50,14 +47,12 @@ const mapStateToProps = (state) => ({
   counties: state.get('counties').toJS(),
   county_id: state.getIn(['crossReportForm', 'county_id', 'value']) || '',
   countyAgencies: {
-    [DEPARTMENT_OF_JUSTICE]: getDepartmentOfJusticeAgenciesSelector(state).toJS(),
     [DISTRICT_ATTORNEY]: getDistrictAttorneyAgenciesSelector(state).toJS(),
     [LAW_ENFORCEMENT]: getLawEnforcementAgenciesSelector(state).toJS(),
     [COMMUNITY_CARE_LICENSING]: getCommunityCareLicensingAgenciesSelector(state).toJS(),
     [COUNTY_LICENSING]: getCountyLicensingAgenciesSelector(state).toJS(),
   },
   countyLicensing: getCountyLicensingFormSelector(state).toJS(),
-  departmentOfJustice: getDepartmentOfJusticeFormSelector(state).toJS(),
   districtAttorney: getDistrictAttorneyFormSelector(state).toJS(),
   hasAgencies: Boolean(Object.keys(AGENCY_TYPES).reduce((result, key) => result || state.getIn(['crossReportForm', key, 'selected']), false)),
   errors: getVisibleErrorsSelector(state).toJS(),

--- a/app/javascript/enums/CrossReport.js
+++ b/app/javascript/enums/CrossReport.js
@@ -1,13 +1,11 @@
 export const COMMUNITY_CARE_LICENSING = 'COMMUNITY_CARE_LICENSING'
 export const COUNTY_LICENSING = 'COUNTY_LICENSING'
-export const DEPARTMENT_OF_JUSTICE = 'DEPARTMENT_OF_JUSTICE'
 export const DISTRICT_ATTORNEY = 'DISTRICT_ATTORNEY'
 export const LAW_ENFORCEMENT = 'LAW_ENFORCEMENT'
 
 export const AGENCY_TYPES = Object.freeze({
   [DISTRICT_ATTORNEY]: 'District attorney',
   [LAW_ENFORCEMENT]: 'Law enforcement',
-  [DEPARTMENT_OF_JUSTICE]: 'Department of justice',
   [COUNTY_LICENSING]: 'County licensing',
   [COMMUNITY_CARE_LICENSING]: 'Community care licensing',
 })

--- a/app/javascript/selectors/screening/countyAgenciesSelectors.js
+++ b/app/javascript/selectors/screening/countyAgenciesSelectors.js
@@ -1,7 +1,6 @@
 import {createSelector} from 'reselect'
 import {
   DISTRICT_ATTORNEY,
-  DEPARTMENT_OF_JUSTICE,
   LAW_ENFORCEMENT,
   COMMUNITY_CARE_LICENSING,
   COUNTY_LICENSING,
@@ -11,10 +10,6 @@ export const getCountyAgenciesSelector = (state) => state.get('countyAgencies')
 export const getDistrictAttorneyAgenciesSelector = createSelector(
   getCountyAgenciesSelector,
   (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === DISTRICT_ATTORNEY)
-)
-export const getDepartmentOfJusticeAgenciesSelector = createSelector(
-  getCountyAgenciesSelector,
-  (countyAgencies) => countyAgencies.filter((countyAgency) => countyAgency.get('type') === DEPARTMENT_OF_JUSTICE)
 )
 export const getLawEnforcementAgenciesSelector = createSelector(
   getCountyAgenciesSelector,

--- a/app/javascript/selectors/screening/crossReportFormSelectors.js
+++ b/app/javascript/selectors/screening/crossReportFormSelectors.js
@@ -3,7 +3,6 @@ import {
   COMMUNITY_CARE_LICENSING,
   COUNTY_LICENSING,
   CROSS_REPORTS_REQUIRED_FOR_ALLEGATIONS,
-  DEPARTMENT_OF_JUSTICE,
   DISTRICT_ATTORNEY,
   LAW_ENFORCEMENT,
 } from 'enums/CrossReport'
@@ -15,7 +14,6 @@ import {
   getAgencyRequiredErrors,
   getCommunityCareLicensingErrors,
   getCountyLicensingErrors,
-  getDepartmentOfJusticeErrors,
   getDistrictAttorneyErrors,
   getLawEnforcementErrors,
 } from 'selectors/screening/crossReportShowSelectors'
@@ -25,7 +23,6 @@ import {getScreeningSelector} from 'selectors/screeningSelectors'
 import {areCrossReportsRequired} from 'utils/allegationsHelper'
 
 export const getDistrictAttorneyFormSelector = (state) => (state.getIn(['crossReportForm', DISTRICT_ATTORNEY]) || Map())
-export const getDepartmentOfJusticeFormSelector = (state) => (state.getIn(['crossReportForm', DEPARTMENT_OF_JUSTICE]) || Map())
 export const getLawEnforcementFormSelector = (state) => (state.getIn(['crossReportForm', LAW_ENFORCEMENT]) || Map())
 export const getCountyLicensingFormSelector = (state) => (state.getIn(['crossReportForm', COUNTY_LICENSING]) || Map())
 export const getCommunityCareLicensingFormSelector = (state) => (state.getIn(['crossReportForm', COMMUNITY_CARE_LICENSING]) || Map())
@@ -33,13 +30,11 @@ export const getCommunityCareLicensingFormSelector = (state) => (state.getIn(['c
 const getSelectedAgenciesSelector = createSelector(
   getCommunityCareLicensingFormSelector,
   getCountyLicensingFormSelector,
-  getDepartmentOfJusticeFormSelector,
   getDistrictAttorneyFormSelector,
   getLawEnforcementFormSelector,
-  (communityCareLicensing, countyLicensing, departmentOfJustice, districtAttorney, lawEnforcement) => fromJS({
+  (communityCareLicensing, countyLicensing, districtAttorney, lawEnforcement) => fromJS({
     [COMMUNITY_CARE_LICENSING]: communityCareLicensing,
     [COUNTY_LICENSING]: countyLicensing,
-    [DEPARTMENT_OF_JUSTICE]: departmentOfJustice,
     [DISTRICT_ATTORNEY]: districtAttorney,
     [LAW_ENFORCEMENT]: lawEnforcement,
   }).filter((agencyForm, _type) => agencyForm.get('selected'))
@@ -83,7 +78,6 @@ export const getErrorsSelector = createSelector(
     method: combineCompact(isRequiredIfCreate(method, 'Please select cross-report communication method.', () => (agencies.size !== 0))),
     [COMMUNITY_CARE_LICENSING]: combineCompact(() => (getCommunityCareLicensingErrors(agencies))),
     [COUNTY_LICENSING]: combineCompact(() => (getCountyLicensingErrors(agencies))),
-    [DEPARTMENT_OF_JUSTICE]: combineCompact(() => (getDepartmentOfJusticeErrors(agencies))),
     [DISTRICT_ATTORNEY]: combineCompact(() => (
       getDistrictAttorneyErrors(agencies) ||
       getAgencyRequiredErrors(DISTRICT_ATTORNEY, agencies, allegations)

--- a/app/javascript/selectors/screening/crossReportShowSelectors.js
+++ b/app/javascript/selectors/screening/crossReportShowSelectors.js
@@ -5,7 +5,6 @@ import {
   AGENCY_TYPES,
   CROSS_REPORTS_REQUIRED_FOR_ALLEGATIONS,
   DISTRICT_ATTORNEY,
-  DEPARTMENT_OF_JUSTICE,
   COUNTY_LICENSING,
   COMMUNITY_CARE_LICENSING,
   LAW_ENFORCEMENT,
@@ -74,15 +73,6 @@ export const getDistrictAttorneyErrors = (agencies) => {
   }
 }
 
-export const getDepartmentOfJusticeErrors = (agencies) => {
-  const {type, id} = findAgencyData(agencies, DEPARTMENT_OF_JUSTICE)
-  if (isBlank(type) || id) {
-    return undefined
-  } else {
-    return 'Please enter an agency name.'
-  }
-}
-
 export const getLawEnforcementErrors = (agencies) => {
   const {type, id} = findAgencyData(agencies, LAW_ENFORCEMENT)
   if (isBlank(type) || id) {
@@ -127,7 +117,6 @@ export const getErrorsSelector = createSelector(
     method: combineCompact(isRequiredIfCreate(crossReport.get('method'), 'Please select a cross-report communication method.', () => (agencies.size !== 0))),
     [COMMUNITY_CARE_LICENSING]: combineCompact(() => (getCommunityCareLicensingErrors(agencies))),
     [COUNTY_LICENSING]: combineCompact(() => (getCountyLicensingErrors(agencies))),
-    [DEPARTMENT_OF_JUSTICE]: combineCompact(() => (getDepartmentOfJusticeErrors(agencies))),
     [DISTRICT_ATTORNEY]: combineCompact(() => (getDistrictAttorneyErrors(agencies))),
     [LAW_ENFORCEMENT]: combineCompact(() => (getLawEnforcementErrors(agencies))),
     agencyRequired: combineCompact(

--- a/app/javascript/views/CrossReportForm.jsx
+++ b/app/javascript/views/CrossReportForm.jsx
@@ -11,7 +11,6 @@ import {
   COMMUNICATION_METHODS,
   COMMUNITY_CARE_LICENSING,
   COUNTY_LICENSING,
-  DEPARTMENT_OF_JUSTICE,
   DISTRICT_ATTORNEY,
   LAW_ENFORCEMENT,
 } from 'enums/CrossReport'
@@ -25,7 +24,6 @@ const CrossReportForm = ({
   county_id,
   countyAgencies,
   countyLicensing,
-  departmentOfJustice,
   districtAttorney,
   hasAgencies,
   errors,
@@ -120,16 +118,6 @@ const CrossReportForm = ({
           </div>
           <div className='col-md-6'>
             <ul className='unstyled-list'>
-              <li key={DEPARTMENT_OF_JUSTICE}>
-                <CrossReportAgencyField
-                  type={DEPARTMENT_OF_JUSTICE}
-                  selected={departmentOfJustice.selected}
-                  value={departmentOfJustice.agency.value}
-                  countyAgencies={countyAgencies[DEPARTMENT_OF_JUSTICE]}
-                  errors={errors[DEPARTMENT_OF_JUSTICE]}
-                  actions={agencyFieldActions}
-                />
-              </li>
               <li key={COUNTY_LICENSING}>
                 <CrossReportAgencyField
                   type={COUNTY_LICENSING}
@@ -209,7 +197,6 @@ CrossReportForm.propTypes = {
   countyAgencies: PropTypes.object,
   countyLicensing: PropTypes.object.isRequired,
   county_id: PropTypes.string.isRequired,
-  departmentOfJustice: PropTypes.object.isRequired,
   districtAttorney: PropTypes.object.isRequired,
   errors: PropTypes.object.isRequired,
   hasAgencies: PropTypes.bool.isRequired,

--- a/spec/controllers/api/v1/system_codes_controller_spec.rb
+++ b/spec/controllers/api/v1/system_codes_controller_spec.rb
@@ -86,13 +86,13 @@ describe Api::V1::SystemCodesController do
        },
        {
          'id' => 'GPumYGQ00F',
-         'name' => 'Hovernment Agency',
+         'name' => 'Hoverment Agency',
          'type' => 'COUNTY_LICENSING',
          'county_id' => '1086'
        },
        {
          'id' => 'GPumYGQ00F',
-         'name' => 'Hovernment Agency',
+         'name' => 'Hoverment Agency',
          'type' => 'COUNTY_LICENSING',
          'county_id' => '2080'
        },
@@ -185,7 +185,7 @@ describe Api::V1::SystemCodesController do
        },
        {
          'id' => 'GPumYGQ00F',
-         'name' => 'Hovernment Agency',
+         'name' => 'Hoverment Agency',
          'type' => 'county_licensing',
          'county_id' => '1086'
        },

--- a/spec/features/screening/cross_reports_spec.rb
+++ b/spec/features/screening/cross_reports_spec.rb
@@ -27,8 +27,8 @@ feature 'cross reports' do
       expect(page).to_not have_content 'Communication Time and Method'
       expect(page).to have_content 'County'
       select 'Sacramento', from: 'County'
-      find('label', text: /\ADepartment of justice\z/).click
-      select 'DOJ Agency', from: 'Department of justice agency name'
+      find('label', text: /\ACounty licensing\z/).click
+      select 'Hovernment Agency', from: 'County licensing agency name'
       find('label', text: /\ALaw enforcement\z/).click
       select 'The Sheriff', from: 'Law enforcement agency name'
       expect(page).to have_content 'Communication Time and Method'
@@ -48,7 +48,7 @@ feature 'cross reports' do
               'county_id' => 'c42',
               'agencies' => array_including(
                 hash_including('id' => 'BMG2f3J75C', 'type' => 'LAW_ENFORCEMENT'),
-                hash_including('id' => 'EYIS9Nh75C', 'type' => 'DEPARTMENT_OF_JUSTICE')
+                hash_including('id' => 'GPumYGQ00F', 'type' => 'COUNTY_LICENSING')
               ),
               'inform_date' => reported_on.to_s(:db),
               'method' => communication_method
@@ -67,7 +67,7 @@ feature 'cross reports' do
       CrossReport.new(
         county_id: 'c42',
         agencies: [
-          { id: 'EYIS9Nh75C', type: 'DEPARTMENT_OF_JUSTICE' },
+          { id: 'GPumYGQ00F', type: 'COUNTY_LICENSING' },
           { id: 'BMG2f3J75C', type: 'LAW_ENFORCEMENT' }
         ],
         method: communication_method,
@@ -86,7 +86,7 @@ feature 'cross reports' do
       select 'San Francisco', from: 'County'
       expect(page).to have_select('County', selected: 'San Francisco')
 
-      expect(find(:checkbox, 'Department of justice')).to_not be_checked
+      expect(find(:checkbox, 'County licensing')).to_not be_checked
 
       find('label', text: /\ALaw enforcement\z/).click
       expect(find(:checkbox, 'Law enforcement')).to be_checked
@@ -125,7 +125,7 @@ feature 'cross reports' do
       CrossReport.new(
         county_id: 'c42',
         agencies: [
-          { id: 'EYIS9Nh75C', type: 'DEPARTMENT_OF_JUSTICE' },
+          { id: 'LsUFj7O00E', type: 'COMMUNITY_CARE_LICENSING' },
           { id: 'BMG2f3J75C', type: 'LAW_ENFORCEMENT' }
         ],
         method: 'Child Abuse Form',
@@ -142,8 +142,8 @@ feature 'cross reports' do
     within '#cross-report-card', text: 'Cross Report' do
       expect(page).to_not have_content 'County'
       expect(page).to_not have_content 'Sacramento'
-      expect(page).to have_content 'Department of justice'
-      expect(page).to have_content 'DOJ Agency'
+      expect(page).to have_content 'Community care licensing'
+      expect(page).to have_content "Daisie's Preschool"
       expect(page).to have_content 'Law enforcement'
       expect(page).to have_content 'The Sheriff'
       expect(page).to have_content Date.today.strftime('%m/%d/%Y')
@@ -156,8 +156,9 @@ feature 'cross reports' do
       expect(page).to have_select('County', selected: 'Sacramento')
       expect(find(:checkbox, 'Law enforcement')).to be_checked
       expect(page).to have_select('Law enforcement agency name', selected: 'The Sheriff')
-      expect(find(:checkbox, 'Department of justice')).to be_checked
-      expect(page).to have_select('Department of justice agency name', selected: 'DOJ Agency')
+      expect(find(:checkbox, 'Community care licensing')).to be_checked
+      expect(page).to have_select('Community care licensing agency name',
+        selected: "Daisie's Preschool")
       expect(page).to have_field('Communication Method', with: 'Child Abuse Form')
       expect(page).to have_field('Cross Reported on Date', with: Date.today.strftime('%m/%d/%Y'))
     end
@@ -193,10 +194,10 @@ feature 'cross reports' do
 
     within '#cross-report-card' do
       select 'State of California', from: 'County'
-      find('label', text: /\ADepartment of justice\z/).click
+      find('label', text: /\ACounty licensing\z/).click
       fill_in_datepicker 'Cross Reported on Date', with: reported_on
       select communication_method, from: 'Communication Method'
-      find('label', text: /\ADepartment of justice\z/).click
+      find('label', text: /\ACounty licensing\z/).click
       find('label', text: /\ALaw enforcement\z/).click
       expect(page).to have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y'))
       expect(page).to have_field('Communication Method', with: communication_method)
@@ -236,10 +237,10 @@ feature 'cross reports' do
 
     within '#cross-report-card' do
       select 'San Francisco', from: 'County'
-      find('label', text: /\ADepartment of justice\z/).click
+      find('label', text: /\ACounty licensing\z/).click
       fill_in_datepicker 'Cross Reported on Date', with: reported_on
       select communication_method, from: 'Communication Method'
-      find('label', text: /\ADepartment of justice\z/).click
+      find('label', text: /\ACounty licensing\z/).click
       find('label', text: /\ALaw enforcement\z/).click
       expect(page).to have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y'))
       expect(page).to have_field('Communication Method', with: communication_method)
@@ -287,10 +288,10 @@ feature 'cross reports' do
 
     within '#cross-report-card' do
       select 'State of California', from: 'County'
-      find('label', text: /\ADepartment of justice\z/).click
+      find('label', text: /\ACounty licensing\z/).click
       fill_in_datepicker 'Cross Reported on Date', with: reported_on
       select communication_method, from: 'Communication Method'
-      find('label', text: /\ADepartment of justice\z/).click
+      find('label', text: /\ACounty licensing\z/).click
       click_button 'Save'
     end
 
@@ -298,7 +299,7 @@ feature 'cross reports' do
 
     within '#cross-report-card' do
       select 'State of California', from: 'County'
-      find('label', text: /\ADepartment of justice\z/).click
+      find('label', text: /\ACounty licensing\z/).click
       expect(page).to have_field('Cross Reported on Date', with: '')
       expect(page).to have_field('Communication Method', with: '')
     end

--- a/spec/features/screening/cross_reports_spec.rb
+++ b/spec/features/screening/cross_reports_spec.rb
@@ -28,7 +28,7 @@ feature 'cross reports' do
       expect(page).to have_content 'County'
       select 'Sacramento', from: 'County'
       find('label', text: /\ACounty licensing\z/).click
-      select 'Hovernment Agency', from: 'County licensing agency name'
+      select 'Hoverment Agency', from: 'County licensing agency name'
       find('label', text: /\ALaw enforcement\z/).click
       select 'The Sheriff', from: 'Law enforcement agency name'
       expect(page).to have_content 'Communication Time and Method'

--- a/spec/features/screening/validations/cross_reports_validations_spec.rb
+++ b/spec/features/screening/validations/cross_reports_validations_spec.rb
@@ -12,7 +12,7 @@ feature 'Cross Reports Validations' do
           :cross_report,
           county_id: 'c41',
           agencies: [
-            FactoryGirl.create(:agency, id: nil, type: 'DEPARTMENT_OF_JUSTICE')
+            FactoryGirl.create(:agency, id: nil, type: 'COUNTY_LICENSING')
           ]
         )
       ]
@@ -55,13 +55,13 @@ feature 'Cross Reports Validations' do
               cross_reports: [
                 county_id: 'c41',
                 agencies: [
-                  { type: 'DEPARTMENT_OF_JUSTICE', id: 'EYIS9Nh75C' }
+                  { type: 'COUNTY_LICENSING', id: 'GPumYGQ00F' }
                 ]
               ]
             }
           ) do
             within '#cross-report-card.edit' do
-              select 'DOJ Agency', from: 'Department of justice agency name'
+              select 'Hovernment Agency', from: 'County licensing agency name'
             end
           end
         end
@@ -71,21 +71,21 @@ feature 'Cross Reports Validations' do
         end
 
         scenario 'displays error on blur' do
-          select '', from: 'Department of justice agency name'
+          select '', from: 'County licensing agency name'
           blur_field
           should_have_content error_message, inside: '#cross-report-card.edit'
         end
 
         scenario 'removes error on change' do
-          select '', from: 'Department of justice agency name'
+          select '', from: 'County licensing agency name'
           blur_field
           should_have_content error_message, inside: '#cross-report-card.edit'
-          select 'DOJ Agency', from: 'Department of justice agency name'
+          select 'Hovernment Agency', from: 'County licensing agency name'
           should_not_have_content error_message, inside: '#cross-report-card.edit'
         end
 
         scenario 'shows error on save page' do
-          select '', from: 'Department of justice agency name'
+          select '', from: 'County licensing agency name'
           blur_field
           should_have_content error_message, inside: '#cross-report-card.edit'
           save_card('cross-report')
@@ -102,7 +102,7 @@ feature 'Cross Reports Validations' do
           stub_and_visit_edit_screening(screening)
         end
         scenario 'shows no error when filled in' do
-          select 'DOJ Agency', from: 'Department of justice agency name'
+          select 'Hovernment Agency', from: 'County licensing agency name'
           blur_field
           should_not_have_content error_message, inside: '#cross-report-card .card-body'
           save_card('cross-report')

--- a/spec/features/screening/validations/cross_reports_validations_spec.rb
+++ b/spec/features/screening/validations/cross_reports_validations_spec.rb
@@ -61,7 +61,7 @@ feature 'Cross Reports Validations' do
             }
           ) do
             within '#cross-report-card.edit' do
-              select 'Hovernment Agency', from: 'County licensing agency name'
+              select 'Hoverment Agency', from: 'County licensing agency name'
             end
           end
         end
@@ -80,7 +80,7 @@ feature 'Cross Reports Validations' do
           select '', from: 'County licensing agency name'
           blur_field
           should_have_content error_message, inside: '#cross-report-card.edit'
-          select 'Hovernment Agency', from: 'County licensing agency name'
+          select 'Hoverment Agency', from: 'County licensing agency name'
           should_not_have_content error_message, inside: '#cross-report-card.edit'
         end
 
@@ -102,7 +102,7 @@ feature 'Cross Reports Validations' do
           stub_and_visit_edit_screening(screening)
         end
         scenario 'shows no error when filled in' do
-          select 'Hovernment Agency', from: 'County licensing agency name'
+          select 'Hoverment Agency', from: 'County licensing agency name'
           blur_field
           should_not_have_content error_message, inside: '#cross-report-card .card-body'
           save_card('cross-report')

--- a/spec/javascripts/reducers/crossReportFormReducerSpec.js
+++ b/spec/javascripts/reducers/crossReportFormReducerSpec.js
@@ -49,14 +49,6 @@ describe('crossReportFormReducer', () => {
             touched: true,
           },
         },
-        DEPARTMENT_OF_JUSTICE: {
-          selected: true,
-          touched: false,
-          agency: {
-            value: '',
-            touched: false,
-          },
-        },
         COUNTY_LICENSING: {
           selected: false,
           touched: false,
@@ -98,14 +90,6 @@ describe('crossReportFormReducer', () => {
             },
           },
           LAW_ENFORCEMENT: {
-            selected: false,
-            touched: false,
-            agency: {
-              value: '',
-              touched: false,
-            },
-          },
-          DEPARTMENT_OF_JUSTICE: {
             selected: false,
             touched: false,
             agency: {
@@ -164,14 +148,6 @@ describe('crossReportFormReducer', () => {
             touched: true,
           },
         },
-        DEPARTMENT_OF_JUSTICE: {
-          selected: true,
-          touched: false,
-          agency: {
-            value: '',
-            touched: false,
-          },
-        },
         COUNTY_LICENSING: {
           selected: false,
           touched: false,
@@ -218,14 +194,6 @@ describe('crossReportFormReducer', () => {
             agency: {
               value: '5234',
               touched: true,
-            },
-          },
-          DEPARTMENT_OF_JUSTICE: {
-            selected: true,
-            touched: false,
-            agency: {
-              value: '',
-              touched: false,
             },
           },
           COUNTY_LICENSING: {
@@ -292,14 +260,6 @@ describe('crossReportFormReducer', () => {
             touched: true,
           },
         },
-        DEPARTMENT_OF_JUSTICE: {
-          selected: false,
-          touched: false,
-          agency: {
-            value: '',
-            touched: false,
-          },
-        },
         COUNTY_LICENSING: {
           selected: false,
           touched: false,
@@ -345,14 +305,6 @@ describe('crossReportFormReducer', () => {
             agency: {
               value: '',
               touched: true,
-            },
-          },
-          DEPARTMENT_OF_JUSTICE: {
-            selected: false,
-            touched: false,
-            agency: {
-              value: '',
-              touched: false,
             },
           },
           COUNTY_LICENSING: {
@@ -420,14 +372,6 @@ describe('crossReportFormReducer', () => {
               touched: false,
             },
           },
-          DEPARTMENT_OF_JUSTICE: {
-            selected: false,
-            touched: false,
-            agency: {
-              value: '',
-              touched: false,
-            },
-          },
           COUNTY_LICENSING: {
             selected: false,
             touched: false,
@@ -488,14 +432,6 @@ describe('crossReportFormReducer', () => {
             },
           },
           LAW_ENFORCEMENT: {
-            selected: false,
-            touched: false,
-            agency: {
-              value: '',
-              touched: false,
-            },
-          },
-          DEPARTMENT_OF_JUSTICE: {
             selected: false,
             touched: false,
             agency: {
@@ -581,14 +517,6 @@ describe('crossReportFormReducer', () => {
             touched: true,
           },
         },
-        DEPARTMENT_OF_JUSTICE: {
-          selected: false,
-          touched: false,
-          agency: {
-            value: '',
-            touched: false,
-          },
-        },
         COUNTY_LICENSING: {
           selected: false,
           touched: false,
@@ -633,14 +561,6 @@ describe('crossReportFormReducer', () => {
             touched: true,
             agency: {
               value: '5234',
-              touched: true,
-            },
-          },
-          DEPARTMENT_OF_JUSTICE: {
-            selected: false,
-            touched: true,
-            agency: {
-              value: '',
               touched: true,
             },
           },

--- a/spec/javascripts/reducers/systemCodes/countyAgenciesReducerSpec.js
+++ b/spec/javascripts/reducers/systemCodes/countyAgenciesReducerSpec.js
@@ -29,7 +29,7 @@ describe('countyAgenciesReducer', () => {
         },
         {
           id: 'GPumYGQ00F',
-          name: 'Hovernment Agency',
+          name: 'Hoverment Agency',
           type: 'COUNTY_LICENSING',
           county_id: '1086',
         },
@@ -62,7 +62,7 @@ describe('countyAgenciesReducer', () => {
           },
           {
             id: 'GPumYGQ00F',
-            name: 'Hovernment Agency',
+            name: 'Hoverment Agency',
             type: 'COUNTY_LICENSING',
             county_id: '1086',
           },

--- a/spec/javascripts/selectors/screening/crossReportFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/crossReportFormSelectorsSpec.js
@@ -7,7 +7,6 @@ import {
   getErrorsSelector,
   getScreeningWithEditsSelector,
   getDistrictAttorneyFormSelector,
-  getDepartmentOfJusticeFormSelector,
   getLawEnforcementFormSelector,
   getCountyLicensingFormSelector,
   getCommunityCareLicensingFormSelector,
@@ -46,14 +45,6 @@ describe('crossReportFormSelectors', () => {
         touched: false,
       },
     },
-    DEPARTMENT_OF_JUSTICE = {
-      selected: false,
-      touched: false,
-      agency: {
-        value: '',
-        touched: false,
-      },
-    },
     DISTRICT_ATTORNEY = {
       selected: false,
       touched: false,
@@ -77,7 +68,6 @@ describe('crossReportFormSelectors', () => {
       method,
       COMMUNITY_CARE_LICENSING,
       COUNTY_LICENSING,
-      DEPARTMENT_OF_JUSTICE,
       DISTRICT_ATTORNEY,
       LAW_ENFORCEMENT,
     }
@@ -429,14 +419,6 @@ describe('crossReportFormSelectors', () => {
                 touched: false,
               },
             },
-            DEPARTMENT_OF_JUSTICE: {
-              selected: true,
-              touched: false,
-              agency: {
-                value: '',
-                touched: false,
-              },
-            },
             DISTRICT_ATTORNEY: {
               selected: true,
               touched: false,
@@ -457,8 +439,6 @@ describe('crossReportFormSelectors', () => {
           expect(getErrorsSelector(state).get('COMMUNITY_CARE_LICENSING'))
             .toEqualImmutable(fromJS(['Please enter an agency name.']))
           expect(getErrorsSelector(state).get('COUNTY_LICENSING'))
-            .toEqualImmutable(fromJS(['Please enter an agency name.']))
-          expect(getErrorsSelector(state).get('DEPARTMENT_OF_JUSTICE'))
             .toEqualImmutable(fromJS(['Please enter an agency name.']))
           expect(getErrorsSelector(state).get('DISTRICT_ATTORNEY'))
             .toEqualImmutable(fromJS(['Please enter an agency name.']))
@@ -487,8 +467,6 @@ describe('crossReportFormSelectors', () => {
             .toEqualImmutable(List())
           expect(getErrorsSelector(state).get('COUNTY_LICENSING'))
             .toEqualImmutable(List())
-          expect(getErrorsSelector(state).get('DEPARTMENT_OF_JUSTICE'))
-            .toEqualImmutable(List())
           expect(getErrorsSelector(state).get('DISTRICT_ATTORNEY'))
             .toEqualImmutable(List())
           expect(getErrorsSelector(state).get('LAW_ENFORCEMENT'))
@@ -510,29 +488,6 @@ describe('crossReportFormSelectors', () => {
         },
       })})
       expect(getDistrictAttorneyFormSelector(state))
-        .toEqualImmutable(fromJS({
-          selected: true,
-          touched: false,
-          agency: {
-            value: '1234',
-            touched: true,
-          },
-        }))
-    })
-  })
-  describe('getDepartmentOfJusticeFormSelector', () => {
-    it('returns data from form for DEPARTMENT_OF_JUSTICE', () => {
-      const state = fromJS({crossReportForm: getCrossReportState({
-        DEPARTMENT_OF_JUSTICE: {
-          selected: true,
-          touched: false,
-          agency: {
-            value: '1234',
-            touched: true,
-          },
-        },
-      })})
-      expect(getDepartmentOfJusticeFormSelector(state))
         .toEqualImmutable(fromJS({
           selected: true,
           touched: false,

--- a/spec/javascripts/selectors/screening/crossReportShowSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/crossReportShowSelectorsSpec.js
@@ -118,7 +118,6 @@ describe('crossReportShowSelectors', () => {
             {type: 'LAW_ENFORCEMENT'},
             {type: 'COMMUNITY_CARE_LICENSING'},
             {type: 'COUNTY_LICENSING'},
-            {type: 'DEPARTMENT_OF_JUSTICE'},
           ],
         }]
         it('returns an error on informDate', () => {
@@ -136,8 +135,6 @@ describe('crossReportShowSelectors', () => {
           expect(getErrorsSelector(state).get('COMMUNITY_CARE_LICENSING'))
             .toEqualImmutable(fromJS(['Please enter an agency name.']))
           expect(getErrorsSelector(state).get('COUNTY_LICENSING'))
-            .toEqualImmutable(fromJS(['Please enter an agency name.']))
-          expect(getErrorsSelector(state).get('DEPARTMENT_OF_JUSTICE'))
             .toEqualImmutable(fromJS(['Please enter an agency name.']))
           expect(getErrorsSelector(state).get('DISTRICT_ATTORNEY'))
             .toEqualImmutable(fromJS(['Please enter an agency name.']))
@@ -161,8 +158,6 @@ describe('crossReportShowSelectors', () => {
           expect(getErrorsSelector(state).get('COMMUNITY_CARE_LICENSING'))
             .toEqualImmutable(List())
           expect(getErrorsSelector(state).get('COUNTY_LICENSING'))
-            .toEqualImmutable(List())
-          expect(getErrorsSelector(state).get('DEPARTMENT_OF_JUSTICE'))
             .toEqualImmutable(List())
           expect(getErrorsSelector(state).get('DISTRICT_ATTORNEY'))
             .toEqualImmutable(List())

--- a/spec/javascripts/views/CrossReportFormSpec.jsx
+++ b/spec/javascripts/views/CrossReportFormSpec.jsx
@@ -13,7 +13,6 @@ describe('CrossReportForm', () => {
     countyAgencies = {
       COMMUNITY_CARE_LICENSING: [],
       COUNTY_LICENSING: [],
-      DEPARTMENT_OF_JUSTICE: [],
       DISTRICT_ATTORNEY: [],
       LAW_ENFORCEMENT: [],
     },
@@ -26,14 +25,6 @@ describe('CrossReportForm', () => {
       },
     },
     lawEnforcement = {
-      selected: false,
-      touched: false,
-      agency: {
-        value: '',
-        touched: false,
-      },
-    },
-    departmentOfJustice = {
       selected: false,
       touched: false,
       agency: {
@@ -62,7 +53,6 @@ describe('CrossReportForm', () => {
       method: [],
       COMMUNITY_CARE_LICENSING: [],
       COUNTY_LICENSING: [],
-      DEPARTMENT_OF_JUSTICE: [],
       DISTRICT_ATTORNEY: [],
       LAW_ENFORCEMENT: [],
     },
@@ -80,7 +70,6 @@ describe('CrossReportForm', () => {
       counties,
       county_id,
       countyAgencies,
-      departmentOfJustice,
       districtAttorney,
       errors,
       lawEnforcement,
@@ -180,7 +169,6 @@ describe('CrossReportForm', () => {
           countyAgencies: {
             COMMUNITY_CARE_LICENSING: [],
             COUNTY_LICENSING: [],
-            DEPARTMENT_OF_JUSTICE: [],
             DISTRICT_ATTORNEY: [{id: '123', value: 'asdf'}],
             LAW_ENFORCEMENT: [],
           },
@@ -196,7 +184,6 @@ describe('CrossReportForm', () => {
           countyAgencies: {
             COMMUNITY_CARE_LICENSING: [],
             COUNTY_LICENSING: [],
-            DEPARTMENT_OF_JUSTICE: [],
             DISTRICT_ATTORNEY: [],
             LAW_ENFORCEMENT: [{id: '123', value: 'asdf'}],
           },
@@ -212,7 +199,6 @@ describe('CrossReportForm', () => {
         countyAgencies: {
           COMMUNITY_CARE_LICENSING: [],
           COUNTY_LICENSING: [],
-          DEPARTMENT_OF_JUSTICE: [],
           DISTRICT_ATTORNEY: [{id: '123', value: 'asdf'}],
           LAW_ENFORCEMENT: [],
         },
@@ -235,7 +221,6 @@ describe('CrossReportForm', () => {
         countyAgencies: {
           COMMUNITY_CARE_LICENSING: [],
           COUNTY_LICENSING: [],
-          DEPARTMENT_OF_JUSTICE: [],
           DISTRICT_ATTORNEY: [],
           LAW_ENFORCEMENT: [{id: '123', value: 'asdf'}],
         },
@@ -251,29 +236,6 @@ describe('CrossReportForm', () => {
       expect(field.props().actions).toEqual(actions)
       expect(field.props().errors).toEqual(['le is missing'])
     })
-    it('renders DEPARTMENT_OF_JUSTICE agency field', () => {
-      const component = renderCrossReportForm({
-        county_id: '12',
-        departmentOfJustice: {selected: true, agency: {value: '1234'}},
-        countyAgencies: {
-          COMMUNITY_CARE_LICENSING: [],
-          COUNTY_LICENSING: [],
-          DEPARTMENT_OF_JUSTICE: [{id: '123', value: 'asdf'}],
-          DISTRICT_ATTORNEY: [],
-          LAW_ENFORCEMENT: [],
-        },
-        errors: {
-          DEPARTMENT_OF_JUSTICE: ['doj is missing'],
-        },
-        actions,
-      })
-      const field = component.find('CrossReportAgencyField[type="DEPARTMENT_OF_JUSTICE"]')
-      expect(field.props().selected).toEqual(true)
-      expect(field.props().value).toEqual('1234')
-      expect(field.props().countyAgencies).toEqual([{id: '123', value: 'asdf'}])
-      expect(field.props().actions).toEqual(actions)
-      expect(field.props().errors).toEqual(['doj is missing'])
-    })
     it('renders COUNTY_LICENSING agency field', () => {
       const component = renderCrossReportForm({
         county_id: '12',
@@ -281,7 +243,6 @@ describe('CrossReportForm', () => {
         countyAgencies: {
           COMMUNITY_CARE_LICENSING: [],
           COUNTY_LICENSING: [{id: '123', value: 'asdf'}],
-          DEPARTMENT_OF_JUSTICE: [],
           DISTRICT_ATTORNEY: [],
           LAW_ENFORCEMENT: [],
         },
@@ -304,7 +265,6 @@ describe('CrossReportForm', () => {
         countyAgencies: {
           COMMUNITY_CARE_LICENSING: [{id: '123', value: 'asdf'}],
           COUNTY_LICENSING: [],
-          DEPARTMENT_OF_JUSTICE: [],
           DISTRICT_ATTORNEY: [],
           LAW_ENFORCEMENT: [],
         },

--- a/spec/support/helpers/autocompleter_helpers.rb
+++ b/spec/support/helpers/autocompleter_helpers.rb
@@ -26,11 +26,9 @@ module AutocompleterHelpers
     if split
       value.split('').each do |character|
         find_field(locator).native.send_keys(character)
-        sleep 0.3
       end
     else
       fill_in locator, with: value
-      sleep 0.5
     end
   end
 

--- a/spec/support/helpers/county_agencies_helper.rb
+++ b/spec/support/helpers/county_agencies_helper.rb
@@ -29,7 +29,7 @@ module CountyAgenciesHelpers
       },
       {
         'id' => 'GPumYGQ00F',
-        'name' => 'Hovernment Agency',
+        'name' => 'Hoverment Agency',
         'type' => 'COUNTY_LICENSING',
         'county_id' => county_id
       },


### PR DESCRIPTION
### Jira Story

- [remove DOJ option on Cross Report card for a Screening INT-445](https://osi-cwds.atlassian.net/browse/INT-445)

### Background
Cross reporting to Department of Justice is never done on the screening phase. It is often done in the investigation phase instead. As a result, we're removing the option from the screening page. Result (taken from local machine):
![image](https://user-images.githubusercontent.com/28609622/35051185-7f638036-fb59-11e7-94ad-5b7997638921.png)


### Testing Notes
Passes all tests. Last commit reduces test run time by at least 3 minutes (tested both locally and on CI)
![image](https://user-images.githubusercontent.com/28609622/35052002-641ced2e-fb5b-11e7-91b6-ab699978e3b4.png)
https://ci.mycasebook.org/job/intake_test_phase/job/int_445_remove_doj_from_cross_reports/