### PR TITLE
Fix copy and pasting to MS Word in Chrome

### DIFF
--- a/app/javascript/containers/screenings/HistoryTableContainer.jsx
+++ b/app/javascript/containers/screenings/HistoryTableContainer.jsx
@@ -13,6 +13,17 @@ const mapStateToProps = (state) => {
     cases: getFormattedCasesSelector(state).toJS(),
     referrals: getFormattedReferralsSelector(state).toJS(),
     screenings: [],
+    // To make the copied table fit in MS Word, we have to temporarily resize it.
+    onCopy: (copyContent) => {
+      copyContent.style.width = '1%'
+      return copyContent
+    },
+    onSuccess: (copyContent) => {
+      copyContent.style.width = null
+    },
+    onError: (copyContent) => {
+      copyContent.style.width = null
+    },
   }
   if (IntakeConfig.isFeatureActive('release_two')) {
     return props

--- a/app/javascript/views/history/HistoryTable.jsx
+++ b/app/javascript/views/history/HistoryTable.jsx
@@ -7,7 +7,7 @@ import Clipboard from 'react-clipboard.js'
 
 export default class HistoryTable extends React.Component {
   render() {
-    const {cases, referrals, screenings} = this.props
+    const {cases, onCopy, onError, onSuccess, referrals, screenings} = this.props
     return (<div className='card-body no-pad-top'>
       <div className='table-responsive' ref={(history) => { this.historyTable = history }}>
         <table className='table table-hover'>
@@ -34,7 +34,12 @@ export default class HistoryTable extends React.Component {
       </div>
       <div className='row'>
         <div className='centered'>
-          <Clipboard className='btn btn-primary' option-target={() => (this.historyTable)}>
+          <Clipboard
+            className='btn btn-primary'
+            onSuccess={() => onSuccess(this.historyTable)}
+            onError={() => onError(this.historyTable)}
+            option-target={() => (onCopy(this.historyTable))}
+          >
             Copy
           </Clipboard>
         </div>
@@ -46,6 +51,9 @@ export default class HistoryTable extends React.Component {
 
 HistoryTable.propTypes = {
   cases: PropTypes.array,
+  onCopy: PropTypes.func,
+  onError: PropTypes.func,
+  onSuccess: PropTypes.func,
   referrals: PropTypes.array,
   screenings: PropTypes.array,
 }

--- a/spec/javascripts/views/history/HistoryTableSpec.jsx
+++ b/spec/javascripts/views/history/HistoryTableSpec.jsx
@@ -46,7 +46,11 @@ describe('HistoryTable', () => {
       it('renders', () => {
         const component = renderHistoryTable({})
         const copyButton = component.find('ClipboardButton')
+
+        expect(copyButton.exists()).toEqual(true)
         expect(copyButton.props()['option-target']).toBeDefined()
+        expect(copyButton.props().onSuccess).toBeDefined()
+        expect(copyButton.props().onError).toBeDefined()
       })
     })
   })


### PR DESCRIPTION
[#1088]

### Jira Story

- [Name of Story INT-NNN](https://osi-cwds.atlassian.net/browse/INT-NNN)

### Purpose

To allow copying from Chrome and pasting into MS Word without the table partially hidden

### Background

To fix copying in IE11, we upgraded the clipboard library. This caused Chrome copy/paste functionality to break because it made the table too big to fit into a standard MS Word document.