### PR TITLE
remove route dependency on referral_submit feature

### DIFF
--- a/config/routes/active_referral_submit_constraint.rb
+++ b/config/routes/active_referral_submit_constraint.rb
@@ -5,7 +5,7 @@ module Routes
   # for available routes while referral_submit is active and release_two is not active
   class ActiveReferralSubmitConstraint
     def self.matches?(_request)
-      Feature.active?(:referral_submit) && Feature.inactive?(:release_two)
+      Feature.inactive?(:release_two)
     end
   end
 end


### PR DESCRIPTION
### Jira Story

No Story

### Background
This route constraint on referral_submit breaks referral submission. The feature was removed but the constraint still uses it, so the route is inaccessible