### PR TITLE
Don't run migrations on docker reup

### DIFF
--- a/lib/tasks/docker.rake
+++ b/lib/tasks/docker.rake
@@ -11,10 +11,7 @@ namespace :docker do # rubocop:disable BlockLength
       'docker-compose down',
       'docker-compose run --rm api bundle',
       'docker-compose run --rm ca_intake bundle',
-      'docker-compose up -d',
-      'docker-compose restart api',
-      'docker-compose exec api bash -c "bundle exec rake db:structure:dump"',
-      'docker-compose exec api bash -c "RAILS_ENV=test bundle exec rake db:test:load"'
+      'docker-compose up -d'
     ]
   end
   desc 'Cleans docker of old dangling containers & images'


### PR DESCRIPTION
- migrations are now run when intake API container
is started. Running them a second time can cause deadlocks

[#fix]

### Jira Story

- [Name of Story INT-NNN](https://osi-cwds.atlassian.net/browse/INT-NNN)

### Purpose


### Background


### Questions for Reviewer


### Notes for Reviewer


### Testing Notes

