### PR TITLE
search term must be formatted as the user is typing

### DIFF
--- a/app/services/person_search_query_builder.rb
+++ b/app/services/person_search_query_builder.rb
@@ -28,9 +28,7 @@ class PersonSearchQueryBuilder
   def formatted_search_term
     @search_term
       .downcase
-      .gsub(%r((\d{1,2})[-/](\d{1,2})[-/](\d{4})), '\1\2\3')
-      .gsub(%r((\d{1,2})[-/](\d{4})), '\1\2')
-      .gsub(%r((\d{1,2})[-/](\d{1,2})), '\1\2')
+      .gsub(%r{[-/]*(\d+)[-/]*}, '\1')
   end
 
   def query


### PR DESCRIPTION
[#INT-1145]

### Jira Story

- [Name of Story INT-1145](https://osi-cwds.atlassian.net/browse/INT-1145)

### Purpose
Follow up on a previous pull request, that had regexes specifically for each date time format we support. It did not take care of when the user was typing. I simplified the regex and added some tests for formatting the search term as the user types.

### Implementation Notes
Elastic search is not indexed to handle formatted date time searches. Each datetime is stripped of formatting when its indexed. As a result we have to send elastic search date times stripped of formatting.

This solution strictly removes all dashes and slashes from the search term that are next to numbers. Hence, if a user types in something that is not a valid datetime format such as "1/2-2005" or "1//2/2005/" they will still get results. If we want search to be more restrictive, we need to come up with a better searching strategy that will involve dora, elastic search, and as-little-as-possible effort on the front end.