### PR TITLE
Int 1272 feature specs stubbing with webmock

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -6,7 +6,9 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum, this matches the default thread size of Active Record.
 #
-threads_count = ENV.fetch('RAILS_MAX_THREADS') { 5 }.to_i
+rails_env = ENV.fetch('RAILS_ENV') { 'development' }
+
+threads_count = ENV.fetch('RAILS_MAX_THREADS') { rails_env == 'production' ? 5 : 1 }.to_i
 threads threads_count, threads_count
 
 # Specifies the `port` that Puma will listen on to receive requests,
@@ -16,7 +18,7 @@ port        ENV.fetch('PORT') { 3000 }
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch('RAILS_ENV') { 'development' }
+environment rails_env
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked webserver processes. If using threads and workers together

--- a/lib/error_handler.rb
+++ b/lib/error_handler.rb
@@ -8,7 +8,7 @@ module ErrorHandler
         rescue_from(WebMock::NetConnectNotAllowedError) do |exception|
           incident_id = SecureRandom.uuid
           log_standard_error(exception, incident_id)
-          render json: generate_standard_error(exception, incident_id), status: 500
+          raise StandardError, exception.message
         end
       end
       rescue_from StandardError, with: :handle_exception

--- a/spec/features/contacts/create_investigation_contact_spec.rb
+++ b/spec/features/contacts/create_investigation_contact_spec.rb
@@ -88,6 +88,15 @@ feature 'Create Investigation Contact' do
   end
 
   scenario 'saving with communication method not set to in-person save location as office' do
+    contact_id = 'new_contact_id'
+    show_path = ExternalRoutes.ferb_api_investigations_contact_path(investigation_id, contact_id)
+    create_path = ExternalRoutes.ferb_api_investigations_contacts_path(investigation_id)
+    persisted_contact = { legacy_descriptor: { legacy_id: contact_id } }
+    stub_request(:post, ferb_api_url(create_path)).and_return(
+      json_body(persisted_contact.to_json, status: 201)
+    )
+    stub_request(:get, ferb_api_url(show_path)).and_return(json_body({}.to_json, status: 200))
+
     fill_in_datepicker 'Date/Time', with: '08/17/2016 3:00 AM'
     select 'Contact status 1', from: 'Status'
     select 'Communication method 2', from: 'Communication Method'

--- a/spec/features/contacts/edit_investigation_contact_spec.rb
+++ b/spec/features/contacts/edit_investigation_contact_spec.rb
@@ -50,6 +50,7 @@ feature 'Edit Investigation Contact' do
     stub_request(:get, investigation_show_url)
       .and_return(json_body(investigation.to_json, status: 200))
     stub_request(:get, contact_show_url).and_return(json_body(contact.to_json, status: 200))
+    stub_request(:put, contact_show_url).and_return(json_body({}.to_json, status: 200))
     visit edit_investigation_contact_path(investigation_id: investigation_id, id: contact_id)
   end
 

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -72,6 +72,9 @@ feature 'home page' do
 
   context 'when no releases are enabled' do
     scenario 'includes title and navigation links' do
+      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path)).and_return(
+        json_body([], status: 200)
+      )
       visit root_path
       expect(page).to have_title 'Intake'
       expect(page).to have_button 'Start Screening'

--- a/spec/features/investigations/show_investigation_spec.rb
+++ b/spec/features/investigations/show_investigation_spec.rb
@@ -78,7 +78,13 @@ feature 'Show Investigation' do
       end
     end
 
-    scenario 'view an existing screening returns 404', browser: :poltergeist do
+    scenario 'view an existing investigation returns 404', browser: :poltergeist do
+      pending(<<~MESSAGE)
+        This is waiting for changes that will enable our single page application to handle routes better.
+        Currently, we are using react router and rails router to handle routing our 404 pages.
+
+        This test was giving us a false positive, because rails is returning 500
+      MESSAGE
       investigation_id = '12345'
       visit investigation_path(id: investigation_id)
       expect(
@@ -87,7 +93,7 @@ feature 'Show Investigation' do
           intake_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
         )
       ).to_not have_been_made
-      expect(page.status_code).to_not eq 200
+      expect(page.status_code).to eq 404
     end
   end
 end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -104,6 +104,10 @@ feature 'login' do
           let(:base_path) { 'intake' }
 
           scenario 'when user logs out' do
+            pending(<<~MESSAGE)
+              base path cannot be configured during the test run.
+              This exposes a problem with how we are handling base path in our environment setup.
+            MESSAGE
             visit root_path(accessCode: 'tempToken123')
             # regular click_link won't keep the pop-up menu open for some reason
             execute_script('$(".fa.fa-user").click()')
@@ -141,6 +145,7 @@ feature 'login' do
     expect(a_request(:get, auth_validation_url)).to have_been_made
     WebMock.reset!
 
+    stub_system_codes
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
       .and_return(json_body(screening_results, status: 200))
     visit root_path
@@ -293,6 +298,7 @@ feature 'login perry v1' do
     expect(a_request(:get, auth_validation_url)).to have_been_made
     WebMock.reset!
 
+    stub_system_codes
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
       .and_return(json_body(screening_results, status: 200))
     visit root_path

--- a/spec/features/screening/allegations/edit_allegations_spec.rb
+++ b/spec/features/screening/allegations/edit_allegations_spec.rb
@@ -706,6 +706,8 @@ feature 'edit allegations' do
 
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      .and_return(json_body({}.to_json, status: 200))
     stub_empty_relationships_for_screening(screening)
     stub_empty_history_for_screening(screening)
 

--- a/spec/features/screening/allegations/show_allegations_spec.rb
+++ b/spec/features/screening/allegations/show_allegations_spec.rb
@@ -34,6 +34,8 @@ feature 'show allegations' do
     stub_empty_history_for_screening(screening)
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      .and_return(json_body({}.to_json, status: 200))
 
     visit screening_path(id: screening.id)
 
@@ -329,6 +331,8 @@ feature 'show allegations' do
 
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      .and_return(json_body({}.to_json, status: 200))
     stub_empty_relationships_for_screening(screening)
     stub_empty_history_for_screening(screening)
 

--- a/spec/features/screening/cross_reports_spec.rb
+++ b/spec/features/screening/cross_reports_spec.rb
@@ -16,6 +16,9 @@ feature 'cross reports' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_request(
+      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+    ).and_return(json_body(existing_screening.to_json, status: 200))
     stub_empty_relationships_for_screening(existing_screening)
     stub_empty_history_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
@@ -76,6 +79,9 @@ feature 'cross reports' do
     ]
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+    ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_request(
+      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
     stub_empty_relationships_for_screening(existing_screening)
     stub_empty_history_for_screening(existing_screening)
@@ -185,6 +191,9 @@ feature 'cross reports' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_request(
+      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+    ).and_return(json_body(existing_screening.to_json, status: 200))
     stub_empty_relationships_for_screening(existing_screening)
     stub_empty_history_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening.id)
@@ -227,6 +236,9 @@ feature 'cross reports' do
   scenario 'communication method and time fields are cleared after county change' do
     stub_request(
       :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+    ).and_return(json_body(existing_screening.to_json, status: 200))
+    stub_request(
+      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).and_return(json_body(existing_screening.to_json, status: 200))
     stub_empty_relationships_for_screening(existing_screening)
     stub_empty_history_for_screening(existing_screening)

--- a/spec/features/screening/edit_screening_spec.rb
+++ b/spec/features/screening/edit_screening_spec.rb
@@ -272,6 +272,7 @@ feature 'Edit Screening' do
       stub_request(
         :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
       ).and_return(json_body(existing_screening.to_json, status: 200))
+      stub_county_agencies('c42')
       stub_empty_relationships_for_screening(existing_screening)
       stub_empty_history_for_screening(existing_screening)
       visit edit_screening_path(id: existing_screening.id)

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -374,6 +374,11 @@ feature 'Create participant' do
       scenario 'cannot add sensitive' do
         Feature.run_with_activated(:authentication) do
           stub_empty_history_for_screening(existing_screening)
+          stub_person_search(search_term: 'Marge', person_response: marge_response)
+          stub_request(
+            :post,
+            intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id))
+          ).and_return(json_body({}.to_json, status: 201))
           visit edit_screening_path(id: existing_screening.id, token: insensitive_token)
           within '#search-card', text: 'Search' do
             fill_in 'Search for any person', with: 'Marge'

--- a/spec/features/screening/participant/editing_participant_spec.rb
+++ b/spec/features/screening/participant/editing_participant_spec.rb
@@ -57,6 +57,8 @@ feature 'Edit Person' do
 
   context 'editing and saving basic person information' do
     scenario 'saves the person information' do
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
+        .and_return(json_body(marge.to_json, status: 201))
       visit edit_screening_path(id: screening.id)
       within edit_participant_card_selector(marge.id) do
         within '.card-header' do
@@ -101,6 +103,9 @@ feature 'Edit Person' do
 
   context 'editing and saving person phone numbers' do
     scenario 'saves the person information' do
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
+        .and_return(json_body({}.to_json, status: 201))
+
       visit edit_screening_path(id: screening.id)
       within edit_participant_card_selector(marge.id) do
         within '.card-body' do
@@ -141,6 +146,9 @@ feature 'Edit Person' do
 
   context 'editing and saving addresses' do
     scenario 'saves the person information' do
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(homer.id)))
+        .and_return(json_body({}.to_json, status: 201))
+
       address = homer.addresses.first
       visit edit_screening_path(id: screening.id)
       within edit_participant_card_selector(homer.id) do
@@ -194,6 +202,9 @@ feature 'Edit Person' do
 
   context 'editing and saving person demographics' do
     scenario 'saves the person information' do
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
+        .and_return(json_body({}.to_json, status: 201))
+
       visit edit_screening_path(id: screening.id)
       dob = Time.parse(marge.date_of_birth).strftime('%m/%d/%Y')
       within edit_participant_card_selector(marge.id) do
@@ -223,6 +234,9 @@ feature 'Edit Person' do
   end
 
   scenario 'editing & saving a person for a screening saves only the relevant person ids' do
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
+      .and_return(json_body({}.to_json, status: 201))
+
     visit edit_screening_path(id: screening.id)
 
     within edit_participant_card_selector(marge.id) do
@@ -543,6 +557,9 @@ feature 'Edit Person' do
   end
 
   scenario 'setting an approximate age' do
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
+      .and_return(json_body(marge.to_json, status: 201))
+
     visit edit_screening_path(id: screening.id)
     within edit_participant_card_selector(marge.id) do
       expect(page).to have_field('Approximate Age', disabled: true)

--- a/spec/features/screening/participant/phone_number_spec.rb
+++ b/spec/features/screening/participant/phone_number_spec.rb
@@ -11,6 +11,9 @@ feature 'Participant Phone Number' do
   before do
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
+    stub_request(
+      :put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id))
+    ).and_return(json_body(marge.to_json, status: 200))
     stub_empty_relationships_for_screening(screening)
     stub_empty_history_for_screening(screening)
   end

--- a/spec/features/screening/screening_information_spec.rb
+++ b/spec/features/screening/screening_information_spec.rb
@@ -19,6 +19,8 @@ feature 'screening information card' do
   before(:each) do
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      .and_return(json_body(screening.to_json, status: 200))
     stub_empty_relationships_for_screening(screening)
     stub_empty_history_for_screening(screening)
     visit edit_screening_path(id: screening.id)

--- a/spec/features/screening/show_screening_spec.rb
+++ b/spec/features/screening/show_screening_spec.rb
@@ -170,13 +170,13 @@ feature 'Show Screening' do
   end
 
   context 'when release two is enabled' do
-    around do |example|
-      Feature.run_with_activated(:release_two) do
-        example.run
-      end
-    end
-
     scenario 'view an existing screening returns 404', browser: :poltergeist do
+      pending(<<~MESSAGE)
+        This is waiting for changes that will enable our single page application to handle routes better.
+        Currently, we are using react router and rails router to handle routing our 404 pages.
+
+        This test was giving us a false positive, because rails is returning 500
+      MESSAGE
       stub_request(
         :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
       ).and_return(json_body(existing_screening.to_json))
@@ -184,7 +184,7 @@ feature 'Show Screening' do
       stub_empty_history_for_screening(existing_screening)
       visit screening_path(id: existing_screening.id)
 
-      expect(page.status_code).to_not eq 200
+      expect(page.status_code).to eq 404
     end
   end
 

--- a/spec/features/screening/submit_screening_spec.rb
+++ b/spec/features/screening/submit_screening_spec.rb
@@ -35,6 +35,12 @@ feature 'Submit Screening' do
         )
       end
 
+      before do
+        stub_request(
+          :put, intake_api_url(ExternalRoutes.intake_api_participant_path(participant.id))
+        ).and_return(json_body(existing_screening.to_json, status: 200))
+      end
+
       scenario 'submit button is disabled until all cards are saved' do
         visit edit_screening_path(existing_screening.id)
         expect(page).to have_button('Submit', disabled: true)
@@ -132,6 +138,10 @@ feature 'Submit Screening' do
       end
 
       scenario 'the submit button is disabled until the person is valid' do
+        stub_request(
+          :put, intake_api_url(ExternalRoutes.intake_api_participant_path(person.id))
+        ).and_return(json_body(person.to_json, status: 200))
+
         visit edit_screening_path(existing_screening.id)
         save_all_cards
         within('.card', text: person_name) { click_button 'Save' }

--- a/spec/features/screening/validations/allegations_sibling_at_risk_validations_spec.rb
+++ b/spec/features/screening/validations/allegations_sibling_at_risk_validations_spec.rb
@@ -54,6 +54,9 @@ feature 'Allegations Sibling At Risk Validations' do
     end
 
     scenario 'User sees error when adding at risk allegation' do
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(victim.id)))
+        .and_return(json_body(victim.to_json, status: 200))
+
       within '.card.edit', text: 'Allegations' do
         fill_in_react_select "allegations_#{victim.id}_#{perpetrator.id}",
           with: 'At risk, sibling abused'
@@ -308,6 +311,13 @@ feature 'Allegations Sibling At Risk Validations' do
     end
 
     scenario 'User can fix error' do
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(perpetrator.id)))
+        .and_return(json_body(perpetrator.to_json, status: 200))
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(victim2.id)))
+        .and_return(json_body(victim2.to_json, status: 200))
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(victim.id)))
+        .and_return(json_body(victim.to_json, status: 200))
+
       new_allegation = FactoryGirl.create(
         :allegation,
         victim_id: victim2.id,

--- a/spec/features/screening/validations/cross_reports_validations_spec.rb
+++ b/spec/features/screening/validations/cross_reports_validations_spec.rb
@@ -85,6 +85,9 @@ feature 'Cross Reports Validations' do
         end
 
         scenario 'shows error on save page' do
+          stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+            .and_return(json_body(screening.to_json, status: 201))
+
           select '', from: 'County licensing agency name'
           blur_field
           should_have_content error_message, inside: '#cross-report-card.edit'
@@ -98,6 +101,8 @@ feature 'Cross Reports Validations' do
           stub_county_agencies('c41')
           screening.cross_reports[0].agencies[0].id = 'EYIS9Nh75C'
           stub_and_visit_edit_screening(screening)
+          stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+            .and_return(json_body(screening.to_json, status: 201))
         end
         scenario 'shows no error when filled in' do
           select 'Hoverment Agency', from: 'County licensing agency name'

--- a/spec/features/screening/validations/narrative_validations_spec.rb
+++ b/spec/features/screening/validations/narrative_validations_spec.rb
@@ -12,6 +12,8 @@ feature 'Narrative Card Validations' do
     before do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
         .and_return(json_body(screening.to_json, status: 200))
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+        .and_return(json_body(screening.to_json, status: 200))
       stub_empty_relationships_for_screening(screening)
       stub_empty_history_for_screening(screening)
 

--- a/spec/features/screening/validations/screening_decision_validations_spec.rb
+++ b/spec/features/screening/validations/screening_decision_validations_spec.rb
@@ -236,6 +236,8 @@ feature 'Screening Decision Validations' do
       let(:screening_decision) { nil }
 
       scenario 'do not show error on restriction_rationale' do
+        stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+          .and_return(json_body(screening.to_json, status: 200))
         blur_field
         should_not_have_content error_message, inside: '#decision-card.edit'
         save_card('decision')

--- a/spec/features/system_codes_spec.rb
+++ b/spec/features/system_codes_spec.rb
@@ -6,6 +6,8 @@ feature 'System codes' do
   scenario 'system codes are fetch once per page load' do
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
       .and_return(json_body([].to_json, status: 200))
+    stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
+      .and_return(json_body([].to_json, status: 200))
     stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_lov_path))
       .and_return(json_body([].to_json, status: 200))
     visit root_path

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -5,7 +5,6 @@ require 'support/capybara/screenshot'
 require 'capybara/accessible'
 require 'capybara/poltergeist'
 require 'selenium-webdriver'
-Capybara.raise_server_errors = false
 
 # Tests must be run in the correct timezone because
 # of UTC converstion and explicit expectations.
@@ -35,6 +34,7 @@ end
 Capybara.default_driver = :accessible_selenium
 
 Capybara.server_port = 8889 + ENV['TEST_ENV_NUMBER'].to_i
+Capybara.raise_server_errors = true
 
 # Allow aria-label to be used in locators
 Capybara.enable_aria_label = true

--- a/spec/support/helpers/events_helpers.rb
+++ b/spec/support/helpers/events_helpers.rb
@@ -6,7 +6,7 @@ module EventsHelpers
   end
 
   def blur_field
-    page.document.find('body').click
+    page.document.find('.page-title').click
   end
 end
 


### PR DESCRIPTION
### Jira Story

- [Name of Story INT-1272](https://osi-cwds.atlassian.net/browse/INT-1272)

### Purpose
These changes, force the test to stub all requests or fail.

### Notes for Reviewer
`Capybara.raise_server_errors` needed to be turned off for some tests because fake routes were being used. In test and development environments rails will raise a route not found exception instead of throwing a 404 error. Any suggestions for how to handle these specific cases better would be greatly appreciated.

Puma has a deadlock issue with ruby > 2.3, so I changed the thread count to be 1 for test and development. Another solution would be turning on eager_loading, but that causes our test setup to fail right now.

I changed the blur helper to click on the page title because its always present, and clicking on the body caused a screenings put request.

### Pending Tests
Three tests were marked pending because they expose flaws in our design decisions for handling routes and/or base path.

We created a spike to determine how to handle routes better and the effort that would require.

These tests were silently passing before.