### PR TITLE
Ux refactor buttons (rebased)

### DIFF
--- a/app/assets/stylesheets/shame_overrides.scss
+++ b/app/assets/stylesheets/shame_overrides.scss
@@ -1,13 +1,56 @@
 @import 'constants';
 
+
+// Card Header Fix //
+
+.card {
+  .card-header {
+    align-items: center;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+
+    span {
+      display: inline-block;
+      margin-right: auto;
+    }
+
+    .btn.btn-default {
+      margin-right: 2rem;
+      padding: 1rem;
+    }
+
+    .btn.btn-warning {
+      background-color: transparent;
+      border: 0;
+      box-shadow: none;
+      color: $red;
+      margin-right: 2rem;
+      padding: 1rem;
+    }
+
+    .btn.btn-warning:hover,
+    .btn.btn-warning:focus,
+    .btn.btn-warning:active {
+      text-decoration: underline;
+    }
+  }
+
+  .card-body {
+    .btn {
+      margin: 0;
+    }
+  }
+}
+
+// Navigation Fix //
+
 .anchor {
   display: block;
   height: 13rem;
   margin-top: -13rem;
   visibility: hidden;
 }
-
-// Navigation //
 
 .inactive-navlink {
   display: none;

--- a/app/javascript/common/EditLink.jsx
+++ b/app/javascript/common/EditLink.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 
 const EditLink = ({ariaLabel, onClick}) => (
-  <a aria-label={ariaLabel} className='btn btn-primary pull-right' href='#' onClick={onClick}>
+  <a aria-label={ariaLabel} className='btn btn-default pull-right' href='#' onClick={onClick}>
     Edit
   </a>
 )

--- a/app/javascript/investigations/ContactForm.jsx
+++ b/app/javascript/investigations/ContactForm.jsx
@@ -196,9 +196,9 @@ class ContactForm extends React.Component {
                   </div>
                 </div>
                 <div className='row'>
-                  <div className='centered'>
-                    <button className='btn btn-primary' type='submit'>Save</button>
-                    { hasCancel &&
+                  <div className='col-md-12'>
+                    <div className='pull-right'>
+                      { hasCancel &&
                         <button
                           className='btn btn-default'
                           onClick={(event) => {
@@ -206,7 +206,9 @@ class ContactForm extends React.Component {
                             onCancel()
                           }}
                         >Cancel</button>
-                    }
+                      }
+                      <button className='btn btn-primary' type='submit'>Save</button>
+                    </div>
                   </div>
                 </div>
               </form>

--- a/app/javascript/views/AllegationsForm.jsx
+++ b/app/javascript/views/AllegationsForm.jsx
@@ -56,9 +56,11 @@ const AllegationsForm = ({
       </div>
     </div>
     <div className='row'>
-      <div className='centered'>
-        <button className='btn btn-primary' onClick={onSave}>Save</button>
-        <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+      <div className='col-md-12'>
+        <div className='pull-right'>
+          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+          <button className='btn btn-primary' onClick={onSave}>Save</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/views/CrossReportForm.jsx
+++ b/app/javascript/views/CrossReportForm.jsx
@@ -179,9 +179,11 @@ const CrossReportForm = ({
         }
       </div>
       <div className='row'>
-        <div className='centered'>
-          <button className='btn btn-primary' onClick={save}>Save</button>
-          <button className='btn btn-default' onClick={cancel}>Cancel</button>
+        <div className='col-md-12'>
+          <div className='pull-right'>
+            <button className='btn btn-default' onClick={cancel}>Cancel</button>
+            <button className='btn btn-primary' onClick={save}>Save</button>
+          </div>
         </div>
       </div>
     </div>

--- a/app/javascript/views/IncidentInformationForm.jsx
+++ b/app/javascript/views/IncidentInformationForm.jsx
@@ -92,9 +92,11 @@ const IncidentInformationForm = ({incidentDate, errors, onChange, onBlur, addres
       </div>
     </fieldset>
     <div className='row'>
-      <div className='centered'>
-        <button className='btn btn-primary' onClick={onSave}>Save</button>
-        <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+      <div className='col-md-12'>
+        <div className='pull-right'>
+          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+          <button className='btn btn-primary' onClick={onSave}>Save</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/views/NarrativeForm.jsx
+++ b/app/javascript/views/NarrativeForm.jsx
@@ -28,9 +28,11 @@ const NarrativeForm = ({
       </FormField>
     </div>
     <div className='row'>
-      <div className='centered'>
-        <button className='btn btn-primary' onClick={onSave}>Save</button>
-        <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+      <div className='col-md-12'>
+        <div className='pull-right'>
+          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+          <button className='btn btn-primary' onClick={onSave}>Save</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/views/ScreeningDecisionForm.jsx
+++ b/app/javascript/views/ScreeningDecisionForm.jsx
@@ -118,9 +118,11 @@ const ScreeningDecisionForm = ({
       </div>
     </div>
     <div className='row'>
-      <div className='centered'>
-        <button className='btn btn-primary' onClick={onSave}>Save</button>
-        <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+      <div className='col-md-12'>
+        <div className='pull-right'>
+          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+          <button className='btn btn-primary' onClick={onSave}>Save</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/views/ScreeningInformationForm.jsx
+++ b/app/javascript/views/ScreeningInformationForm.jsx
@@ -81,9 +81,11 @@ const ScreeningInformationForm = ({
       </SelectField>
     </div>
     <div className='row'>
-      <div className='centered'>
-        <button className='btn btn-primary' onClick={onSave}>Save</button>
-        <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+      <div className='col-md-12'>
+        <div className='pull-right'>
+          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+          <button className='btn btn-primary' onClick={onSave}>Save</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/views/WorkerSafetyForm.jsx
+++ b/app/javascript/views/WorkerSafetyForm.jsx
@@ -38,9 +38,11 @@ const WorkerSafetyForm = ({
       </div>
     </div>
     <div className='row'>
-      <div className='centered'>
-        <button className='btn btn-primary' onClick={onSave}>Save</button>
-        <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+      <div className='col-md-12'>
+        <div className='pull-right'>
+          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+          <button className='btn btn-primary' onClick={onSave}>Save</button>
+        </div>
       </div>
     </div>
   </div>

--- a/app/javascript/views/people/PersonCard.jsx
+++ b/app/javascript/views/people/PersonCard.jsx
@@ -30,9 +30,11 @@ const PersonCard = ({
       {mode === 'edit' && edit}
       {mode === 'edit' &&
         <div className='row'>
-          <div className='centered'>
-            <button className='btn btn-primary' onClick={onSave}>Save</button>
-            <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+          <div className='col-md-12'>
+            <div className='pull-right'>
+              <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+              <button className='btn btn-primary' onClick={onSave}>Save</button>
+            </div>
           </div>
         </div>
       }

--- a/app/javascript/views/people/PersonCardHeader.jsx
+++ b/app/javascript/views/people/PersonCardHeader.jsx
@@ -7,11 +7,11 @@ const PersonCardHeader = ({informationFlag, title, onDelete, onEdit, showDelete,
     <span>{title}</span>
     { informationFlag && <span className='information-flag'>{informationFlag}</span>}
     { showDelete &&
-      <button aria-label='Delete person'
+      <button aria-label='Remove person'
         className='pull-right btn btn-warning'
         onClick={onDelete}
       >
-        Delete
+        Remove
       </button>
     }
     { showEdit &&

--- a/app/javascript/views/people/PersonSearchForm.jsx
+++ b/app/javascript/views/people/PersonSearchForm.jsx
@@ -26,7 +26,7 @@ export class PersonSearchForm extends React.Component {
     return (
       <div>
         <a className='anchor' id='search-card-anchor'/>
-        <div className='card edit double-gap-bottom' id='search-card'>
+        <div className='card double-gap-bottom' id='search-card'>
           <div className='card-header'>
             <span>Search</span>
           </div>

--- a/spec/features/screening/allegations/edit_allegations_spec.rb
+++ b/spec/features/screening/allegations/edit_allegations_spec.rb
@@ -247,7 +247,7 @@ feature 'edit allegations' do
       stub_request(:delete, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
         .and_return(json_body(nil, status: 204))
 
-      click_button 'Delete person'
+      click_button 'Remove person'
     end
 
     within '.card.edit', text: 'Allegations' do
@@ -454,7 +454,7 @@ feature 'edit allegations' do
       stub_request(:delete, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
         .and_return(json_body(nil, status: 204))
 
-      click_button 'Delete person'
+      click_button 'Remove person'
     end
 
     within '.card.edit', text: 'Allegations' do

--- a/spec/features/screening/allegations/show_allegations_spec.rb
+++ b/spec/features/screening/allegations/show_allegations_spec.rb
@@ -154,7 +154,7 @@ feature 'show allegations' do
       .and_return(json_body(screening.to_json, status: 200))
 
     within show_participant_card_selector(marge.id) do
-      click_button 'Delete person'
+      click_button 'Remove person'
     end
 
     within '.card.show', text: 'Allegations' do

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -248,7 +248,7 @@ feature 'Create participant' do
       within '.card-header' do
         expect(page).to_not have_content('Sensitive')
         expect(page).to have_content 'Homer Simpson'
-        expect(page).to have_button 'Delete person'
+        expect(page).to have_button 'Remove person'
       end
 
       within '.card-body' do
@@ -394,7 +394,7 @@ feature 'Create participant' do
             within '.card-header' do
               expect(page).to have_content('Sensitive')
               expect(page).to have_content 'Marge Simpson'
-              expect(page).to have_button 'Delete person'
+              expect(page).to have_button 'Remove person'
             end
           end
         end

--- a/spec/features/screening/participant/delete_participant_spec.rb
+++ b/spec/features/screening/participant/delete_participant_spec.rb
@@ -31,7 +31,7 @@ feature 'Delete Participant' do
 
     within edit_participant_card_selector(participant.id) do
       within '.card-header' do
-        click_button 'Delete person'
+        click_button 'Remove person'
       end
     end
     expect(
@@ -49,7 +49,7 @@ feature 'Delete Participant' do
 
     within show_participant_card_selector(participant.id) do
       within '.card-header' do
-        click_button 'Delete person'
+        click_button 'Remove person'
       end
     end
     expect(

--- a/spec/features/screening/participant/editing_participant_spec.rb
+++ b/spec/features/screening/participant/editing_participant_spec.rb
@@ -64,7 +64,7 @@ feature 'Edit Person' do
         within '.card-header' do
           expect(page).to have_content('Sensitive')
           expect(page).to have_content marge_formatted_name
-          expect(page).to have_button 'Delete person'
+          expect(page).to have_button 'Remove person'
         end
         within '.card-body' do
           table_description = marge.legacy_descriptor.legacy_table_description
@@ -269,7 +269,7 @@ feature 'Edit Person' do
       within '.card-header' do
         expect(page).to have_content('Sensitive')
         expect(page).to have_content marge_formatted_name
-        expect(page).to have_button 'Delete person'
+        expect(page).to have_button 'Remove person'
       end
 
       within '.card-body' do

--- a/spec/features/screening/participant/show_participant_spec.rb
+++ b/spec/features/screening/participant/show_participant_spec.rb
@@ -61,7 +61,7 @@ feature 'Show Screening' do
           "#{existing_participant.first_name} Jay #{existing_participant.last_name}, Esq"
         )
         expect(page).to have_link 'Edit person'
-        expect(page).to have_button 'Delete person'
+        expect(page).to have_button 'Remove person'
       end
 
       within '.card-body' do

--- a/spec/features/screening/relationships_card_spec.rb
+++ b/spec/features/screening/relationships_card_spec.rb
@@ -131,7 +131,7 @@ feature 'Relationship card' do
         visit edit_screening_path(id: participants_screening.id)
         within edit_participant_card_selector(participant.id) do
           within '.card-header' do
-            click_button 'Delete person'
+            click_button 'Remove person'
           end
         end
 

--- a/spec/features/snapshot/add_remove_people_spec.rb
+++ b/spec/features/snapshot/add_remove_people_spec.rb
@@ -100,7 +100,7 @@ feature 'Adding and removing a person from a snapshot' do
         expect(page).not_to have_content 'Edit'
         expect(page).to_not have_content('Sensitive')
         expect(page).to have_content("#{person.first_name} #{person.last_name}")
-        click_button 'Delete person'
+        click_button 'Remove person'
       end
     end
 

--- a/spec/javascripts/views/people/PersonCardHeaderSpec.jsx
+++ b/spec/javascripts/views/people/PersonCardHeaderSpec.jsx
@@ -59,20 +59,20 @@ describe('PersonCardHeader', () => {
   describe('delete button', () => {
     it('displays if showDelete is true', () => {
       const component = renderComponent({showDelete: true})
-      const deleteButton = component.find('button[aria-label="Delete person"]')
+      const deleteButton = component.find('button[aria-label="Remove person"]')
       expect(deleteButton.exists()).toEqual(true)
     })
 
     it('calls the onDelete function from the props when clicked', () => {
       const component = renderComponent({showEdit: true})
-      const deleteButton = component.find('button[aria-label="Delete person"]')
+      const deleteButton = component.find('button[aria-label="Remove person"]')
       deleteButton.simulate('click')
       expect(onDelete).toHaveBeenCalled()
     })
 
     it('displays if showDelete is false', () => {
       const component = renderComponent({showDelete: false})
-      const deleteButton = component.find('button[aria-label="Delete person"]')
+      const deleteButton = component.find('button[aria-label="Remove person"]')
       expect(deleteButton.exists()).toEqual(false)
     })
   })


### PR DESCRIPTION
### Jira Story

- Unknown (We're looking for one) - See also #548 

## Description
This pull request contains changes to move Intake styles closer to those of shared Wood Duck components. It primarily affects the buttons in the top right of the cards, which now look more like links than buttons, and the Save/Cancel buttons at the bottom of cards (which float right instead of center). It also changes the terminology for removing a person from Snapshot: "Delete" is now "Remove."

This pull request does not contain code that I personally wrote. It is a refactored version of #548, in which I consolidated all of the changes into a handful of small, cohesive commits while preserving the semantic history of the branch.

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
There were several tests that ensured the presence of "Delete" buttons, and Pierre modified those accordingly. Other changes are only small style tweaks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

Edit:  It is also worth noting that these changes include some CSS that uses flexbox. I manually tested in IE and Edge.