### PR TITLE
This change is required to use a rails relative url root for all routes

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -3,4 +3,6 @@
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('../config/environment', __FILE__)
-run Rails.application
+map ENV['RAILS_RELATIVE_URL_ROOT'] || '/' do
+  run Rails.application
+end


### PR DESCRIPTION
### Jira Story

- [Investigate strategies to have multiple rails apps running on the same domain but different folders.](https://osi-cwds.atlassian.net/browse/INT-1320)

### Purpose

The routes will have the provided pathname as a base. So all digital services can work on the same domain