### PR TITLE
Padding fixed on the decision card in view mode [INT-1301]

### DIFF
--- a/app/javascript/views/ScreeningDecisionShow.jsx
+++ b/app/javascript/views/ScreeningDecisionShow.jsx
@@ -31,7 +31,7 @@ const ScreeningDecisionShow = ({
         <a href={sdmPath} target='_blank' id='complete_sdm'>Complete SDM</a>
       </div>
       <div className='row'>
-        <div className='col-md-12'>
+        <div className='col-md-12 double-pad-left'>
           <ShowField label='Additional information' errors={additionalInformation.errors} required={isAdditionalInfoRequired}>
             {additionalInformation.value}
           </ShowField>

--- a/app/javascript/views/ScreeningDecisionShow.jsx
+++ b/app/javascript/views/ScreeningDecisionShow.jsx
@@ -30,22 +30,22 @@ const ScreeningDecisionShow = ({
         <div>Determine Decision and Response Time by using Structured Decision Making.</div>
         <a href={sdmPath} target='_blank' id='complete_sdm'>Complete SDM</a>
       </div>
-      <div className='row'>
-        <div className='col-md-12 double-pad-left'>
-          <ShowField label='Additional information' errors={additionalInformation.errors} required={isAdditionalInfoRequired}>
-            {additionalInformation.value}
+    </div>
+    <div className='row'>
+      <div className='col-md-12'>
+        <ShowField label='Additional information' errors={additionalInformation.errors} required={isAdditionalInfoRequired}>
+          {additionalInformation.value}
+        </ShowField>
+        {accessRestriction.value &&
+          <ShowField label='Access restrictions'>
+            {accessRestriction.value}
           </ShowField>
-          {accessRestriction.value &&
-            <ShowField label='Access restrictions'>
-              {accessRestriction.value}
-            </ShowField>
-          }
-          {(accessRestriction.value || restrictionRationale.value) &&
-            <ShowField label='Restrictions rationale' errors={restrictionRationale.errors} required>
-              {restrictionRationale.value}
-            </ShowField>
-          }
-        </div>
+        }
+        {(accessRestriction.value || restrictionRationale.value) &&
+          <ShowField label='Restrictions rationale' errors={restrictionRationale.errors} required>
+            {restrictionRationale.value}
+          </ShowField>
+        }
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Jira Story

- [Padding on the Decision Card in View Mode INT-1301](https://osi-cwds.atlassian.net/browse/INT-1301)

## Description
Padding fixed on the decision card in view mode.
Check the screenshot attachment (fixed) in JIRA.

## Tests
No behavioral change so test not needed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

