### PR TITLE
Scroll search results separately

### DIFF
--- a/app/javascript/common/Autocompleter.jsx
+++ b/app/javascript/common/Autocompleter.jsx
@@ -10,13 +10,16 @@ const menuStyle = {
   border: '1px solid #d4d4d4',
   borderBottomLeftRadius: '4px',
   borderBottomRightRadius: '4px',
+  display: 'block',
   fontFamily: 'Helvetica, sans-serif',
   fontSize: '16px',
   fontWeight: 300,
+  maxHeight: '32em',
+  overflowX: 'hidden',
+  overflowY: 'scroll',
   position: 'absolute',
   width: '100%',
   zIndex: 2,
-  display: 'block',
 }
 const resultStyle = {
   borderBottom: '2px solid #d4d4d4',
@@ -73,7 +76,7 @@ export class Autocompleter extends Component {
   renderMenu(items, searchTerm, _style) {
     const {canCreateNewPerson, onLoadMoreResults, onSelect, total} = this.props
     return (
-      <div style={menuStyle}>
+      <div style={menuStyle} className='autocomplete-menu'>
         <SuggestionHeader
           currentNumberOfResults={items.length}
           total={total}

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -238,6 +238,14 @@ describe('<Autocompleter />', () => {
         expect(suggestions.length).toEqual(2)
       })
 
+      it('scrolls when there are many results', () => {
+        const menu = autocompleter.find('.autocomplete-menu')
+        const menuStyle = menu.prop('style')
+        expect(menuStyle.maxHeight).toEqual(jasmine.any(String))
+        expect(menuStyle.overflowY).toBe('scroll')
+        expect(menuStyle.overflowX).not.toBe('scroll') // No need to horizontally scroll
+      })
+
       it('displays person suggestion', () => {
         const suggestions = autocompleter.find('PersonSuggestion')
         const suggestion = suggestions.at(0)


### PR DESCRIPTION
Limit the maximum height of the Autocompleter's search results, and allow those results to scroll separately from the rest of the page. This provides reasonable behavior when there are many results.

### Jira Story

- [INT-1203 Page contents scrolls behind the search results in the React AutoSuggest component.](https://osi-cwds.atlassian.net/browse/INT-1203)

## Description

A bug exists when person searches return many results, such as when querying for a common name. The scroll results were displayed in full, statically on top of the page contents. When scrolling, the entire page (including both the results and the page contents behind) would scroll alongside. This patch places the search results into their own scrollable area.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

