### PR TITLE
No mock fail feature spec

### DIFF
--- a/lib/error_handler.rb
+++ b/lib/error_handler.rb
@@ -4,6 +4,13 @@
 module ErrorHandler
   def self.included(base)
     base.class_eval do
+      if Rails.env.test?
+        rescue_from(WebMock::NetConnectNotAllowedError) do |exception|
+          incident_id = SecureRandom.uuid
+          log_standard_error(exception, incident_id)
+          render json: generate_standard_error(exception, incident_id), status: 500
+        end
+      end
       rescue_from StandardError, with: :handle_exception
     end
   end

--- a/spec/features/api_response_spec.rb
+++ b/spec/features/api_response_spec.rb
@@ -53,10 +53,7 @@ feature 'API call' do
   end
 
   scenario 'returns a success' do
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
-      .and_return(json_body(screening.to_json, status: 200))
-    stub_empty_relationships_for_screening(screening)
-    visit screening_path(id: screening.id)
+    stub_and_visit_show_screening(screening)
     expect(page.current_url).to have_content screening_path(screening.id)
   end
 end

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -12,6 +12,7 @@ feature 'error pages' do
     Rails.application.config.consider_all_requests_local = true
     Rails.application.config.action_dispatch.show_exceptions = false
   end
+  let(:screening) { FactoryGirl.create(:screening, :submittable) }
 
   context 'page does not exist' do
     scenario 'renders 404 page' do
@@ -30,10 +31,11 @@ feature 'error pages' do
 
   context 'screening does not exist' do
     scenario 'renders not found error page' do
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(1)))
+      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
         .and_return(json_body('Screening is not found!!', status: 404))
-      stub_empty_history_for_screening(id: 1)
-      visit edit_screening_path(id: 1)
+      stub_empty_relationships_for_screening(screening)
+      stub_empty_history_for_screening(screening)
+      visit edit_screening_path(id: screening.id)
       expect(page).to have_text('Sorry, this is not the page you want.')
       expect(page).to have_text(
         "It may have been deleted or doesn't exist. Please check the address or"
@@ -71,10 +73,11 @@ feature 'error pages' do
 
   context 'when user attempts to access a screening created by another' do
     scenario 'renders 403 page' do
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(1)))
+      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
         .and_return(json_body('Forbidden!!', status: 403))
-      stub_empty_history_for_screening(id: 1)
-      visit edit_screening_path(id: 1)
+      stub_empty_relationships_for_screening(screening)
+      stub_empty_history_for_screening(screening)
+      visit edit_screening_path(id: screening.id)
       expect(page).to have_current_path('/forbidden')
       expect(page).to have_text('This page is restricted.')
       expect(page).to have_text("You don't have the appropriate permissions to view this page.")

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -152,6 +152,8 @@ feature 'login' do
     screening = FactoryGirl.create(:screening, name: 'My Screening')
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
+    stub_empty_history_for_screening(screening)
+    stub_empty_relationships_for_screening(screening)
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
       .and_return(json_body([].to_json, status: 200))
     stub_empty_history_for_screening(screening)
@@ -308,6 +310,7 @@ feature 'login perry v1' do
       stub_request(:get, auth_validation_url)
         .and_return(json_body(auth_artifact.to_json, status: 200))
       stub_empty_history_for_screening(screening)
+      stub_empty_relationships_for_screening(screening)
 
       bobs_token = 'BOBS_TOKEN'
       Capybara.using_session(:bob) do

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -30,6 +30,8 @@ feature 'Create Screening' do
 
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id)))
         .and_return(json_body(new_screening.to_json, status: 200))
+      stub_empty_relationships_for_screening(new_screening)
+      stub_empty_history_for_screening(new_screening)
 
       visit root_path
       click_button 'Start Screening'

--- a/spec/features/screening/decision_spec.rb
+++ b/spec/features/screening/decision_spec.rb
@@ -18,6 +18,8 @@ feature 'decision card' do
     stub_empty_history_for_screening(screening)
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
+    stub_empty_relationships_for_screening(screening)
+    stub_empty_history_for_screening(screening)
 
     visit edit_screening_path(id: screening.id)
   end

--- a/spec/features/screening/validations/cross_reports_validations_spec.rb
+++ b/spec/features/screening/validations/cross_reports_validations_spec.rb
@@ -97,8 +97,6 @@ feature 'Cross Reports Validations' do
         before do
           stub_county_agencies('c41')
           screening.cross_reports[0].agencies[0].id = 'EYIS9Nh75C'
-          stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
-            .and_return(json_body(screening.to_json, status: 200))
           stub_and_visit_edit_screening(screening)
         end
         scenario 'shows no error when filled in' do

--- a/spec/features/screening/validations/screening_information_validations_spec.rb
+++ b/spec/features/screening/validations/screening_information_validations_spec.rb
@@ -188,6 +188,7 @@ feature 'Screening Information Validations' do
     before do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
         .and_return(json_body(screening.to_json, status: 200))
+      stub_empty_relationships_for_screening(screening)
       stub_empty_history_for_screening(screening)
 
       visit screening_path(id: screening.id)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -71,7 +71,8 @@ RSpec.configure do |config|
   end
 
   config.around(:each, type: :feature) do |example|
-    WebMock.disable_net_connect!(allow_localhost: true)
+    allowed_sites = ->(uri) { uri.host == Capybara.server_host && uri !~ %r{/api/} }
+    WebMock.disable_net_connect!(allow: allowed_sites)
     example.run
     WebMock.allow_net_connect!
   end


### PR DESCRIPTION
### Jira Story

No Story

### Purpose
Make Request stubbing more restrictive so that we don't allow real network requests

### Background
using `WebMock.disable_net_connect!(allow_localhost: true)` allows real network requests between intake and intake api (any connection on local host). I changed it to allow localhost unless its calling an api endpoint.

### Notes
This won't force engineers to stub requests that are irrelevant but will keep them from making real network requests. Its very hard to force the test to fail when the network requests are denied because the requests happen after page visit.

