### PR TITLE
Update Jenkinsfile to find PR branch names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ import java.text.SimpleDateFormat
 
 node('intake-slave') {
     checkout scm
-    def branch = env.BRANCH_NAME ?: 'master'
+    def branch = env.BRANCH_NAME ?: (env.GIT_BRANCH ?: 'master')
     def curStage = 'Start'
     def pipelineStatus = 'SUCCESS'
     def successColor = '11AB1B'
@@ -51,7 +51,7 @@ node('intake-slave') {
                     sh 'make tag latest $(git describe --tags $(git rev-list --tags --max-count=1))'
                 }
                 sh "make publish"
-                }   
+                }
             }
         }
     }


### PR DESCRIPTION
Jenkins gives different environment variables for finding the git
branch name depending on whether the job is configured for for all
GitHub branches or only Pull Requests. We use the branch name to
determine some publish and deploy behavior for the master branch,
so this prevents falsely detecting PRs as master.

### Jira Story

- No story

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->
This is a configuration file change, and only affects the build process, not end users. We tested manually that Jenkins will get the correct branch name from this pull request.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
There are no tests for the Jenkinsfile, nor any linting for it.
