### PR TITLE
Int 1353 add error for illegal sensitive adding

### DIFF
--- a/app/javascript/common/Autocompleter.jsx
+++ b/app/javascript/common/Autocompleter.jsx
@@ -47,6 +47,8 @@ export class Autocompleter extends Component {
       onChange('')
       onSelect(item)
       this.setState({menuVisible: false})
+    } else {
+      alert('You are not authorized to add this person.') // eslint-disable-line no-alert
     }
   }
 

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -112,6 +112,7 @@ feature 'Create participant' do
           PersonSearchResultBuilder.build do |builder|
             builder.with_first_name('Marge')
             builder.with_last_name('Simpson')
+            builder.with_sensitivity
           end
         ]
       end
@@ -294,9 +295,7 @@ feature 'Create participant' do
             fill_in 'Search for any person', with: 'Marge'
             find('strong', text: 'Marge Simpson').click
           end
-          expect(
-            a_request(:post, intake_api_url(ExternalRoutes.intake_api_participants_path))
-          ).to_not have_been_made
+          expect(accept_alert).to eq('You are not authorized to add this person.')
         end
       end
 

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -100,6 +100,7 @@ describe('<Autocompleter />', () => {
 
     describe('when an item is not selectable', () => {
       beforeEach(() => {
+        spyOn(window, 'alert')
         const isSelectable = jasmine.createSpy('isSelectable').and.returnValue(false)
         const autocompleter = mountAutocompleter({
           results, onClear, onChange, onSelect, isSelectable,
@@ -110,10 +111,11 @@ describe('<Autocompleter />', () => {
           .simulate('click', null)
       })
 
-      it('does nothing', () => {
+      it('only presents error message', () => {
         expect(onClear).not.toHaveBeenCalled()
         expect(onChange).not.toHaveBeenCalledWith('')
         expect(onSelect).not.toHaveBeenCalled()
+        expect(window.alert).toHaveBeenCalledWith('You are not authorized to add this person.')
       })
     })
   })


### PR DESCRIPTION
### Jira Story

- [Selecting Sensitive Person from Search Results Does Not Give Error Message When User Cannot Access INT-1353](https://osi-cwds.atlassian.net/browse/INT-1353)

### Purpose
Bug fix to handle the case where a person is not authorized to add any sensitive people but makes the attempt

### Background
A previous story added an error message if someone who is authorized to add sensitive people attempts to add a person who is sensitive but not available to the county of the user.

### Questions for Reviewer


### Notes for Reviewer


### Testing Notes
User should NOT be authorized to add sensitive people.  In preint login, replace `Sensitive Persons` with `Sealed`.
