### PR TITLE
Fixed the bug people with long names cause the person icon to be orph…

### DIFF
--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -119,3 +119,9 @@
     }
   }
 }
+
+@media (min-width: 992px){
+.container {
+    width: 990px;
+}
+}

--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -120,6 +120,18 @@
   }
 }
 
+.nested-block {
+  .navlink {
+    display: flex;
+    padding: 1rem;
+
+    .pre-icon {
+      margin-right: 1rem;
+      margin-top: .4rem;
+    }
+  }
+}
+
 @media (min-width: 992px){
   .container {
     width: 990px;

--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -121,7 +121,7 @@
 }
 
 @media (min-width: 992px){
-.container {
+  .container {
     width: 990px;
-}
+  }
 }

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -106,7 +106,7 @@ export class ScreeningPage extends React.Component {
       return (
         <div className='row'>
           <ScreeningSideBar participants={participants} />
-          <div className='col-sm-8 col-md-9 col-lg-9'>
+          <div className='col-sm-8 col-md-9'>
             <h1>{referralId && `Referral #${referralId}`}</h1>
             {hasApiValidationErrors && <ErrorDetail errors={submitReferralErrors} />}
             <CardContainer

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -106,7 +106,7 @@ export class ScreeningPage extends React.Component {
       return (
         <div className='row'>
           <ScreeningSideBar participants={participants} />
-          <div className='col-md-10'>
+          <div className='col-sm-8 col-md-9 col-lg-9'>
             <h1>{referralId && `Referral #${referralId}`}</h1>
             {hasApiValidationErrors && <ErrorDetail errors={submitReferralErrors} />}
             <CardContainer

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -106,7 +106,7 @@ export class ScreeningPage extends React.Component {
       return (
         <div className='row'>
           <ScreeningSideBar participants={participants} />
-          <div className='col-sm-8 col-md-9'>
+          <div className='col-xs-8 col-md-9'>
             <h1>{referralId && `Referral #${referralId}`}</h1>
             {hasApiValidationErrors && <ErrorDetail errors={submitReferralErrors} />}
             <CardContainer

--- a/app/javascript/screenings/ScreeningSideBar.jsx
+++ b/app/javascript/screenings/ScreeningSideBar.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import nameFormatter from 'utils/nameFormatter'
 
 const ScreeningSideBar = (props) => (
-  <div className='col-sm-4 col-md-3 hide-mobile'>
+  <div className='col-xs-4 col-md-3 hide-mobile'>
     <SideBar>
       <NavLinks>
         <NavLink text='Screening Information' href='#screening-information-card-anchor' />

--- a/app/javascript/screenings/ScreeningSideBar.jsx
+++ b/app/javascript/screenings/ScreeningSideBar.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {SideBar, NavLinks, NavLink} from 'react-wood-duck'
 import PropTypes from 'prop-types'
+
 import nameFormatter from 'utils/nameFormatter'
 
 const ScreeningSideBar = (props) => (
@@ -8,16 +9,18 @@ const ScreeningSideBar = (props) => (
     <SideBar>
       <NavLinks>
         <NavLink text='Screening Information' href='#screening-information-card-anchor' />
-        <NavLink key={1} text='People & Roles' href='#search-card-anchor' >
+        <NavLink key={1} text='People & Roles' href='#search-card-anchor'>
           <NavLinks nested={true} >
-            {props.participants && props.participants.map(({id, first_name, last_name, middle_name, name_suffix}) =>
-              <NavLink
-                key={id}
-                text={nameFormatter({first_name, last_name, middle_name, name_suffix})}
-                href={`#participants-card-${id}`}
-                preIcon='fa fa-user'
-              />
-            )}
+            <div className='nested-block'>
+              {props.participants && props.participants.map(({id, first_name, last_name, name_suffix}) =>
+                <NavLink
+                  key={id}
+                  text={nameFormatter({first_name, last_name, name_suffix})}
+                  href={`#participants-card-${id}`}
+                  preIcon='fa fa-user'
+                />
+              )}
+            </div>
           </NavLinks>
         </NavLink>
         <NavLink text='Narrative' href='#narrative-card-anchor' />

--- a/app/javascript/screenings/ScreeningSideBar.jsx
+++ b/app/javascript/screenings/ScreeningSideBar.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import nameFormatter from 'utils/nameFormatter'
 
 const ScreeningSideBar = (props) => (
-  <div className='col-sm-4 col-md-3 col-lg-3 hide-mobile'>
+  <div className='col-sm-4 col-md-3 hide-mobile'>
     <SideBar>
       <NavLinks>
         <NavLink text='Screening Information' href='#screening-information-card-anchor' />

--- a/app/javascript/screenings/ScreeningSideBar.jsx
+++ b/app/javascript/screenings/ScreeningSideBar.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import nameFormatter from 'utils/nameFormatter'
 
 const ScreeningSideBar = (props) => (
-  <div className='col-md-2 hide-mobile'>
+  <div className='col-sm-4 col-md-3 col-lg-3 hide-mobile'>
     <SideBar>
       <NavLinks>
         <NavLink text='Screening Information' href='#screening-information-card-anchor' />

--- a/app/javascript/snapshots/SnapshotPage.jsx
+++ b/app/javascript/snapshots/SnapshotPage.jsx
@@ -52,7 +52,7 @@ export class SnapshotPage extends React.Component {
         <div className='container'>
           <div className='row'>
             <SnapshotSideBar participants={participants} />
-            <div className='col-md-10'>
+            <div className='col-md-9 col-sm-8 col-lg-9'>
               <div className='row'>
                 <div className='card edit double-gap-bottom' id='snapshot-card'>
                   <div className='card-body'>

--- a/app/javascript/snapshots/SnapshotPage.jsx
+++ b/app/javascript/snapshots/SnapshotPage.jsx
@@ -52,7 +52,7 @@ export class SnapshotPage extends React.Component {
         <div className='container'>
           <div className='row'>
             <SnapshotSideBar participants={participants} />
-            <div className='col-md-9 col-sm-8 col-lg-9'>
+            <div className='col-md-9 col-sm-8 '>
               <div className='row'>
                 <div className='card edit double-gap-bottom' id='snapshot-card'>
                   <div className='card-body'>

--- a/app/javascript/snapshots/SnapshotPage.jsx
+++ b/app/javascript/snapshots/SnapshotPage.jsx
@@ -52,7 +52,7 @@ export class SnapshotPage extends React.Component {
         <div className='container'>
           <div className='row'>
             <SnapshotSideBar participants={participants} />
-            <div className='col-md-9 col-sm-8 '>
+            <div className='col-md-9 col-xs-8 '>
               <div className='row'>
                 <div className='card edit double-gap-bottom' id='snapshot-card'>
                   <div className='card-body'>

--- a/app/javascript/snapshots/SnapshotSideBar.jsx
+++ b/app/javascript/snapshots/SnapshotSideBar.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import nameFormatter from 'utils/nameFormatter'
 
 const SnapshotSideBar = (props) => (
-  <div className='col-md-3 col-sm-4 col-lg-3 hide-mobile'>
+  <div className='col-md-3 col-sm-4 hide-mobile'>
     <SideBar>
       <NavLinks>
         <NavLink key={1} text='People & Roles' href='#search-card-anchor' >

--- a/app/javascript/snapshots/SnapshotSideBar.jsx
+++ b/app/javascript/snapshots/SnapshotSideBar.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import nameFormatter from 'utils/nameFormatter'
 
 const SnapshotSideBar = (props) => (
-  <div className='col-md-2 hide-mobile'>
+  <div className='col-md-3 col-sm-4 col-lg-3 hide-mobile'>
     <SideBar>
       <NavLinks>
         <NavLink key={1} text='People & Roles' href='#search-card-anchor' >

--- a/app/javascript/snapshots/SnapshotSideBar.jsx
+++ b/app/javascript/snapshots/SnapshotSideBar.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import nameFormatter from 'utils/nameFormatter'
 
 const SnapshotSideBar = (props) => (
-  <div className='col-md-3 col-sm-4 hide-mobile'>
+  <div className='col-md-3 col-xs-4 hide-mobile'>
     <SideBar>
       <NavLinks>
         <NavLink key={1} text='People & Roles' href='#search-card-anchor' >

--- a/app/javascript/snapshots/SnapshotSideBar.jsx
+++ b/app/javascript/snapshots/SnapshotSideBar.jsx
@@ -8,15 +8,17 @@ const SnapshotSideBar = (props) => (
     <SideBar>
       <NavLinks>
         <NavLink key={1} text='People & Roles' href='#search-card-anchor' >
-          <NavLinks nested={true} >
-            {props.participants && props.participants.map(({id, first_name, last_name, middle_name, name_suffix}) =>
-              <NavLink
-                key={id}
-                text={nameFormatter({first_name, last_name, middle_name, name_suffix})}
-                href={`#participants-card-${id}`}
-                preIcon='fa fa-user'
-              />
-            )}
+          <NavLinks nested={true}>
+            <div className='nested-block'>
+              {props.participants && props.participants.map(({id, first_name, last_name, name_suffix}) =>
+                <NavLink
+                  key={id}
+                  text={nameFormatter({first_name, last_name, name_suffix})}
+                  href={`#participants-card-${id}`}
+                  preIcon='fa fa-user'
+                />
+              )}
+            </div>
           </NavLinks>
         </NavLink>
         <NavLink text='Relationships' href='#relationships-card-anchor' />

--- a/spec/features/screening/show_screening_spec.rb
+++ b/spec/features/screening/show_screening_spec.rb
@@ -75,7 +75,7 @@ feature 'Show Screening' do
         .to include('#decision-card-anchor')
     end
 
-    within '.col-md-10' do
+    within '.col-md-9' do
       expect(page).to have_css('a.anchor#screening-information-card-anchor', visible: false)
       expect(page).to have_css('a.anchor#narrative-card-anchor', visible: false)
       expect(page).to have_css('a.anchor#incident-information-card-anchor', visible: false)

--- a/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
@@ -4,7 +4,7 @@ import ScreeningSideBar from 'screenings/ScreeningSideBar'
 
 describe('ScreeningSideBar', () => {
   let component
-  const participants = [{id: '1', first_name: 'scooby', last_name: 'doo', middle_name: 'dooby', name_suffix: ''}]
+  const participants = [{id: '1', first_name: 'scooby', last_name: 'doo', name_suffix: ''}]
   beforeEach(() => {
     component = shallow(<ScreeningSideBar participants={participants}/>, {disableLifecycleMethods: true})
   })
@@ -29,8 +29,8 @@ describe('ScreeningSideBar', () => {
     })
 
     it('renders a link to the People selected/created based on search', () => {
-      expect(component.find('NavLink[text="scooby dooby doo"]').exists()).toBe(true)
-      expect(component.find('NavLink[text="scooby dooby doo"]').props().href
+      expect(component.find('NavLink[text="scooby doo"]').exists()).toBe(true)
+      expect(component.find('NavLink[text="scooby doo"]').props().href
       ).toBe('#participants-card-1')
     })
   })

--- a/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
@@ -10,7 +10,7 @@ describe('ScreeningSideBar', () => {
   })
 
   it('renders the div wrapper', () => {
-    expect(component.find('div.col-md-3 div.col-sm-4 div.col-lg-3').exists()).toBe(true)
+    expect(component.find('div.col-md-3 div.col-sm-4').exists()).toBe(true)
   })
 
   it('renders the SideBar component', () => {

--- a/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
@@ -10,7 +10,7 @@ describe('ScreeningSideBar', () => {
   })
 
   it('renders the div wrapper', () => {
-    expect(component.find('div.col-md-3 div.col-sm-4').exists()).toBe(true)
+    expect(component.find('div.col-md-3 div.col-xs-4').exists()).toBe(true)
   })
 
   it('renders the SideBar component', () => {

--- a/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningSideBarSpec.jsx
@@ -10,7 +10,7 @@ describe('ScreeningSideBar', () => {
   })
 
   it('renders the div wrapper', () => {
-    expect(component.find('div.col-md-2').exists()).toBe(true)
+    expect(component.find('div.col-md-3 div.col-sm-4 div.col-lg-3').exists()).toBe(true)
   })
 
   it('renders the SideBar component', () => {

--- a/spec/javascripts/components/snapshots/SnapshotSideBarSpec.jsx
+++ b/spec/javascripts/components/snapshots/SnapshotSideBarSpec.jsx
@@ -10,7 +10,7 @@ describe('SnapshotSideBar', () => {
   })
 
   it('renders the div wrapper', () => {
-    expect(component.find('div.col-md-3 div.col-sm-4').exists()).toBe(true)
+    expect(component.find('div.col-md-3 div.col-xs-4').exists()).toBe(true)
   })
 
   it('renders the SideBar component', () => {

--- a/spec/javascripts/components/snapshots/SnapshotSideBarSpec.jsx
+++ b/spec/javascripts/components/snapshots/SnapshotSideBarSpec.jsx
@@ -10,7 +10,7 @@ describe('SnapshotSideBar', () => {
   })
 
   it('renders the div wrapper', () => {
-    expect(component.find('div.col-md-3 div.col-sm-4 div.col-lg-3').exists()).toBe(true)
+    expect(component.find('div.col-md-3 div.col-sm-4').exists()).toBe(true)
   })
 
   it('renders the SideBar component', () => {

--- a/spec/javascripts/components/snapshots/SnapshotSideBarSpec.jsx
+++ b/spec/javascripts/components/snapshots/SnapshotSideBarSpec.jsx
@@ -4,7 +4,7 @@ import SnapshotSideBar from 'snapshots/SnapshotSideBar'
 
 describe('SnapshotSideBar', () => {
   let component
-  const participants = [{id: '23', first_name: 'Ultra', last_name: 'Goku', middle_name: 'Instinct', name_suffix: ''}]
+  const participants = [{id: '23', first_name: 'Ultra', last_name: 'Goku', middle_name: '', name_suffix: ''}]
   beforeEach(() => {
     component = shallow(<SnapshotSideBar participants={participants} />)
   })
@@ -24,8 +24,8 @@ describe('SnapshotSideBar', () => {
     })
 
     it('renders a link to the People selected from search', () => {
-      expect(component.find('NavLink[text="Ultra Instinct Goku"]').exists()).toBe(true)
-      expect(component.find('NavLink[text="Ultra Instinct Goku"]').props().href
+      expect(component.find('NavLink[text="Ultra Goku"]').exists()).toBe(true)
+      expect(component.find('NavLink[text="Ultra Goku"]').props().href
       ).toBe('#participants-card-23')
     })
   })

--- a/spec/javascripts/components/snapshots/SnapshotSideBarSpec.jsx
+++ b/spec/javascripts/components/snapshots/SnapshotSideBarSpec.jsx
@@ -10,7 +10,7 @@ describe('SnapshotSideBar', () => {
   })
 
   it('renders the div wrapper', () => {
-    expect(component.find('div.col-md-2').exists()).toBe(true)
+    expect(component.find('div.col-md-3 div.col-sm-4 div.col-lg-3').exists()).toBe(true)
   })
 
   it('renders the SideBar component', () => {


### PR DESCRIPTION
Alignment for people/roles in left-hand navigation pane

### Jira Story

- [Alignment for people/roles in left-hand navigation pane INT-1498](https://osi-cwds.atlassian.net/secure/RapidBoard.jspa?rapidView=89&projectKey=INT&modal=detail&selectedIssue=INT-1498)

## Description
Alignment for people/roles in left-hand navigation pane which tends to break when the user has a long name

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

