### PR TITLE
refetch relationships when person is deleted

### DIFF
--- a/app/javascript/sagas/deleteSnapshotPersonSaga.js
+++ b/app/javascript/sagas/deleteSnapshotPersonSaga.js
@@ -5,6 +5,7 @@ import {
   deletePersonSuccess,
   deletePersonFailure,
 } from 'actions/personCardActions'
+import {fetchRelationships} from 'actions/relationshipsActions'
 import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
 import {getSnapshotIdValueSelector} from 'selectors/snapshotSelectors'
 
@@ -13,6 +14,7 @@ export function* deleteSnapshotPerson({payload: {id}}) {
     yield call(destroy, `/api/v1/participants/${id}`)
     yield put(deletePersonSuccess(id))
     const snapshotId = yield select(getSnapshotIdValueSelector)
+    yield put(fetchRelationships('snapshots', snapshotId))
     yield put(fetchHistoryOfInvolvements('snapshots', snapshotId))
   } catch (error) {
     yield put(deletePersonFailure(error.responseJSON))

--- a/spec/features/snapshot/add_remove_people_spec.rb
+++ b/spec/features/snapshot/add_remove_people_spec.rb
@@ -32,7 +32,6 @@ feature 'Adding and removing a person from a snapshot' do
         ExternalRoutes.ferb_api_screening_history_of_involvements_path(snapshot.id)
       )
     ).and_return(json_body({}.to_json, status: 200))
-
     stub_request(
       :get,
       intake_api_url(
@@ -110,6 +109,7 @@ feature 'Adding and removing a person from a snapshot' do
         :delete, intake_api_url(ExternalRoutes.intake_api_participant_path(person.id))
       )
     ).to have_been_made
+
     expect(
       a_request(
         :get,
@@ -119,12 +119,14 @@ feature 'Adding and removing a person from a snapshot' do
       )
     ).to have_been_made.times(2)
 
-    stub_request(
-      :get,
-      intake_api_url(
-        ExternalRoutes.intake_api_relationships_by_screening_path(snapshot.id)
+    expect(
+      a_request(
+        :get,
+        intake_api_url(
+          ExternalRoutes.intake_api_relationships_by_screening_path(snapshot.id)
+        )
       )
-    ).and_return(json_body([].to_json, status: 200))
+    ).to have_been_made.times(2)
 
     expect(page).not_to have_content show_participant_card_selector(person.id)
     expect(page).not_to have_content(person.first_name)

--- a/spec/javascripts/sagas/deleteSnapshotPersonSagaSpec.js
+++ b/spec/javascripts/sagas/deleteSnapshotPersonSagaSpec.js
@@ -7,6 +7,7 @@ import {
 } from 'sagas/deleteSnapshotPersonSaga'
 import {DELETE_SNAPSHOT_PERSON} from 'actions/personCardActions'
 import * as personCardActions from 'actions/personCardActions'
+import {fetchRelationships} from 'actions/relationshipsActions'
 import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
 import {getSnapshotIdValueSelector} from 'selectors/snapshotSelectors'
 
@@ -21,7 +22,7 @@ describe('deleteParticipant', () => {
   const id = '123'
   const action = personCardActions.deleteSnapshotPerson(id)
 
-  it('deletes and puts participant, fetches a screening, and fetches relationships', () => {
+  it('deletes and puts participant, fetches a screening, relationships, and history_of_involvements', () => {
     const gen = deleteSnapshotPerson(action)
     expect(gen.next().value).toEqual(call(destroy, '/api/v1/participants/123'))
     expect(gen.next().value).toEqual(
@@ -31,6 +32,9 @@ describe('deleteParticipant', () => {
       select(getSnapshotIdValueSelector)
     )
     const snapshotId = '444'
+    expect(gen.next(snapshotId).value).toEqual(
+      put(fetchRelationships('snapshots', snapshotId))
+    )
     expect(gen.next(snapshotId).value).toEqual(
       put(fetchHistoryOfInvolvements('snapshots', snapshotId))
     )


### PR DESCRIPTION
[#404]

### Jira Story

- [INT-404](https://osi-cwds.atlassian.net/browse/INT-404)

### Purpose

There is a bug in the original INT-404 commit. Relationships is not being re-fetched when you delete a person from a snapshot.
