### PR TITLE
Int 559 show address types in snapshot

### DIFF
--- a/app/javascript/reducers/index.js
+++ b/app/javascript/reducers/index.js
@@ -1,3 +1,4 @@
+import addressTypes from 'reducers/systemCodes/addressTypesReducer'
 import allegationsForm from 'reducers/allegationsFormReducer'
 import allegationTypes from 'reducers/systemCodes/allegationTypesReducer'
 import communicationMethods from 'reducers/systemCodes/communicationMethodsReducer'
@@ -36,6 +37,7 @@ import userInfo from 'reducers/userInfoReducer'
 import usStates from 'reducers/systemCodes/usStatesReducer'
 
 const rootReducer = combineReducers({
+  addressTypes,
   allegationsForm,
   allegationTypes,
   communicationMethods,

--- a/app/javascript/reducers/systemCodes/addressTypesReducer.js
+++ b/app/javascript/reducers/systemCodes/addressTypesReducer.js
@@ -1,0 +1,15 @@
+import {createReducer} from 'utils/createReducer'
+import {List, fromJS} from 'immutable'
+import {FETCH_SYSTEM_CODES_COMPLETE} from 'actions/systemCodesActions'
+import {findByCategory} from 'selectors'
+const ADDRESS_TYPE = 'address_type'
+
+export default createReducer(List(), {
+  [FETCH_SYSTEM_CODES_COMPLETE](state, {payload: {systemCodes}, error}) {
+    if (error) {
+      return state
+    } else {
+      return fromJS(findByCategory(systemCodes, ADDRESS_TYPE))
+    }
+  },
+})

--- a/app/javascript/selectors/index.js
+++ b/app/javascript/selectors/index.js
@@ -3,10 +3,6 @@ export const findByCategory = (statusCodes = List(), selectedCategory) => (
   statusCodes.filter(({category}) => category === selectedCategory)
 )
 
-export const findByCode = (statusCodes, selectedCode) => (
-  statusCodes.find(({code}) => code === selectedCode) || {}
-)
-
 export const buildSelector = (...funcs) => (
   (arg) => {
     var selector = funcs.pop()

--- a/app/javascript/selectors/peopleSearchSelectors.js
+++ b/app/javascript/selectors/peopleSearchSelectors.js
@@ -39,7 +39,7 @@ export const getPeopleResultsSelector = (state) => getPeopleSearchSelector(state
       ethnicity: mapEthnicities(state, result),
       dateOfBirth: fullResult.getIn(['highlight', 'date_of_birth', 0], result.get('date_of_birth')),
       ssn: formatSSN(fullResult.getIn(['highlight', 'ssn', 0], result.get('ssn'))),
-      address: mapAddress(result),
+      address: mapAddress(state, result),
       phoneNumber: phoneNumber && Map({
         number: phoneNumber.get('number'),
         type: phoneNumber.get('type'),

--- a/app/javascript/utils/peopleSearchHelper.js
+++ b/app/javascript/utils/peopleSearchHelper.js
@@ -46,22 +46,25 @@ export const mapEthnicities = (state, result) => buildSelector(
   })
 )(state)
 
-export const mapAddress = (result) => buildSelector(
-  (result) => (result.get('addresses') || List()).isEmpty(),
-  (result) => result.getIn(['addresses', 0, 'city']),
-  (result) => result.getIn(['addresses', 0, 'state_code']),
-  (result) => result.getIn(['addresses', 0, 'zip']),
-  (result) => result.getIn(['addresses', 0, 'street_number']),
-  (result) => result.getIn(['addresses', 0, 'street_name']),
-  (addressesEmpty, city, stateCode, zip, streetNumber, streetName) => {
+export const mapAddress = (state, result) => buildSelector(
+  (state) => state.get('addressTypes'),
+  () => (result.get('addresses') || List()).isEmpty(),
+  () => result.getIn(['addresses', 0, 'city']),
+  () => result.getIn(['addresses', 0, 'state_code']),
+  () => result.getIn(['addresses', 0, 'zip']),
+  () => result.getIn(['addresses', 0, 'type', 'id']),
+  () => result.getIn(['addresses', 0, 'street_number']),
+  () => result.getIn(['addresses', 0, 'street_name']),
+  (addressTypes, addressesEmpty, city, stateCode, zip, typeId, streetNumber, streetName) => {
     if (addressesEmpty) { return null } else {
+      const type = findByCode(addressTypes.toJS(), typeId).value
       return Map({
         city: city,
         state: stateCode,
         zip: zip,
-        type: '', // TODO: Implement as part of #INT-537
+        type: type ? type : '',
         streetAddress: `${streetNumber} ${streetName}`,
       })
     }
   }
-)(result)
+)(state)

--- a/app/javascript/utils/peopleSearchHelper.js
+++ b/app/javascript/utils/peopleSearchHelper.js
@@ -1,5 +1,6 @@
 import {Map, List, fromJS} from 'immutable'
-import {findByCode, buildSelector} from 'selectors'
+import {buildSelector} from 'selectors'
+import {systemCodeDisplayValue} from 'selectors/systemCodeSelectors'
 
 export const mapLanguages = (state, result) => buildSelector(
   (state) => state.get('languages'),
@@ -8,7 +9,7 @@ export const mapLanguages = (state, result) => buildSelector(
     languages
       .sort((item) => item.get('primary'))
       .map((language) => (
-        findByCode(statusCodes.toJS(), language.get('id')).value)
+        systemCodeDisplayValue(language.get('id'), statusCodes))
       )
 
   )
@@ -25,12 +26,12 @@ export const mapRaces = (state, result) => buildSelector(
   () => result.get('unable_to_determine_code'),
   (ethnicityTypes, raceTypes, unableToDetermineCodes, races, unableToDetermineCode) => {
     if (unableToDetermineCode) {
-      return List([findByCode(unableToDetermineCodes.toJS(), unableToDetermineCode).value])
+      return List([systemCodeDisplayValue(unableToDetermineCode, unableToDetermineCodes)])
     } else {
       return races
         .map((race) => (Map({
-          race: findByCode(raceTypes.toJS(), race.get('id')).value,
-          race_detail: findByCode(ethnicityTypes.toJS(), race.get('id')).value,
+          race: systemCodeDisplayValue(race.get('id'), raceTypes),
+          race_detail: systemCodeDisplayValue(race.get('id'), ethnicityTypes),
         })))
     }
   }
@@ -41,7 +42,7 @@ export const mapEthnicities = (state, result) => buildSelector(
   () => (result.getIn(['race_ethnicity', 'hispanic_codes']) || List()),
   () => (result.getIn(['race_ethnicity', 'hispanic_origin_code'])),
   (hispanicOriginCodes, ethnicities, hispanicLatinoOriginCode) => fromJS({
-    hispanic_latino_origin: findByCode(hispanicOriginCodes.toJS(), hispanicLatinoOriginCode).value,
+    hispanic_latino_origin: systemCodeDisplayValue(hispanicLatinoOriginCode, hispanicOriginCodes),
     ethnicity_detail: ethnicities.map((ethnicity) => ethnicity.get('description')).toJS(),
   })
 )(state)
@@ -57,7 +58,7 @@ export const mapAddress = (state, result) => buildSelector(
   () => result.getIn(['addresses', 0, 'street_name']),
   (addressTypes, addressesEmpty, city, stateCode, zip, typeId, streetNumber, streetName) => {
     if (addressesEmpty) { return null } else {
-      const type = findByCode(addressTypes.toJS(), typeId).value
+      const type = systemCodeDisplayValue(typeId, addressTypes)
       return Map({
         city: city,
         state: stateCode,

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -20,12 +20,18 @@ feature 'home page' do
               builder.with_last_name('Simpson')
               builder.with_ssn('123-23-1234')
               builder.with_gender('female')
-              builder.with_addresses(
-                street_number: 123,
-                street_name: 'Fake St',
-                state_code: 'CA',
-                type: 'Home'
-              )
+              builder.with_addresses do
+                [
+                  AddressSearchResultBuilder.build do |address|
+                    address.with_street_number('123')
+                    address.with_street_name('Fake St')
+                    address.with_state_code('CA')
+                    address.with_type do
+                      AddressTypeSearchResultBuilder.build('Home')
+                    end
+                  end
+                ]
+              end
             end
           ]
         end

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -39,14 +39,20 @@ feature 'searching a participant in autocompleter' do
                 ]
               end
               builder.with_phone_number(number: '971-287-6774', type: 'Home')
-              builder.with_addresses([{
-                                       street_number: '123',
-                                       street_name: 'Fake St',
-                                       state_code: 'NY',
-                                       city: 'Springfield',
-                                       zip: '11222',
-                                       type: ''
-                                     }])
+              builder.with_addresses do
+                [
+                  AddressSearchResultBuilder.build do |address|
+                    address.with_street_number('123')
+                    address.with_street_name('Fake St')
+                    address.with_state_code('NY')
+                    address.with_city('Springfield')
+                    address.with_zip('11222')
+                    address.with_type do
+                      AddressTypeSearchResultBuilder.build('Home')
+                    end
+                  end
+                ]
+              end
               builder.with_race_and_ethnicity do
                 RaceEthnicitySearchResultBuilder.build do |race_ethnicity|
                   race_ethnicity.with_hispanic_origin_code('Y')
@@ -84,6 +90,7 @@ feature 'searching a participant in autocompleter' do
         expect(page).to have_content '1234'
         expect(page).to have_content '123-23-1234'
         expect(page).to have_content '123 Fake St, Springfield, NY 11222'
+        expect(page).to have_content 'Home'
         expect(page).to have_content 'Sensitive'
         expect(page).to_not have_content 'Sealed'
       end
@@ -192,7 +199,7 @@ feature 'searching a participant in autocompleter' do
               builder.with_middle_name('Jacqueline')
               builder.with_last_name('Simpson')
               builder.with_name_suffix('md')
-              builder.with_addresses({})
+              builder.with_addresses { [] }
             end
           ]
         end

--- a/spec/javascripts/reducers/systemCodes/addressTypesReducerSpec.js
+++ b/spec/javascripts/reducers/systemCodes/addressTypesReducerSpec.js
@@ -1,0 +1,24 @@
+import {List, fromJS} from 'immutable'
+import * as matchers from 'jasmine-immutable-matchers'
+import addressTypesReducer from 'reducers/systemCodes/addressTypesReducer'
+import {fetchSuccess, fetchFailure} from 'actions/systemCodesActions'
+
+describe('addressTypesReducer', () => {
+  beforeEach(() => jasmine.addMatchers(matchers))
+
+  describe('on FETCH_STATUS_CODES_COMPLETE', () => {
+    it('returns the system codes for counties', () => {
+      const action = fetchSuccess([
+        {code: '123', value: 'Home', category: 'address_type'},
+        {code: '456', value: 'Monterey', category: 'county_type'},
+      ])
+      expect(addressTypesReducer(List(), action)).toEqualImmutable(fromJS([
+        {code: '123', value: 'Home', category: 'address_type'},
+      ]))
+    })
+    it('returns the last state on failure', () => {
+      const action = fetchFailure()
+      expect(addressTypesReducer(List(), action)).toEqualImmutable(List())
+    })
+  })
+})

--- a/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
+++ b/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
@@ -36,6 +36,10 @@ describe('peopleSearchSelectors', () => {
     {code: '1', value: 'state'},
   ]
 
+  const addressTypes = [
+    {code: '1', value: 'address type'},
+  ]
+
   describe('getLastResultsSortValueSelector', () => {
     it('returns the last results sort attribute', () => {
       const peopleSearch = {
@@ -80,7 +84,7 @@ describe('peopleSearchSelectors', () => {
               city: 'Flushing',
               state_code: 'state',
               zip: '11344',
-              type: 'School',
+              type: {id: '1'},
             }],
             phone_numbers: [{
               id: '2',
@@ -103,6 +107,7 @@ describe('peopleSearchSelectors', () => {
         hispanicOriginCodes,
         usStates,
         peopleSearch,
+        addressTypes,
       })
       const peopleResults = getPeopleResultsSelector(state)
       expect(peopleResults).toEqualImmutable(
@@ -131,7 +136,7 @@ describe('peopleSearchSelectors', () => {
             city: 'Flushing',
             state: 'state',
             zip: '11344',
-            type: '',
+            type: 'address type',
             streetAddress: '234 Fake Street',
           },
           phoneNumber: {
@@ -155,7 +160,7 @@ describe('peopleSearchSelectors', () => {
               city: 'Flushing',
               state_code: 'state',
               zip: '11344',
-              type: 'School',
+              type: {id: '1'},
             }, {
               id: '2',
               street_number: '2',
@@ -163,7 +168,7 @@ describe('peopleSearchSelectors', () => {
               city: 'Flushing',
               state_code: 'state',
               zip: '11222',
-              type: 'Home',
+              type: {id: '1'},
             }],
             phone_numbers: [{
               number: '994-907-6774',
@@ -183,6 +188,7 @@ describe('peopleSearchSelectors', () => {
         hispanicOriginCodes,
         usStates,
         peopleSearch,
+        addressTypes,
       })
       const peopleResults = getPeopleResultsSelector(state)
       expect(peopleResults.getIn([0, 'address'])).toEqualImmutable(
@@ -190,7 +196,7 @@ describe('peopleSearchSelectors', () => {
           city: 'Flushing',
           state: 'state',
           zip: '11344',
-          type: '',
+          type: 'address type',
           streetAddress: '234 Fake Street',
         })
       )
@@ -219,6 +225,7 @@ describe('peopleSearchSelectors', () => {
         hispanicOriginCodes,
         usStates,
         peopleSearch,
+        addressTypes,
       })
       const peopleResults = getPeopleResultsSelector(state)
       expect(peopleResults.getIn([0, 'address'])).toEqual(null)
@@ -252,6 +259,7 @@ describe('peopleSearchSelectors', () => {
         hispanicOriginCodes,
         usStates,
         peopleSearch,
+        addressTypes,
       })
       const peopleResults = getPeopleResultsSelector(state)
       expect(peopleResults.getIn([0, 'firstName'])).toEqual('<em>Bar</em>t')
@@ -276,6 +284,7 @@ describe('peopleSearchSelectors', () => {
         hispanicOriginCodes,
         usStates,
         peopleSearch,
+        addressTypes,
       })
       const peopleResults = getPeopleResultsSelector(state)
       expect(peopleResults.getIn([0, 'ssn'])).toEqual('123-45-6789')
@@ -300,6 +309,7 @@ describe('peopleSearchSelectors', () => {
         hispanicOriginCodes,
         usStates,
         peopleSearch,
+        addressTypes,
       })
       const peopleResults = getPeopleResultsSelector(state)
       expect(peopleResults.getIn([0, 'ssn'])).toEqual('<em>123-45-6789</em>')

--- a/spec/javascripts/store/storeSpec.js
+++ b/spec/javascripts/store/storeSpec.js
@@ -18,6 +18,7 @@ describe('Store', () => {
   beforeEach(() => {
     jasmine.addMatchers(matchers)
     initialState = fromJS({
+      addressTypes: [],
       allegationsForm: [],
       allegationTypes: [],
       communicationMethods: [],

--- a/spec/javascripts/utils/peopleSearchHelperSpec.js
+++ b/spec/javascripts/utils/peopleSearchHelperSpec.js
@@ -37,6 +37,10 @@ describe('peopleSearchHelper', () => {
     {code: 'N', value: 'no'},
   ]
 
+  const addressTypes = [
+    {code: '1', value: 'address type'},
+  ]
+
   describe('mapLanguages', () => {
     it('maps languages to lov values by id, sorting by primary', () => {
       const result = fromJS({
@@ -90,19 +94,43 @@ describe('peopleSearchHelper', () => {
   })
 
   describe('mapAddress', () => {
-    it('returns the city, state, zip, empty type, and a joined street address', () => {
+    it('returns the city, state, zip, type, and a joined street address', () => {
       const result = fromJS({
         addresses: [{
           city: 'city',
           state_code: 'state',
           zip: 'zip',
-          type: 'blah',
+          type: {id: '1'},
           street_number: '123',
           street_name: 'C Street',
 
         }],
       })
-      const addressResult = mapAddress(result)
+      const state = fromJS({addressTypes})
+      const addressResult = mapAddress(state, result)
+      expect(addressResult).toEqualImmutable(fromJS({
+        city: 'city',
+        state: 'state',
+        zip: 'zip',
+        type: 'address type',
+        streetAddress: '123 C Street',
+      }))
+    })
+
+    it('returns city state, zip, a joined street address, and empty string when type is undefined', () => {
+      const result = fromJS({
+        addresses: [{
+          city: 'city',
+          state_code: 'state',
+          zip: 'zip',
+          type: {id: 'not a value to be found'},
+          street_number: '123',
+          street_name: 'C Street',
+
+        }],
+      })
+      const state = fromJS({addressTypes})
+      const addressResult = mapAddress(state, result)
       expect(addressResult).toEqualImmutable(fromJS({
         city: 'city',
         state: 'state',

--- a/spec/support/helpers/system_code_helpers.rb
+++ b/spec/support/helpers/system_code_helpers.rb
@@ -119,6 +119,12 @@ module SystemCodeHelpers
     ]
   end
 
+  def address_types
+    [
+      { code: '1', value: 'Home', category: 'address_type' }
+    ]
+  end
+
   def system_codes
     [
       *allegation_type_codes,
@@ -133,7 +139,8 @@ module SystemCodeHelpers
       *language_codes,
       *hispanic_origin_codes,
       *us_state_codes,
-      *unable_to_determine_codes
+      *unable_to_determine_codes,
+      *address_types
     ]
   end
 

--- a/spec/support/person_search_result_builder.rb
+++ b/spec/support/person_search_result_builder.rb
@@ -73,8 +73,8 @@ class PersonSearchResultBuilder
     ]
   end
 
-  def with_addresses(addresses)
-    @search_result[:_source][:addresses] = addresses
+  def with_addresses
+    @search_result[:_source][:addresses] = yield
   end
 
   def with_legacy_descriptor(legacy_descriptor)
@@ -182,7 +182,7 @@ class HispanicCodesSearchResultBuilder
 
   def self.build(ethnicity)
     builder = new(ethnicity)
-    yeild(builder)
+    yield(builder)
     builder.hispanic_codes
   end
 
@@ -194,4 +194,60 @@ class HispanicCodesSearchResultBuilder
   end
 
   attr_reader :hispanic_codes
+end
+
+class AddressSearchResultBuilder
+  def self.build
+    builder = new
+    yield(builder)
+    builder.address
+  end
+
+  def initialize
+    @address = {}
+  end
+
+  def with_street_number(number)
+    address[:street_number] = number
+  end
+
+  def with_street_name(name)
+    address[:street_name] = name
+  end
+
+  def with_state_code(code)
+    address[:state_code] = code
+  end
+
+  def with_city(city)
+    address[:city] = city
+  end
+
+  def with_zip(zip)
+    address[:zip] = zip
+  end
+
+  def with_type
+    address[:type] = yield
+  end
+
+  attr_reader :address
+end
+
+class AddressTypeSearchResultBuilder
+  include ::SystemCodeHelpers
+
+  def self.build(type)
+    builder = new(type)
+    builder.address_type
+  end
+
+  def initialize(type)
+    system_code = find_system_code(value: type, category: 'address_type')
+    @address_type = {
+      id: system_code[:code]
+    }
+  end
+
+  attr_reader :address_type
 end


### PR DESCRIPTION
### Jira Story

- [Show address types in Snapshot search results and person card INT-559](https://osi-cwds.atlassian.net/browse/INT-559)

### Purpose
Show address types in snapshot search results and also in person card using the lov service

### Background
we were mapping address type to empty string before.

### Questions for Reviewer


### Notes for Reviewer
related to ca-cwds/intake_api#204

### Testing Notes

