### PR TITLE
Int 1325 transfer staff person endpoint

### DIFF
--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -43,10 +43,6 @@ class ExternalRoutes
       "/api/v1/screenings/#{id}/relationships"
     end
 
-    def ferb_api_staff_path(id)
-      "/staffpersons/#{id}"
-    end
-
     def ferb_api_investigation_path(id)
       "/investigations/#{id}"
     end
@@ -69,6 +65,10 @@ class ExternalRoutes
 
     def ferb_api_cross_report_agency
       '/cross_report_agency'
+    end
+
+    def ferb_api_staff_path(id)
+      "/staffpersons/#{id}"
     end
 
     def sdm_path

--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -43,8 +43,8 @@ class ExternalRoutes
       "/api/v1/screenings/#{id}/relationships"
     end
 
-    def intake_api_staff_path(id)
-      "/api/v1/staff/#{id}"
+    def ferb_api_staff_path(id)
+      "/staffpersons/#{id}"
     end
 
     def ferb_api_investigation_path(id)

--- a/app/repositories/staff_repository.rb
+++ b/app/repositories/staff_repository.rb
@@ -4,9 +4,9 @@
 # resource via the API
 class StaffRepository
   def self.find(security_token, id)
-    response = IntakeAPI.make_api_call(
+    response = FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.intake_api_staff_path(id),
+      ExternalRoutes.ferb_api_staff_path(id),
       :get
     )
     Staff.new(response.body)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,6 +70,9 @@ Rails.application.routes.draw do
     post '/dora/people/person/_search' => 'dev#null', as: :dora_people
     post '/dora/people-summary/person-summary/_search' => 'dev#null', as: :dora_people_light_index
   end
+  scope host: Rails.configuration.intake_api[:ferb_url] do
+    get '/staffpersons/:id' => 'dev#null', as: :tpt_staff
+  end
 
   resources :version, only: :index
   get '/logout' => 'home#logout'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,9 +70,6 @@ Rails.application.routes.draw do
     post '/dora/people/person/_search' => 'dev#null', as: :dora_people
     post '/dora/people-summary/person-summary/_search' => 'dev#null', as: :dora_people_light_index
   end
-  scope host: Rails.configuration.intake_api[:ferb_url] do
-    get '/staffpersons/:id' => 'dev#null', as: :tpt_staff
-  end
 
   resources :version, only: :index
   get '/logout' => 'home#logout'

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -36,7 +36,7 @@ feature 'login' do
   end
 
   context 'user provides valid security access code', browser: :poltergeist do
-    let(:staff_url) { intake_api_url(ExternalRoutes.intake_api_staff_path(1234)) }
+    let(:staff_url) { intake_api_url(ExternalRoutes.ferb_api_staff_path(1234)) }
     before do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .and_return(json_body(screening_results, status: 200))
@@ -232,7 +232,7 @@ feature 'login perry v1' do
   end
 
   context 'user provides valid security token', browser: :poltergeist do
-    let(:staff_url) { intake_api_url(ExternalRoutes.intake_api_staff_path(1234)) }
+    let(:staff_url) { intake_api_url(ExternalRoutes.ferb_api_staff_path(1234)) }
     before do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .and_return(json_body(screening_results, status: 200))

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -36,7 +36,7 @@ feature 'login' do
   end
 
   context 'user provides valid security access code', browser: :poltergeist do
-    let(:staff_url) { intake_api_url(ExternalRoutes.ferb_api_staff_path(1234)) }
+    let(:staff_url) { ferb_api_url(ExternalRoutes.ferb_api_staff_path(1234)) }
     before do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .and_return(json_body(screening_results, status: 200))
@@ -232,7 +232,7 @@ feature 'login perry v1' do
   end
 
   context 'user provides valid security token', browser: :poltergeist do
-    let(:staff_url) { intake_api_url(ExternalRoutes.ferb_api_staff_path(1234)) }
+    let(:staff_url) { ferb_api_url(ExternalRoutes.ferb_api_staff_path(1234)) }
     before do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .and_return(json_body(screening_results, status: 200))

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -60,7 +60,7 @@ feature 'Create Screening' do
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
 
-        stub_request(:get, intake_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
+        stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
           .and_return(json_body(user_details.to_json, status: 200))
 
         visit root_path(token: 123)
@@ -122,7 +122,7 @@ feature 'Create Screening' do
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
 
-        stub_request(:get, intake_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
+        stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
           .and_return(json_body(user_details.to_json, status: 200))
 
         visit root_path(token: 123)
@@ -179,7 +179,7 @@ feature 'Create Screening' do
         ).and_return(json_body(new_screening.to_json, status: 200))
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
-        stub_request(:get, intake_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
+        stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
           .and_return(json_body(user_details.to_json, status: 200))
 
         visit root_path(token: 123)

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -60,7 +60,7 @@ feature 'Create Screening' do
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
 
-        stub_request(:get, intake_api_url(ExternalRoutes.intake_api_staff_path('1234')))
+        stub_request(:get, intake_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
           .and_return(json_body(user_details.to_json, status: 200))
 
         visit root_path(token: 123)
@@ -122,7 +122,7 @@ feature 'Create Screening' do
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
 
-        stub_request(:get, intake_api_url(ExternalRoutes.intake_api_staff_path('1234')))
+        stub_request(:get, intake_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
           .and_return(json_body(user_details.to_json, status: 200))
 
         visit root_path(token: 123)
@@ -179,7 +179,7 @@ feature 'Create Screening' do
         ).and_return(json_body(new_screening.to_json, status: 200))
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
-        stub_request(:get, intake_api_url(ExternalRoutes.intake_api_staff_path('1234')))
+        stub_request(:get, intake_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
           .and_return(json_body(user_details.to_json, status: 200))
 
         visit root_path(token: 123)

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -303,7 +303,7 @@ feature 'Create participant' do
                     body: { staffId: '123', privileges: ['Sensitive Persons'] }.to_json)
       stub_request(:get, %r{https?://.*/authn/validate\?token=#{insensitive_token}})
         .and_return(status: 200, body: { staffId: '123', privileges: [] }.to_json)
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_staff_path('123')))
+      stub_request(:get, intake_api_url(ExternalRoutes.ferb_api_staff_path('123')))
         .and_return(json_body({ staffId: '123', first_name: 'Bob', last_name: 'Boberson',
                                 county: 'San Francisco' }.to_json, status: 200))
     end

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -303,7 +303,7 @@ feature 'Create participant' do
                     body: { staffId: '123', privileges: ['Sensitive Persons'] }.to_json)
       stub_request(:get, %r{https?://.*/authn/validate\?token=#{insensitive_token}})
         .and_return(status: 200, body: { staffId: '123', privileges: [] }.to_json)
-      stub_request(:get, intake_api_url(ExternalRoutes.ferb_api_staff_path('123')))
+      stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_staff_path('123')))
         .and_return(json_body({ staffId: '123', first_name: 'Bob', last_name: 'Boberson',
                                 county: 'San Francisco' }.to_json, status: 200))
     end

--- a/spec/lib/external_routes_spec.rb
+++ b/spec/lib/external_routes_spec.rb
@@ -74,9 +74,9 @@ describe ExternalRoutes do
     end
   end
 
-  describe '.intake_api_staff_path' do
-    it 'returns /api/v1/staff/:id' do
-      expect(described_class.intake_api_staff_path(24)).to eq('/api/v1/staff/24')
+  describe '.ferb_api_staff_path' do
+    it 'returns /staffpersons/:id' do
+      expect(described_class.ferb_api_staff_path(24)).to eq('/staffpersons/24')
     end
   end
 

--- a/spec/repositories/staff_repository_spec.rb
+++ b/spec/repositories/staff_repository_spec.rb
@@ -12,8 +12,8 @@ describe StaffRepository do
     end
 
     before do
-      expect(IntakeAPI).to receive(:make_api_call)
-        .with(security_token, "/api/v1/staff/#{staff_id}", :get)
+      expect(FerbAPI).to receive(:make_api_call)
+        .with(security_token, "/staffpersons/#{staff_id}", :get)
         .and_return(response)
     end
 


### PR DESCRIPTION
### Jira Story

- [Update intake to use existing staff person ferb api endpoint INT-1325](https://osi-cwds.atlassian.net/browse/INT-1325)

## Description
Instead of pointing intake to intake_api (/api/v1/staff/:id), which in turn points to ferb_api (/staffpersons/:id) for fetching staff data, now intake will point directly to ferb_api.  Reducing intake_api's responsibility.

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
