### PR TITLE
Upgraded gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,12 +8,14 @@ gem 'feature'
 gem 'haml-rails'
 gem 'high_voltage'
 gem 'newrelic_rpm'
+gem 'nokogiri', '~> 1.8.1'
 gem 'puma'
 gem 'rails', '~> 5.1'
 gem 'redis-rails'
 gem 'responders'
 gem 'virtus'
 gem 'webpacker'
+gem 'yard', '~> 0.9.11'
 
 group :development, :test do
   gem 'factory_girl_rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -380,7 +380,7 @@ GEM
     xml-simple (1.1.5)
     xpath (2.1.0)
       nokogiri (~> 1.3)
-    yard (0.9.8)
+    yard (0.9.12)
 
 PLATFORMS
   ruby
@@ -403,6 +403,7 @@ DEPENDENCIES
   i18n-tasks
   license_finder
   newrelic_rpm
+  nokogiri (~> 1.8.1)
   parallel_tests
   poltergeist
   pry
@@ -429,6 +430,7 @@ DEPENDENCIES
   web-console (~> 3.5)
   webmock
   webpacker
+  yard (~> 0.9.11)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1


### PR DESCRIPTION
  * Nokogiri to ~> 1.8.1, to remedy the following vulnerability:
  http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-9050

  * Yard to ~> 0.9.11, to remedy the following vulnerability:
  https://nvd.nist.gov/vuln/detail/CVE-2017-17042

### Jira Story

- [Update gems on Intake](https://osi-cwds.atlassian.net/browse/INT-1100)


