### PR TITLE
improve person search profile picture responsiveness

### DIFF
--- a/app/assets/stylesheets/helpers.scss
+++ b/app/assets/stylesheets/helpers.scss
@@ -193,3 +193,13 @@
     display: none;
   }
 }
+
+@media screen and (max-width: 991px) {
+  .profile-picture img {
+    display: none;
+  }
+
+  .profile-picture .image-caption {
+    position: relative;
+  }
+}


### PR DESCRIPTION
### Jira Story

- [nPhoto placeholder expands as browser shrinks (responsive) INT-622](https://osi-cwds.atlassian.net/browse/INT-622)

### Purpose
a temporary fix for browser responsiveness. The profile image in search results becomes ridiculously large when the browser is resized smaller.

The solution is to hide the profile image when it starts to become massive, but keep the sealed and sensitive information markers in each search result so that the user can still tell that the entry is sealed, sensitive or not.

### Notes for Reviewer
In the future, we need to address mobile devices better ... this is only a temporary fix.

