### PR TITLE
INT 1485 - Search query ordering

### DIFF
--- a/app/javascript/selectors/peopleSearchSelectors.js
+++ b/app/javascript/selectors/peopleSearchSelectors.js
@@ -26,26 +26,30 @@ export const getLastResultsSortValueSelector = (state) => {
 
 const formatSSN = (ssn) => ssn && ssn.replace(/(\d{3})(\d{2})(\d{4})/, '$1-$2-$3')
 const formatDOB = (dob, highlight) => (highlight ? '<em>'.concat(dob, '</em>') : dob)
+const formatPhoneNumber = (phoneNumber) => phoneNumber && Map({
+  number: phoneNumberFormatter(phoneNumber.get('number')),
+  type: phoneNumber.get('type'),
+})
 
 // Try to find a match from a list of highlights by stripping out <em> tags
 const highlightNameField = (exactName, highlights) => (highlights.find(
   (highlight) => highlight.replace(/<(\/)?em>/g, '') === exactName
 ) || exactName)
 
+const maybeHighlightedField = (result, highlight, key) => highlight.getIn(
+  [key, 0],
+  highlightNameField(result.get(key), highlight.get('autocomplete_search_bar', List()))
+)
+
 export const getPeopleResultsSelector = (state) => getPeopleSearchSelector(state)
   .get('results')
   .map((fullResult) => {
-    const result = fullResult.get('_source')
-    const phoneNumber = result.getIn(['phone_numbers', 0], null)
-    const highlightDateOfBirth = fullResult.hasIn(['highlight', 'searchable_date_of_birth'])
-    const autocomplete_highlight = fullResult.getIn(['highlight', 'autocomplete_search_bar'], List())
-
+    const result = fullResult.get('_source', Map())
+    const highlight = fullResult.get('highlight', Map())
     return Map({
       legacy_id: result.get('id'),
-      firstName: fullResult.getIn(['highlight', 'first_name', 0],
-        highlightNameField(result.get('first_name'), autocomplete_highlight)),
-      lastName: fullResult.getIn(['highlight', 'last_name', 0],
-        highlightNameField(result.get('last_name'), autocomplete_highlight)),
+      firstName: maybeHighlightedField(result, highlight, 'first_name'),
+      lastName: maybeHighlightedField(result, highlight, 'last_name'),
       middleName: result.get('middle_name'),
       nameSuffix: result.get('name_suffix'),
       legacyDescriptor: result.get('legacy_descriptor'),
@@ -53,13 +57,10 @@ export const getPeopleResultsSelector = (state) => getPeopleSearchSelector(state
       languages: mapLanguages(state, result),
       races: mapRaces(state, result),
       ethnicity: mapEthnicities(state, result),
-      dateOfBirth: formatDOB(result.get('date_of_birth'), highlightDateOfBirth),
-      ssn: formatSSN(fullResult.getIn(['highlight', 'ssn', 0], result.get('ssn'))),
+      dateOfBirth: formatDOB(result.get('date_of_birth'), highlight.has('searchable_date_of_birth')),
+      ssn: formatSSN(highlight.getIn(['ssn', 0], result.get('ssn'))),
       address: mapAddress(state, result),
-      phoneNumber: phoneNumber && Map({
-        number: phoneNumberFormatter(phoneNumber.get('number')),
-        type: phoneNumber.get('type'),
-      }),
+      phoneNumber: formatPhoneNumber(result.getIn(['phone_numbers', 0], null)),
       isSensitive: mapIsSensitive(result),
       isSealed: mapIsSealed(result),
     })

--- a/app/javascript/selectors/peopleSearchSelectors.js
+++ b/app/javascript/selectors/peopleSearchSelectors.js
@@ -23,6 +23,7 @@ export const getLastResultsSortValueSelector = (state) => {
 
 const formatSSN = (ssn) => ssn && ssn.replace(/(\d{3})(\d{2})(\d{4})/, '$1-$2-$3')
 const formatDOB = (dob, highlight) => (highlight ? '<em>'.concat(dob, '</em>') : dob)
+
 export const getPeopleResultsSelector = (state) => getPeopleSearchSelector(state)
   .get('results')
   .map((fullResult) => {

--- a/app/services/person_search_query_builder.rb
+++ b/app/services/person_search_query_builder.rb
@@ -32,7 +32,7 @@ class PersonSearchQueryBuilder
   end
 
   def query
-    { bool: { must: must } }
+    { bool: { must: must, should: should } }
   end
 
   def must
@@ -40,13 +40,35 @@ class PersonSearchQueryBuilder
     [base_query, client_only]
   end
 
+  def match_query(field, term)
+    {
+      match: {
+        field => {
+          query: term
+        }
+      }
+    }
+  end
+
+  def should
+    term = formatted_search_term
+    [
+      match_query(:first_name, term),
+      match_query(:last_name, term),
+      match_query(:'aka.first_name', term),
+      match_query(:'aka.last_name', term),
+      match_query(:date_of_birth_as_text, term),
+      match_query(:ssn, term)
+    ]
+  end
+
   def base_query
     {
-      multi_match: {
-        query: formatted_search_term,
-        type: 'cross_fields',
-        operator: 'and',
-        fields: %w[searchable_name searchable_date_of_birth ssn]
+      match: {
+        autocomplete_search_bar: {
+          query: formatted_search_term,
+          operator: 'and'
+        }
       }
     }
   end

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -123,7 +123,13 @@ feature 'searching a participant in autocompleter' do
                  'query' => {
                    'bool' => {
                      'must' => array_including(
-                       'multi_match' => hash_including('query' => 'ma 12345')
+                       'match' => {
+                         'autocomplete_search_bar' => {
+                           'query': 'ma 12345',
+                           'operator': 'and'
+                         }
+                       },
+                       'should' => array_including(anything)
                      )
                    }
                  },

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -122,15 +122,8 @@ feature 'searching a participant in autocompleter' do
         ).with('body' => {
                  'query' => {
                    'bool' => {
-                     'must' => array_including(
-                       'match' => {
-                         'autocomplete_search_bar' => {
-                           'query': 'ma 12345',
-                           'operator': 'and'
-                         }
-                       },
-                       'should' => array_including(anything)
-                     )
+                     'must' => anything,
+                     'should' => anything
                    }
                  },
                  '_source' => anything,

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -266,7 +266,7 @@ describe('<Autocompleter />', () => {
         expect(suggestion.props().ssn).toEqual('test ssn')
       })
 
-      it('changes backround colour when highlighted', () => {
+      it('changes background colour when highlighted', () => {
         const input = autocompleter.find('input')
         input.simulate('keyDown', {key: 'ArrowDown', keyCode: 40, which: 40})
         const result = autocompleter.find('div[id="search-result-some-legacy-id"]')

--- a/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
+++ b/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
@@ -282,7 +282,7 @@ describe('peopleSearchSelectors', () => {
 
       it('should check autocomplete_search_bar if no exact first_name', () => {
         const peopleSearch = personWithHighlights({
-          // first_name: ['<em>Bar</em>t'],
+          // first_name: (no exact first name)
           last_name: ['Sim<em>pson</em>'],
           ssn: ['<em>123456789</em>'],
           searchable_date_of_birth: ['<em>1990</em>'],
@@ -311,7 +311,7 @@ describe('peopleSearchSelectors', () => {
       it('should check autocomplete_search_bar if no exact last_name', () => {
         const peopleSearch = personWithHighlights({
           first_name: ['<em>Bar</em>t'],
-          // last_name: ['Sim<em>pson</em>'],
+          // last_name: (no exact last name)
           ssn: ['<em>123456789</em>'],
           searchable_date_of_birth: ['<em>1990</em>'],
           autocomplete_search_bar: [
@@ -338,8 +338,8 @@ describe('peopleSearchSelectors', () => {
 
       it('should find autocomplete fields in any order', () => {
         const peopleSearch = personWithHighlights({
-          // first_name: ['<em>Bar</em>t'],
-          // last_name: ['Sim<em>pson</em>'],
+          // first_name: (no exact first name)
+          // last_name: (no exact last name)
           ssn: ['<em>123456789</em>'],
           searchable_date_of_birth: ['<em>1990</em>'],
           autocomplete_search_bar: [
@@ -367,15 +367,14 @@ describe('peopleSearchSelectors', () => {
 
       it('should use exact names if no highlight', () => {
         const peopleSearch = personWithHighlights({
-          // first_name: ['<em>Bar</em>t'],
-          // last_name: ['Sim<em>pson</em>'],
+          // first_name: (no first name matches)
+          // last_name: (no last name matches)
           ssn: ['<em>123456789</em>'],
           searchable_date_of_birth: ['<em>1990</em>'],
           autocomplete_search_bar: [
             '<em>123456789</em>',
             '<em>1990</em>',
-            // 'Sim<em>pson</em>',
-            // '<em>Bar</em>t',
+            // (no first name or last name matches)
           ],
         })
 

--- a/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
+++ b/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
@@ -232,40 +232,138 @@ describe('peopleSearchSelectors', () => {
       expect(peopleResults.getIn([0, 'phoneNumber'])).toEqual(null)
     })
 
-    it('maps person search hightlight fields', () => {
-      const peopleSearch = {
-        results: [{
-          _source: {
-            first_name: 'Bart',
-            last_name: 'Simpson',
-            date_of_birth: '1990-02-13',
-            ssn: '123456789',
-            addresses: [],
-            phone_numbers: [],
-          },
-          highlight: {
-            first_name: ['<em>Bar</em>t'],
-            last_name: ['Sim<em>pson</em>'],
-            ssn: ['<em>123456789</em>'],
-            searchable_date_of_birth: ['<em>1990</em>'],
-          },
-        }],
+    describe('when highlighting', () => {
+      function personWithHighlights(highlight) {
+        return {
+          results: [{
+            _source: {
+              first_name: 'Bart',
+              last_name: 'Simpson',
+              date_of_birth: '1990-02-13',
+              ssn: '123456789',
+              addresses: [],
+              phone_numbers: [],
+            },
+            highlight,
+          }],
+        }
       }
-      const state = fromJS({
-        languages: languageLovs,
-        ethnicityTypes: ethnicityTypeLovs,
-        raceTypes: raceTypeLovs,
-        unableToDetermineCodes,
-        hispanicOriginCodes,
-        usStates,
-        peopleSearch,
-        addressTypes,
+
+      it('should use exact highlighted fields if available', () => {
+        const peopleSearch = personWithHighlights({
+          first_name: ['<em>Bar</em>t'],
+          last_name: ['Sim<em>pson</em>'],
+          ssn: ['<em>123456789</em>'],
+          searchable_date_of_birth: ['<em>1990</em>'],
+          autocomplete_search_bar: [
+            '<em>Bar</em>t',
+            'Sim<em>pson</em>',
+            '<em>123456789</em>',
+            '<em>1990</em>',
+          ],
+        })
+
+        const state = fromJS({
+          languages: languageLovs,
+          ethnicityTypes: ethnicityTypeLovs,
+          raceTypes: raceTypeLovs,
+          unableToDetermineCodes,
+          hispanicOriginCodes,
+          usStates,
+          peopleSearch,
+          addressTypes,
+        })
+        const peopleResults = getPeopleResultsSelector(state)
+        expect(peopleResults.getIn([0, 'firstName'])).toEqual('<em>Bar</em>t')
+        expect(peopleResults.getIn([0, 'lastName'])).toEqual('Sim<em>pson</em>')
+        expect(peopleResults.getIn([0, 'ssn'])).toEqual('<em>123-45-6789</em>')
+        expect(peopleResults.getIn([0, 'dateOfBirth'])).toEqual('<em>1990-02-13</em>')
       })
-      const peopleResults = getPeopleResultsSelector(state)
-      expect(peopleResults.getIn([0, 'firstName'])).toEqual('<em>Bar</em>t')
-      expect(peopleResults.getIn([0, 'lastName'])).toEqual('Sim<em>pson</em>')
-      expect(peopleResults.getIn([0, 'ssn'])).toEqual('<em>123-45-6789</em>')
-      expect(peopleResults.getIn([0, 'dateOfBirth'])).toEqual('<em>1990-02-13</em>')
+
+      it('should check autocomplete_search_bar if no exact first_name', () => {
+        const peopleSearch = personWithHighlights({
+          // first_name: ['<em>Bar</em>t'],
+          last_name: ['Sim<em>pson</em>'],
+          ssn: ['<em>123456789</em>'],
+          searchable_date_of_birth: ['<em>1990</em>'],
+          autocomplete_search_bar: [
+            '<em>Bar</em>t',
+            'Sim<em>pson</em>',
+            '<em>123456789</em>',
+            '<em>1990</em>',
+          ],
+        })
+
+        const state = fromJS({
+          languages: languageLovs,
+          ethnicityTypes: ethnicityTypeLovs,
+          raceTypes: raceTypeLovs,
+          unableToDetermineCodes,
+          hispanicOriginCodes,
+          usStates,
+          peopleSearch,
+          addressTypes,
+        })
+        const peopleResults = getPeopleResultsSelector(state)
+        expect(peopleResults.getIn([0, 'firstName'])).toEqual('<em>Bar</em>t')
+      })
+
+      it('should check autocomplete_search_bar if no exact last_name', () => {
+        const peopleSearch = personWithHighlights({
+          first_name: ['<em>Bar</em>t'],
+          // last_name: ['Sim<em>pson</em>'],
+          ssn: ['<em>123456789</em>'],
+          searchable_date_of_birth: ['<em>1990</em>'],
+          autocomplete_search_bar: [
+            '<em>Bar</em>t',
+            'Sim<em>pson</em>',
+            '<em>123456789</em>',
+            '<em>1990</em>',
+          ],
+        })
+
+        const state = fromJS({
+          languages: languageLovs,
+          ethnicityTypes: ethnicityTypeLovs,
+          raceTypes: raceTypeLovs,
+          unableToDetermineCodes,
+          hispanicOriginCodes,
+          usStates,
+          peopleSearch,
+          addressTypes,
+        })
+        const peopleResults = getPeopleResultsSelector(state)
+        expect(peopleResults.getIn([0, 'lastName'])).toEqual('Sim<em>pson</em>')
+      })
+
+      it('should find autocomplete fields in any order', () => {
+        const peopleSearch = personWithHighlights({
+          first_name: ['<em>Bar</em>t'],
+          // last_name: ['Sim<em>pson</em>'],
+          ssn: ['<em>123456789</em>'],
+          searchable_date_of_birth: ['<em>1990</em>'],
+          autocomplete_search_bar: [
+            '<em>123456789</em>',
+            '<em>1990</em>',
+            'Sim<em>pson</em>',
+            '<em>Bar</em>t',
+          ],
+        })
+
+        const state = fromJS({
+          languages: languageLovs,
+          ethnicityTypes: ethnicityTypeLovs,
+          raceTypes: raceTypeLovs,
+          unableToDetermineCodes,
+          hispanicOriginCodes,
+          usStates,
+          peopleSearch,
+          addressTypes,
+        })
+        const peopleResults = getPeopleResultsSelector(state)
+        expect(peopleResults.getIn([0, 'firstName'])).toEqual('<em>Bar</em>t')
+        expect(peopleResults.getIn([0, 'lastName'])).toEqual('Sim<em>pson</em>')
+      })
     })
 
     it('formats ssn', () => {
@@ -316,4 +414,3 @@ describe('peopleSearchSelectors', () => {
     })
   })
 })
-

--- a/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
+++ b/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
@@ -338,7 +338,7 @@ describe('peopleSearchSelectors', () => {
 
       it('should find autocomplete fields in any order', () => {
         const peopleSearch = personWithHighlights({
-          first_name: ['<em>Bar</em>t'],
+          // first_name: ['<em>Bar</em>t'],
           // last_name: ['Sim<em>pson</em>'],
           ssn: ['<em>123456789</em>'],
           searchable_date_of_birth: ['<em>1990</em>'],
@@ -363,6 +363,35 @@ describe('peopleSearchSelectors', () => {
         const peopleResults = getPeopleResultsSelector(state)
         expect(peopleResults.getIn([0, 'firstName'])).toEqual('<em>Bar</em>t')
         expect(peopleResults.getIn([0, 'lastName'])).toEqual('Sim<em>pson</em>')
+      })
+
+      it('should use exact names if no highlight', () => {
+        const peopleSearch = personWithHighlights({
+          // first_name: ['<em>Bar</em>t'],
+          // last_name: ['Sim<em>pson</em>'],
+          ssn: ['<em>123456789</em>'],
+          searchable_date_of_birth: ['<em>1990</em>'],
+          autocomplete_search_bar: [
+            '<em>123456789</em>',
+            '<em>1990</em>',
+            // 'Sim<em>pson</em>',
+            // '<em>Bar</em>t',
+          ],
+        })
+
+        const state = fromJS({
+          languages: languageLovs,
+          ethnicityTypes: ethnicityTypeLovs,
+          raceTypes: raceTypeLovs,
+          unableToDetermineCodes,
+          hispanicOriginCodes,
+          usStates,
+          peopleSearch,
+          addressTypes,
+        })
+        const peopleResults = getPeopleResultsSelector(state)
+        expect(peopleResults.getIn([0, 'firstName'])).toEqual('Bart')
+        expect(peopleResults.getIn([0, 'lastName'])).toEqual('Simpson')
       })
     })
 

--- a/spec/repositories/person_search_repository_spec.rb
+++ b/spec/repositories/person_search_repository_spec.rb
@@ -49,13 +49,21 @@ describe PersonSearchRepository do
       {
         bool: {
           must: [{
-            multi_match: {
-              query: 'robert barathian',
-              type: 'cross_fields',
-              operator: 'and',
-              fields: %w[searchable_name searchable_date_of_birth ssn]
+            match: {
+              autocomplete_search_bar: {
+                query: 'robert barathian',
+                operator: 'and'
+              }
             }
-          }]
+          }],
+          should: [
+            { match: { first_name: { query: 'robert barathian' } } },
+            { match: { last_name: { query: 'robert barathian' } } },
+            { match: { 'aka.first_name': { query: 'robert barathian' } } },
+            { match: { 'aka.last_name': { query: 'robert barathian' } } },
+            { match: { date_of_birth_as_text: { query: 'robert barathian' } } },
+            { match: { ssn: { query: 'robert barathian' } } }
+          ]
         }
       }
     end

--- a/spec/services/person_search_query_builder_spec.rb
+++ b/spec/services/person_search_query_builder_spec.rb
@@ -53,14 +53,60 @@ describe PersonSearchQueryBuilder do
           search_after: %w[one two],
           query: {
             bool: {
-              must: [{
-                multi_match: {
-                  query: 'this is my search term',
-                  type: 'cross_fields',
-                  operator: 'and',
-                  fields: %w[searchable_name searchable_date_of_birth ssn]
+              must: [
+                {
+                  match: {
+                    autocomplete_search_bar: {
+                      query: 'this is my search term',
+                      operator: 'and'
+                    }
+                  }
                 }
-              }]
+              ],
+              should: [
+                {
+                  match: {
+                    first_name: {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    last_name: {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    'aka.first_name': {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    'aka.last_name': {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    date_of_birth_as_text: {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    ssn: {
+                      query: 'this is my search term'
+                    }
+                  }
+                }
+              ]
             }
           }
         )
@@ -112,14 +158,60 @@ describe PersonSearchQueryBuilder do
           sort: [{ _score: 'desc', _uid: 'desc' }],
           query: {
             bool: {
-              must: [{
-                multi_match: {
-                  query: 'this is my search term',
-                  type: 'cross_fields',
-                  operator: 'and',
-                  fields: %w[searchable_name searchable_date_of_birth ssn]
+              must: [
+                {
+                  match: {
+                    autocomplete_search_bar: {
+                      query: 'this is my search term',
+                      operator: 'and'
+                    }
+                  }
                 }
-              }]
+              ],
+              should: [
+                {
+                  match: {
+                    first_name: {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    last_name: {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    'aka.first_name': {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    'aka.last_name': {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    date_of_birth_as_text: {
+                      query: 'this is my search term'
+                    }
+                  }
+                },
+                {
+                  match: {
+                    ssn: {
+                      query: 'this is my search term'
+                    }
+                  }
+                }
+              ]
             }
           }
         )
@@ -149,20 +241,68 @@ describe PersonSearchQueryBuilder do
         search_terms.each_with_index do |search_term, index|
           expect(
             described_class.new(search_term: search_term).build
-          ).to match(a_hash_including(
-                       query: {
-                         bool: {
-                           must: [{
-                             multi_match: {
-                               query: expected_results[index],
-                               type: 'cross_fields',
-                               operator: 'and',
-                               fields: %w[searchable_name searchable_date_of_birth ssn]
-                             }
-                           }]
-                         }
-                       }
-          ))
+          ).to match(
+            a_hash_including(
+              query: {
+                bool: {
+                  must: [
+                    {
+                      match: {
+                        autocomplete_search_bar: {
+                          query: expected_results[index],
+                          operator: 'and'
+                        }
+                      }
+                    }
+                  ],
+                  should: [
+                    {
+                      match: {
+                        first_name: {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        last_name: {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        'aka.first_name': {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        'aka.last_name': {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        date_of_birth_as_text: {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        ssn: {
+                          query: expected_results[index]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            )
+          )
         end
       end
 
@@ -188,41 +328,138 @@ describe PersonSearchQueryBuilder do
         search_terms.each_with_index do |search_term, index|
           expect(
             described_class.new(search_term: search_term).build
-          ).to match(a_hash_including(
-                       query: {
-                         bool: {
-                           must: [{
-                             multi_match: {
-                               query: expected_results[index],
-                               type: 'cross_fields',
-                               operator: 'and',
-                               fields: %w[searchable_name searchable_date_of_birth ssn]
-                             }
-                           }]
-                         }
-                       }
-          ))
+          ).to match(
+            a_hash_including(
+              query: {
+                bool: {
+                  must: [
+                    {
+                      match: {
+                        autocomplete_search_bar: {
+                          query: expected_results[index],
+                          operator: 'and'
+                        }
+                      }
+                    }
+                  ],
+                  should: [
+                    {
+                      match: {
+                        first_name: {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        last_name: {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        'aka.first_name': {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        'aka.last_name': {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        date_of_birth_as_text: {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        ssn: {
+                          query: expected_results[index]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            )
+          )
         end
       end
 
       it 'keeps apostrophes and slashes in the name' do
         search_term = "A/li'son Juniper 01/02"
+        expected_search_term = "a/li'son juniper 0102"
         expect(
           described_class.new(search_term: search_term).build
-        ).to match(a_hash_including(
-                     query: {
-                       bool: {
-                         must: [{
-                           multi_match: {
-                             query: "a/li'son juniper 0102",
-                             type: 'cross_fields',
-                             operator: 'and',
-                             fields: %w[searchable_name searchable_date_of_birth ssn]
-                           }
-                         }]
-                       }
-                     }
-        ))
+        ).to match(
+          a_hash_including(
+            query: {
+              bool: {
+                must: [
+                  {
+                    match: {
+                      autocomplete_search_bar: {
+                        query: expected_search_term,
+                        operator: 'and'
+                      }
+                    }
+                  }
+                ],
+                should: [
+                  {
+                    match: {
+                      first_name: {
+                        query: expected_search_term
+                      }
+                    }
+                  },
+                  {
+                    match: {
+                      last_name: {
+                        query: expected_search_term
+                      }
+                    }
+                  },
+                  {
+                    match: {
+                      'aka.first_name': {
+                        query: expected_search_term
+                      }
+                    }
+                  },
+                  {
+                    match: {
+                      'aka.last_name': {
+                        query: expected_search_term
+                      }
+                    }
+                  },
+                  {
+                    match: {
+                      date_of_birth_as_text: {
+                        query: expected_search_term
+                      }
+                    }
+                  },
+                  {
+                    match: {
+                      ssn: {
+                        query: expected_search_term
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          )
+        )
       end
 
       it 'removes slashes in date times as the user is typing' do
@@ -271,20 +508,68 @@ describe PersonSearchQueryBuilder do
         search_terms.each_with_index do |search_term, index|
           expect(
             described_class.new(search_term: search_term).build
-          ).to match(a_hash_including(
-                       query: {
-                         bool: {
-                           must: [{
-                             multi_match: {
-                               query: expected_results[index],
-                               type: 'cross_fields',
-                               operator: 'and',
-                               fields: %w[searchable_name searchable_date_of_birth ssn]
-                             }
-                           }]
-                         }
-                       }
-          ))
+          ).to match(
+            a_hash_including(
+              query: {
+                bool: {
+                  must: [
+                    {
+                      match: {
+                        autocomplete_search_bar: {
+                          query: expected_results[index],
+                          operator: 'and'
+                        }
+                      }
+                    }
+                  ],
+                  should: [
+                    {
+                      match: {
+                        first_name: {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        last_name: {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        'aka.first_name': {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        'aka.last_name': {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        date_of_birth_as_text: {
+                          query: expected_results[index]
+                        }
+                      }
+                    },
+                    {
+                      match: {
+                        ssn: {
+                          query: expected_results[index]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            )
+          )
         end
       end
     end

--- a/spec/support/helpers/webmock_helpers.rb
+++ b/spec/support/helpers/webmock_helpers.rb
@@ -22,8 +22,14 @@ module WebmockHelpers
         'query' => {
           'bool' => {
             'must' => array_including(
-              'multi_match' => hash_including('query' => search_term.downcase)
-            )
+              'match' => {
+                'autocomplete_search_bar' => {
+                  'query' => search_term.downcase,
+                  'operator' => 'and'
+                }
+              }
+            ),
+            'should' => anything
           }
         },
         '_source' => anything,


### PR DESCRIPTION
### Jira Story

- [Search results not in the order user expects based on the search criteria INT-1485](https://osi-cwds.atlassian.net/browse/INT-1485)

## Description
This pull request provides the front end portion of INT-1485, with the goal of sorting person summaries with exactly-matched names to the top of the list, above results that only partially matched names. The ElasticSearch index update that made this possible has already been built (and is mostly backwards compatible). The front-end piece does two main things:

1. Updates our query builder in rails to use include new query terms that sort the results properly. (Thanks to @mariamcws for providing the query!)
2. Checks the newly returned fields to ensure we are highlighting search terms in each result as we did before.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
(Depends how you look at it. The search ordering changed.)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
(Waiting on Jenkins to run the feature tests for me.)

