### PR TITLE
Strip out slashes and dashes only in formatted date strings

### DIFF
--- a/app/services/person_search_query_builder.rb
+++ b/app/services/person_search_query_builder.rb
@@ -28,8 +28,9 @@ class PersonSearchQueryBuilder
   def formatted_search_term
     @search_term
       .downcase
-      .gsub(/(\d+\s*)[^a-z0-9 ]+/, '\1') # Remove special chars after digits
-      .gsub(/([a-z]+\s*)[^a-z0-9 ]+/, '\1 ') # Replace special chars after letters w/ space
+      .gsub(%r((\d{1,2})[-/](\d{1,2})[-/](\d{4})), '\1\2\3')
+      .gsub(%r((\d{1,2})[-/](\d{4})), '\1\2')
+      .gsub(%r((\d{1,2})[-/](\d{1,2})), '\1\2')
   end
 
   def query


### PR DESCRIPTION
[#INT-1145]

### Jira Story

- [Name of Story INT-1145](https://osi-cwds.atlassian.net/browse/INT-1145)

### Purpose
To allow more characters in person search but still strip out slashes and dashes in datetimes

### Background
date times are indexed in elastic search without slashes and dashes because the algorithm we use to index natural language would split out each part of the date time into a separate word anding them. Therefore we have to remove slashes and dashes from *only* date time portions of the search. The old solution was essentially whitelisting numbers and letters, which is not good enough because names can technically include apostrophes, dashes, dots, or other unicode characters. 

The recognized date time formats by elasticsearch are:

MMddyyyy (month, day, year - example: 01/09/1995)
MMyyyy (month, year - example: 09/1995)
yyyy (year - example: 1995)
MMdd (month, day - example: 01/09)
Mdyyyy (month, day, year - removed leading zeros - example: 01/09/1995)
Myyyy (month, year - removed leading zeros - example: 9/1995)
Md (month, day - removed leading zeros - example: 1/9)
