### PR TITLE
When copy button is clicked, temporarily remove all css styles

### DIFF
--- a/app/javascript/containers/screenings/HistoryTableContainer.jsx
+++ b/app/javascript/containers/screenings/HistoryTableContainer.jsx
@@ -7,21 +7,41 @@ import {
 } from 'selectors/screening/historyOfInvolvementSelectors'
 import * as IntakeConfig from 'common/config'
 
+const resetCopyStyling = (copyContent) => {
+  if (window.clipboardData === undefined) {
+    Array.from(document.querySelectorAll('link[rel="stylesheet"]')).forEach((el) => (el.removeAttribute('disabled')))
+    copyContent.removeAttribute('style')
+    document.body.removeAttribute('style')
+  }
+  Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.removeAttribute('style')))
+}
+
 const mapStateToProps = (state) => ({
   showCopyButton: IntakeConfig.jsClipboardSupported(),
   cases: getFormattedCasesSelector(state).toJS(),
   referrals: getFormattedReferralsSelector(state).toJS(),
   screenings: getFormattedScreeningsSelector(state).toJS(),
-  // To make the copied table fit in MS Word, we have to temporarily resize it.
+  // To make the copied table fit in MS Word, we have to temporarily restyle it.
   onCopy: (copyContent) => {
-    copyContent.style.width = '1%'
+    // >= IE11 does not need this hack
+    if (window.clipboardData === undefined) {
+      // hack to prevent scrolling when styles disappear
+      document.body.style.height = `${document.body.clientHeight}px`
+      Array.from(document.querySelectorAll('link[rel="stylesheet"]')).forEach((el) => (el.setAttribute('disabled', 'disabled')))
+      copyContent.style.width = '1%'
+    }
+    Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.style.border = '1px solid black'))
+    Array.from(copyContent.querySelectorAll('table')).forEach((el) => {
+      el.style.borderCollapse = 'collapse'
+      el.style.fontSize = '12px'
+    })
     return copyContent
   },
   onSuccess: (copyContent) => {
-    copyContent.style.width = null
+    resetCopyStyling(copyContent)
   },
   onError: (copyContent) => {
-    copyContent.style.width = null
+    resetCopyStyling(copyContent)
   },
 })
 

--- a/app/javascript/containers/snapshot/HistoryTableContainer.js
+++ b/app/javascript/containers/snapshot/HistoryTableContainer.js
@@ -6,21 +6,41 @@ import {
 } from 'selectors/screening/historyOfInvolvementSelectors'
 import * as IntakeConfig from 'common/config'
 
+const resetCopyStyling = (copyContent) => {
+  if (window.clipboardData === undefined) {
+    Array.from(document.querySelectorAll('link[rel="stylesheet"]')).forEach((el) => (el.removeAttribute('disabled')))
+    copyContent.removeAttribute('style')
+    document.body.removeAttribute('style')
+  }
+  Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.removeAttribute('style')))
+}
+
 const mapStateToProps = (state) => ({
   showCopyButton: IntakeConfig.jsClipboardSupported(),
   cases: getFormattedCasesSelector(state).toJS(),
   referrals: getFormattedReferralsSelector(state).toJS(),
   screenings: [],
-  // To make the copied table fit in MS Word, we have to temporarily resize it.
+  // To make the copied table fit in MS Word, we have to temporarily restyle it.
   onCopy: (copyContent) => {
-    copyContent.style.width = '1%'
+    // >= IE11 does not need this hack
+    if (window.clipboardData === undefined) {
+      // hack to prevent scrolling when styles disappear
+      document.body.style.height = `${document.body.clientHeight}px`
+      Array.from(document.querySelectorAll('link[rel="stylesheet"]')).forEach((el) => (el.setAttribute('disabled', 'disabled')))
+      copyContent.style.width = '1%'
+    }
+    Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.style.border = '1px solid black'))
+    Array.from(copyContent.querySelectorAll('table')).forEach((el) => {
+      el.style.borderCollapse = 'collapse'
+      el.style.fontSize = '12px'
+    })
     return copyContent
   },
   onSuccess: (copyContent) => {
-    copyContent.style.width = null
+    resetCopyStyling(copyContent)
   },
   onError: (copyContent) => {
-    copyContent.style.width = null
+    resetCopyStyling(copyContent)
   },
 })
 

--- a/app/javascript/investigations/HistoryTableContainer.jsx
+++ b/app/javascript/investigations/HistoryTableContainer.jsx
@@ -7,12 +7,43 @@ import {
 } from 'selectors/investigation/historyOfInvolvementSelectors'
 import * as IntakeConfig from 'common/config'
 
+const resetCopyStyling = (copyContent) => {
+  if (window.clipboardData === undefined) {
+    Array.from(document.querySelectorAll('link[rel="stylesheet"]')).forEach((el) => (el.removeAttribute('disabled')))
+    copyContent.removeAttribute('style')
+    document.body.removeAttribute('style')
+  }
+  Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.removeAttribute('style')))
+}
+
 const mapStateToProps = (state) => (
   {
     showCopyButton: IntakeConfig.jsClipboardSupported(),
     cases: getFormattedCasesSelector(state).toJS(),
     referrals: getFormattedReferralsSelector(state).toJS(),
     screenings: getFormattedScreeningsSelector(state).toJS(),
+    // To make the copied table fit in MS Word, we have to temporarily restyle it.
+    onCopy: (copyContent) => {
+      // >= IE11 does not need this hack
+      if (window.clipboardData === undefined) {
+        // hack to prevent scrolling when styles disappear
+        document.body.style.height = `${document.body.clientHeight}px`
+        Array.from(document.querySelectorAll('link[rel="stylesheet"]')).forEach((el) => (el.setAttribute('disabled', 'disabled')))
+        copyContent.style.width = '1%'
+      }
+      Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.style.border = '1px solid black'))
+      Array.from(copyContent.querySelectorAll('table')).forEach((el) => {
+        el.style.borderCollapse = 'collapse'
+        el.style.fontSize = '12px'
+      })
+      return copyContent
+    },
+    onSuccess: (copyContent) => {
+      resetCopyStyling(copyContent)
+    },
+    onError: (copyContent) => {
+      resetCopyStyling(copyContent)
+    },
   }
 )
 

--- a/app/javascript/selectors/screening/peopleFormSelectors.js
+++ b/app/javascript/selectors/screening/peopleFormSelectors.js
@@ -24,7 +24,7 @@ import {RACE_DETAILS} from 'enums/Races'
 import {ETHNICITY_DETAILS} from 'enums/Ethnicity'
 
 const calculateAgeFromScreeningDate = (state, personId) => {
-  const screeningStartDate = moment(state.getIn(['screeningInformationForm', 'started_at', 'value']))
+  const screeningStartDate = state.getIn(['screeningInformationForm', 'started_at', 'value'])
   const person = state.getIn(['peopleForm', personId])
   const dateOfBirth = person.getIn(['date_of_birth', 'value'])
   const approximateAge = parseInt(person.getIn(['approximate_age', 'value']), 10)
@@ -33,7 +33,7 @@ const calculateAgeFromScreeningDate = (state, personId) => {
   let ageFromScreeningDate
 
   if (dateOfBirth) {
-    ageFromScreeningDate = screeningStartDate.diff(dateOfBirth, 'years')
+    ageFromScreeningDate = moment(screeningStartDate).diff(dateOfBirth, 'years')
   } else if (approximateAge && approximateAgeUnit) {
     ageFromScreeningDate = moment().diff(screeningStartDate, 'years') + moment.duration(approximateAge, approximateAgeUnit).asYears()
   }

--- a/app/javascript/views/history/ReferralView.jsx
+++ b/app/javascript/views/history/ReferralView.jsx
@@ -35,10 +35,16 @@ const ReferralView = ({dateRange, referralId, status, notification, county, peop
               </tr>
             ))
           }
+          <tr>
+            <td colSpan='2'>
+              <span className='semibold'>Reporter: </span>{reporter}
+            </td>
+            <td>
+              <span className='semibold'>Worker: </span>{worker}
+            </td>
+          </tr>
         </tbody>
       </table>
-      <div className='col-md-6 reporter no-pad'><span>Reporter: </span>{reporter}</div>
-      <div className='col-md-6 assignee no-pad'><span>Worker: </span>{worker}</div>
     </td>
   </tr>
 )

--- a/spec/javascripts/views/history/ReferralViewSpec.jsx
+++ b/spec/javascripts/views/history/ReferralViewSpec.jsx
@@ -80,12 +80,12 @@ describe('ReferralView', () => {
       expect(component.find('.people-and-roles').find('tbody tr').at(1).find('td.allegations.disposition').text()).toEqual('allegations two (not pending)')
     })
 
-    it('renders the reporter and worker below the table', () => {
+    it('renders the reporter and worker', () => {
       const worker = 'Bob'
       const reporter = 'Sally'
       const component = renderReferralView({worker, reporter})
-      expect(component.find('.reporter').text()).toEqual(`Reporter: ${reporter}`)
-      expect(component.find('.assignee').text()).toEqual(`Worker: ${worker}`)
+      expect(component.find('.people-and-roles').text()).toContain(`Reporter: ${reporter}`)
+      expect(component.find('.people-and-roles').text()).toContain(`Worker: ${worker}`)
     })
   })
 })


### PR DESCRIPTION
[#1088]

### Jira Story

- [INT-1088](https://osi-cwds.atlassian.net/browse/INT-1088)

### Purpose

Copy and pasting into MS Word is inconsistent between Chrome, Firefox, and IE.

This hack makes it more similar across the browsers.