### PR TITLE
Avoid url_helpers for dora search URLs

### DIFF
--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -43,6 +43,10 @@ class ExternalRoutes
       "/api/v1/screenings/#{id}/relationships"
     end
 
+    def dora_people_light_index_path
+      '/dora/people-summary/person-summary/_search'
+    end
+
     def ferb_api_investigation_path(id)
       "/investigations/#{id}"
     end

--- a/app/repositories/person_search_repository.rb
+++ b/app/repositories/person_search_repository.rb
@@ -7,7 +7,7 @@ class PersonSearchRepository
     def search(security_token:, search_term:, search_after:)
       response = DoraAPI.make_api_call(
         security_token,
-        Rails.application.routes.url_helpers.dora_people_light_index_path,
+        ExternalRoutes.dora_people_light_index_path,
         :post,
         query(search_term: search_term, search_after: search_after)
       )

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,12 +65,6 @@ Rails.application.routes.draw do
     end
   end
 
-  scope host: Rails.configuration.intake[:dora_api_url] do
-    post '/dora/screenings/screening/_search' => 'dev#null', as: :dora_screenings
-    post '/dora/people/person/_search' => 'dev#null', as: :dora_people
-    post '/dora/people-summary/person-summary/_search' => 'dev#null', as: :dora_people_light_index
-  end
-
   resources :version, only: :index
   get '/logout' => 'home#logout'
   get '/snapshot' => 'home#index'

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -118,7 +118,7 @@ feature 'searching a participant in autocompleter' do
       expect(
         a_request(
           :post,
-          dora_api_url(Rails.application.routes.url_helpers.dora_people_light_index_path)
+          dora_api_url(ExternalRoutes.dora_people_light_index_path)
         ).with('body' => {
                  'query' => {
                    'bool' => {
@@ -373,9 +373,7 @@ feature 'searching a participant in autocompleter' do
         person_response: search_results_three,
         search_after: %w[result_49_score result_49_uuid]
       )
-      search_path = dora_api_url(
-        Rails.application.routes.url_helpers.dora_people_light_index_path
-      )
+      search_path = dora_api_url(ExternalRoutes.dora_people_light_index_path)
       within '#search-card', text: 'Search' do
         fill_in 'Search for any person', with: 'Fi'
         expect(page).to have_content 'Showing 1-25 of 51 results for "Fi"', wait: 3

--- a/spec/support/helpers/webmock_helpers.rb
+++ b/spec/support/helpers/webmock_helpers.rb
@@ -11,9 +11,7 @@ module WebmockHelpers
   end
 
   def stub_person_search(search_term:, person_response:, search_after: nil)
-    request_path = dora_api_url(
-      Rails.application.routes.url_helpers.dora_people_light_index_path
-    )
+    request_path = dora_api_url(ExternalRoutes.dora_people_light_index_path)
     request_payload = {
       'body' => {
         'size' => 25,


### PR DESCRIPTION
### Jira Story

- No Story

## Description

The url_helper was injecting the base path (helpfully!), which
resulted in an unexpected URL in preint, where there was an extra
`/intake`.

## Tests
- [ ] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

These are updated tests that needed to get the URL from the new location.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

Bugfix for preint (search was broken). As far as we can tell, this should have no visible effect on Integration (unless search is also broken there?).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

