### PR TITLE
Int 445 make doj optional in cross reports

### DIFF
--- a/app/javascript/enums/CrossReport.js
+++ b/app/javascript/enums/CrossReport.js
@@ -1,11 +1,13 @@
 export const COMMUNITY_CARE_LICENSING = 'COMMUNITY_CARE_LICENSING'
 export const COUNTY_LICENSING = 'COUNTY_LICENSING'
+export const DEPARTMENT_OF_JUSTICE = 'DEPARTMENT_OF_JUSTICE'
 export const DISTRICT_ATTORNEY = 'DISTRICT_ATTORNEY'
 export const LAW_ENFORCEMENT = 'LAW_ENFORCEMENT'
 
 export const AGENCY_TYPES = Object.freeze({
   [DISTRICT_ATTORNEY]: 'District attorney',
   [LAW_ENFORCEMENT]: 'Law enforcement',
+  [DEPARTMENT_OF_JUSTICE]: 'Department of justice',
   [COUNTY_LICENSING]: 'County licensing',
   [COMMUNITY_CARE_LICENSING]: 'Community care licensing',
 })

--- a/app/javascript/views/CrossReportForm.jsx
+++ b/app/javascript/views/CrossReportForm.jsx
@@ -11,6 +11,7 @@ import {
   COMMUNICATION_METHODS,
   COMMUNITY_CARE_LICENSING,
   COUNTY_LICENSING,
+  DEPARTMENT_OF_JUSTICE,
   DISTRICT_ATTORNEY,
   LAW_ENFORCEMENT,
 } from 'enums/CrossReport'
@@ -24,6 +25,7 @@ const CrossReportForm = ({
   county_id,
   countyAgencies,
   countyLicensing,
+  departmentOfJustice,
   districtAttorney,
   hasAgencies,
   errors,
@@ -118,6 +120,17 @@ const CrossReportForm = ({
           </div>
           <div className='col-md-6'>
             <ul className='unstyled-list'>
+              { departmentOfJustice &&
+                <li key={DEPARTMENT_OF_JUSTICE}>
+                  <CrossReportAgencyField
+                    type={DEPARTMENT_OF_JUSTICE}
+                    selected={departmentOfJustice.selected}
+                    value={departmentOfJustice.agency.value}
+                    countyAgencies={countyAgencies[DEPARTMENT_OF_JUSTICE]}
+                    errors={errors[DEPARTMENT_OF_JUSTICE]}
+                    actions={agencyFieldActions}
+                  />
+                </li> }
               <li key={COUNTY_LICENSING}>
                 <CrossReportAgencyField
                   type={COUNTY_LICENSING}
@@ -197,6 +210,7 @@ CrossReportForm.propTypes = {
   countyAgencies: PropTypes.object,
   countyLicensing: PropTypes.object.isRequired,
   county_id: PropTypes.string.isRequired,
+  departmentOfJustice: PropTypes.object,
   districtAttorney: PropTypes.object.isRequired,
   errors: PropTypes.object.isRequired,
   hasAgencies: PropTypes.bool.isRequired,

--- a/spec/javascripts/views/CrossReportFormSpec.jsx
+++ b/spec/javascripts/views/CrossReportFormSpec.jsx
@@ -16,6 +16,7 @@ describe('CrossReportForm', () => {
       DISTRICT_ATTORNEY: [],
       LAW_ENFORCEMENT: [],
     },
+    departmentOfJustice,
     districtAttorney = {
       selected: false,
       touched: false,
@@ -70,6 +71,7 @@ describe('CrossReportForm', () => {
       counties,
       county_id,
       countyAgencies,
+      departmentOfJustice,
       districtAttorney,
       errors,
       lawEnforcement,
@@ -236,6 +238,46 @@ describe('CrossReportForm', () => {
       expect(field.props().actions).toEqual(actions)
       expect(field.props().errors).toEqual(['le is missing'])
     })
+    it('renders DEPARTMENT_OF_JUSTICE agency field if departmentOfJustice is passed', () => {
+      const component = renderCrossReportForm({
+        county_id: '12',
+        departmentOfJustice: {selected: true, agency: {value: '1234'}},
+        countyAgencies: {
+          COMMUNITY_CARE_LICENSING: [],
+          COUNTY_LICENSING: [],
+          DEPARTMENT_OF_JUSTICE: [{id: '123', value: 'asdf'}],
+          DISTRICT_ATTORNEY: [],
+          LAW_ENFORCEMENT: [],
+        },
+        errors: {
+          DEPARTMENT_OF_JUSTICE: ['doj is missing'],
+        },
+        actions,
+      })
+      const field = component.find('CrossReportAgencyField[type="DEPARTMENT_OF_JUSTICE"]')
+      expect(field.props().selected).toEqual(true)
+      expect(field.props().value).toEqual('1234')
+      expect(field.props().countyAgencies).toEqual([{id: '123', value: 'asdf'}])
+      expect(field.props().actions).toEqual(actions)
+      expect(field.props().errors).toEqual(['doj is missing'])
+    })
+    it('does not render DEPARTMENT_OF_JUSTICE agency field if departmentOfJustice is not passed', () => {
+      const component = renderCrossReportForm({
+        county_id: '12',
+        countyAgencies: {
+          COMMUNITY_CARE_LICENSING: [],
+          COUNTY_LICENSING: [],
+          DISTRICT_ATTORNEY: [],
+          LAW_ENFORCEMENT: [],
+        },
+        errors: {
+          DEPARTMENT_OF_JUSTICE: ['doj is missing'],
+        },
+        actions,
+      })
+      expect(component.find('CrossReportAgencyField[type="DEPARTMENT_OF_JUSTICE"]').exists()).toBe(false)
+    })
+
     it('renders COUNTY_LICENSING agency field', () => {
       const component = renderCrossReportForm({
         county_id: '12',


### PR DESCRIPTION
[#445]

### Jira Story

- [Remove DOJ from screening page INT-445](https://osi-cwds.atlassian.net/browse/INT-445)

### Purpose
Make Department of Justice an optional field in the cross reports view.