### PR TITLE
INT-1509 - Authorize the addition of participants using Ferb

### DIFF
--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -43,12 +43,13 @@ module Api
 
       def create
         participant = Participant.new(participant_params.to_h)
-        result = ParticipantRepository.create(session[:security_token], participant)
 
-        if result[:error?]
-          render json: { status: result[:status] }, status: result[:status]
-        else
-          render json: result[:participant].as_json
+        begin
+          created_participant = ParticipantRepository.create(session[:security_token], participant)
+          render json: created_participant
+        rescue StandardError => e
+          raise e unless e.message == 'Forbidden'
+          render json: { status: 403 }, status: 403
         end
       end
 

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -43,8 +43,13 @@ module Api
 
       def create
         participant = Participant.new(participant_params.to_h)
-        created_participant = ParticipantRepository.create(session[:security_token], participant)
-        render json: created_participant
+        result = ParticipantRepository.create(session[:security_token], participant)
+
+        if result[:error?]
+          render json: { status: result[:status] }, status: result[:status]
+        else
+          render json: result[:participant].as_json
+        end
       end
 
       def update

--- a/app/controllers/api/v1/participants_controller.rb
+++ b/app/controllers/api/v1/participants_controller.rb
@@ -47,8 +47,7 @@ module Api
         begin
           created_participant = ParticipantRepository.create(session[:security_token], participant)
           render json: created_participant
-        rescue StandardError => e
-          raise e unless e.message == 'Forbidden'
+        rescue ParticipantRepository::AuthenticationError
           render json: { status: 403 }, status: 403
         end
       end

--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -75,6 +75,10 @@ class ExternalRoutes
       "/staffpersons/#{id}"
     end
 
+    def ferb_api_client_authorization_path(id)
+      "/authorize/client/#{id}"
+    end
+
     def sdm_path
       'https://ca.sdmdata.org'
     end

--- a/app/repositories/participant_repository.rb
+++ b/app/repositories/participant_repository.rb
@@ -3,6 +3,8 @@
 # ParticipantRepository is a service class responsible for creation of a participant
 # resource via the API
 class ParticipantRepository
+  class AuthenticationError < StandardError; end
+
   def self.create(security_token, participant)
     legacy_id = participant.legacy_descriptor&.legacy_id
 
@@ -58,7 +60,7 @@ class ParticipantRepository
     begin
       FerbAPI.make_api_call(security_token, route, :get)
     rescue ApiError => e
-      raise 'Forbidden' if e.api_error[:http_code] == 403
+      raise AuthenticationError if e.api_error[:http_code] == 403
       raise e
     end
   end

--- a/app/repositories/participant_repository.rb
+++ b/app/repositories/participant_repository.rb
@@ -50,19 +50,15 @@ class ParticipantRepository
     participant.as_json.except('id')
   end
 
-  class << self
-    private
+  private_class_method def self.authorize(security_token, legacy_id)
+    return true if legacy_id.blank?
 
-    def authorize(security_token, legacy_id)
-      return true unless legacy_id
+    auth_response = FerbAPI.make_api_call(
+      security_token,
+      ExternalRoutes.ferb_api_client_authorization_path(legacy_id),
+      :get
+    )
 
-      auth_response = FerbAPI.make_api_call(
-        security_token,
-        ExternalRoutes.ferb_api_client_authorization_path(legacy_id),
-        :get
-      )
-
-      auth_response[:status] >= 200 && auth_response[:status] <= 299
-    end
+    auth_response[:status] >= 200 && auth_response[:status] <= 299
   end
 end

--- a/app/repositories/participant_repository.rb
+++ b/app/repositories/participant_repository.rb
@@ -10,7 +10,10 @@ class ParticipantRepository
       :post,
       post_data(participant).as_json
     )
-    Participant.new(response.body)
+    {
+      error?: false,
+      participant: Participant.new(response.body)
+    }
   end
 
   def self.post_data(participant)

--- a/spec/controllers/api/v1/participants_controller_spec.rb
+++ b/spec/controllers/api/v1/participants_controller_spec.rb
@@ -62,21 +62,37 @@ describe Api::V1::ParticipantsController do
       double(:participant, as_json: participant_params.merge(id: '1'))
     end
 
-    before do
+    it 'should render a participant as json' do
       participant = double(:participant)
       expect(Participant).to receive(:new)
         .with(participant_params).and_return(participant)
       expect(ParticipantRepository).to receive(:create)
         .with(security_token, participant)
-        .and_return(created_participant)
-    end
+        .and_return(error?: false, participant: created_participant)
 
-    it 'renders a participant as json' do
       process :create,
         method: :post,
         params: { screening_id: '1', participant: participant_params },
         session: session
       expect(JSON.parse(response.body)).to eq(created_participant.as_json)
+    end
+
+    it 'should return an error if unauthorized' do
+      participant = double(:participant)
+      expect(Participant).to receive(:new)
+        .with(participant_params).and_return(participant)
+      expect(ParticipantRepository).to receive(:create)
+        .with(security_token, participant)
+        .and_return(error?: true, status: 403)
+
+      process :create,
+        method: :post,
+        params: { screening_id: '1', participant: participant_params },
+        session: session
+      expect(response.status).to eq(403)
+      expect(JSON.parse(response.body)).to eq({
+        status: 403
+      }.as_json)
     end
   end
 

--- a/spec/controllers/api/v1/participants_controller_spec.rb
+++ b/spec/controllers/api/v1/participants_controller_spec.rb
@@ -68,7 +68,7 @@ describe Api::V1::ParticipantsController do
         .with(participant_params).and_return(participant)
       expect(ParticipantRepository).to receive(:create)
         .with(security_token, participant)
-        .and_return(error?: false, participant: created_participant)
+        .and_return(created_participant)
 
       process :create,
         method: :post,
@@ -83,7 +83,7 @@ describe Api::V1::ParticipantsController do
         .with(participant_params).and_return(participant)
       expect(ParticipantRepository).to receive(:create)
         .with(security_token, participant)
-        .and_return(error?: true, status: 403)
+        .and_raise('Forbidden')
 
       process :create,
         method: :post,

--- a/spec/controllers/api/v1/participants_controller_spec.rb
+++ b/spec/controllers/api/v1/participants_controller_spec.rb
@@ -83,7 +83,7 @@ describe Api::V1::ParticipantsController do
         .with(participant_params).and_return(participant)
       expect(ParticipantRepository).to receive(:create)
         .with(security_token, participant)
-        .and_raise('Forbidden')
+        .and_raise(ParticipantRepository::AuthenticationError)
 
       process :create,
         method: :post,

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -246,7 +246,7 @@ feature 'Create participant' do
           participant_homer.legacy_descriptor.legacy_id
         )
       )))
-      .to have_been_made
+      .not_to have_been_made
     expect(a_request(:post,
       intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id))))
       .to have_been_made

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -240,6 +240,13 @@ feature 'Create participant' do
     within '#search-card', text: 'Search' do
       find('strong', text: 'Homer Simpson').click
     end
+    expect(a_request(:get,
+      ferb_api_url(
+        ExternalRoutes.ferb_api_client_authorization_path(
+          participant_homer.legacy_descriptor.legacy_id
+        )
+      )))
+      .to have_been_made
     expect(a_request(:post,
       intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id))))
       .to have_been_made

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -89,7 +89,7 @@ feature 'Create participant' do
       sealed: false,
       sensitive: false,
       languages: %w[French Italian],
-      legacy_descriptor: FactoryBot.create(:legacy_descriptor),
+      legacy_descriptor: FactoryBot.create(:legacy_descriptor, legacy_id: 'ABC123ABC'),
       addresses: [marge_address],
       phone_numbers: [marge_phone_number],
       races: [
@@ -127,6 +127,7 @@ feature 'Create participant' do
           PersonSearchResultBuilder.build do |builder|
             builder.with_first_name('Homer')
             builder.with_last_name('Simpson')
+            builder.with_legacy_descriptor(homer.legacy_descriptor)
           end
         ]
       end
@@ -166,7 +167,6 @@ feature 'Create participant' do
       click_button 'Create a new person'
       expect(page).to_not have_button('Create a new person')
     end
-
     expect(a_request(:post,
       intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id))))
       .to have_been_made
@@ -230,6 +230,14 @@ feature 'Create participant' do
     homer_attributes = build_participant_from_person_and_screening(homer, existing_screening)
     participant_homer = FactoryBot.build(:participant, homer_attributes)
     created_participant_homer = FactoryBot.create(:participant, participant_homer.as_json)
+    stub_request(:get,
+      ferb_api_url(
+        ExternalRoutes.ferb_api_client_authorization_path(
+          created_participant_homer.legacy_descriptor.legacy_id
+        )
+      )).and_return(status: 200)
+
+    puts created_participant_homer.to_json
     stub_request(:post,
       intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
       .and_return(json_body(created_participant_homer.to_json, status: 201))
@@ -243,10 +251,10 @@ feature 'Create participant' do
     expect(a_request(:get,
       ferb_api_url(
         ExternalRoutes.ferb_api_client_authorization_path(
-          participant_homer.legacy_descriptor.legacy_id
+          created_participant_homer.legacy_descriptor.legacy_id
         )
       )))
-      .not_to have_been_made
+      .to have_been_made
     expect(a_request(:post,
       intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id))))
       .to have_been_made
@@ -350,6 +358,12 @@ feature 'Create participant' do
             :participant,
             participant_homer.as_json
           )
+          stub_request(:get,
+            ferb_api_url(
+              ExternalRoutes.ferb_api_client_authorization_path(
+                participant_homer.legacy_descriptor.legacy_id
+              )
+            )).and_return(status: 200)
           stub_request(:post,
             intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
             .and_return(json_body(created_participant_homer.to_json, status: 201))
@@ -419,6 +433,12 @@ feature 'Create participant' do
             :participant,
             participant_homer.as_json
           )
+          stub_request(:get,
+            ferb_api_url(
+              ExternalRoutes.ferb_api_client_authorization_path(
+                participant_homer.legacy_descriptor.legacy_id
+              )
+            )).and_return(status: 200)
           stub_request(:post,
             intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
             .and_return(json_body(created_participant_homer.to_json, status: 201))

--- a/spec/javascripts/sagas/createSnapshotPersonSagaSpec.js
+++ b/spec/javascripts/sagas/createSnapshotPersonSagaSpec.js
@@ -56,4 +56,3 @@ describe('createSnapshotPerson', () => {
     )
   })
 })
-

--- a/spec/repositories/participant_repository_spec.rb
+++ b/spec/repositories/participant_repository_spec.rb
@@ -103,7 +103,7 @@ describe ParticipantRepository do
 
         expect do
           described_class.create(security_token, participant)
-        end.to raise_error('Forbidden')
+        end.to raise_error(described_class::AuthenticationError)
       end
 
       it 'should reraise unexpected API errors' do

--- a/spec/repositories/participant_repository_spec.rb
+++ b/spec/repositories/participant_repository_spec.rb
@@ -31,10 +31,11 @@ describe ParticipantRepository do
         .and_return(response)
     end
 
-    it 'returns the created participant' do
-      created_participant = described_class.create(security_token, participant)
-      expect(created_participant.id).to eq(participant_id)
-      expect(created_participant.first_name).to eq('New Participant')
+    it 'returns the created participant with an error flag' do
+      result = described_class.create(security_token, participant)
+      expect(result[:error?]).to eq(false)
+      expect(result[:participant].id).to eq(participant_id)
+      expect(result[:participant].first_name).to eq('New Participant')
     end
   end
 


### PR DESCRIPTION
### Jira Story

- [Build Authorization rules for Sensitive/Sealed on Intake app INT-1509](https://osi-cwds.atlassian.net/browse/INT-1509)

## Description
Ferb has a new endpoint that can check whether the current user is authorized to add a given client to a screening or snapshot. Previous to this, authorization rules were not being completely enforced, resulting in unexplained (to the user) errors. This change makes a call to that Ferb endpoint to validate that this user has access.

Notes:
* The Ferb endpoint contains the logic for the full authorization matrix, and the frontend only cares about a yes/no (200/403) answer.
* If Ferb is down or inaccessible, you will still get a 500 error when trying to add a new user.
* If you are adding a new participant from the search box, we do not perform an authorization check, because there is no existing client to check!
* It is expected behavior that the error is displayed as an `alert` popup.

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
