### PR TITLE
INT-1197 (1) Fetch relationships by client IDs

### DIFF
--- a/app/controllers/api/v1/relationships_controller.rb
+++ b/app/controllers/api/v1/relationships_controller.rb
@@ -11,6 +11,12 @@ module Api
                                       .find_by_screening_id(session[:security_token], screening_id)
         render json: relationships_for_screening
       end
+
+      def index
+        client_ids = params[:client_ids]
+        relationships = RelationshipsRepository.search(session[:security_token], client_ids)
+        render json: relationships
+      end
     end
   end
 end

--- a/app/controllers/api/v1/relationships_controller.rb
+++ b/app/controllers/api/v1/relationships_controller.rb
@@ -13,7 +13,7 @@ module Api
       end
 
       def index
-        client_ids = params[:client_ids]
+        client_ids = params[:clientIds]&.split ','
         relationships = RelationshipsRepository.search(session[:security_token], client_ids)
         render json: relationships
       end

--- a/app/javascript/actions/relationshipsActions.js
+++ b/app/javascript/actions/relationshipsActions.js
@@ -16,3 +16,6 @@ export function fetchRelationshipsFailure(error) {
 export function fetchRelationships(type, id) {
   return {type: FETCH_RELATIONSHIPS, payload: {type, id}}
 }
+export function fetchRelationshipsByClientIds(ids) {
+  return {type: FETCH_RELATIONSHIPS, payload: {type: 'clients', ids}}
+}

--- a/app/javascript/reducers/relationshipsReducer.js
+++ b/app/javascript/reducers/relationshipsReducer.js
@@ -6,6 +6,23 @@ import {
 import {createReducer} from 'utils/createReducer'
 import {List, fromJS} from 'immutable'
 
+const normalizeLegacyId = (relationship) =>
+  relationship.update('legacy_id', (legacy_id) => (legacy_id || relationship.getIn([
+    'legacy_descriptor',
+    'legacy_id',
+  ])))
+
+const normalizeKeys = (relationship) =>
+  relationship.mapKeys((key) => {
+    if (key === 'legacy_descirptor') {
+      return 'legacy_descriptor'
+    }
+    if (key === 'relationship_to') {
+      return 'relationships'
+    }
+    return key
+  })
+
 export default createReducer(List(), {
   [CREATE_SCREENING_COMPLETE](state, {error}) {
     if (error) {
@@ -17,9 +34,8 @@ export default createReducer(List(), {
   [FETCH_RELATIONSHIPS_COMPLETE](state, {payload: {relationships}, error}) {
     if (error) {
       return state
-    } else {
-      return fromJS(relationships)
     }
+    return fromJS(relationships).map(normalizeKeys).map(normalizeLegacyId)
   },
   [CLEAR_RELATIONSHIPS]() {
     return List()

--- a/app/javascript/sagas/createSnapshotPersonSaga.js
+++ b/app/javascript/sagas/createSnapshotPersonSaga.js
@@ -1,4 +1,4 @@
-import {takeEvery, put, call} from 'redux-saga/effects'
+import {takeEvery, put, call, select} from 'redux-saga/effects'
 import {STATUS_CODES, post} from 'utils/http'
 import {
   CREATE_SNAPSHOT_PERSON,
@@ -6,7 +6,8 @@ import {
   createPersonFailure,
 } from 'actions/personCardActions'
 import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
-import {fetchRelationships} from 'actions/relationshipsActions'
+import {fetchRelationshipsByClientIds} from 'actions/relationshipsActions'
+import {getClientIdsSelector} from 'selectors/clientSelectors'
 
 export function* createSnapshotPerson({payload: {person}}) {
   try {
@@ -22,7 +23,8 @@ export function* createSnapshotPerson({payload: {person}}) {
       },
     })
     yield put(createPersonSuccess(response))
-    yield put(fetchRelationships('snapshots', snapshotId))
+    const clientIds = yield select(getClientIdsSelector)
+    yield put(fetchRelationshipsByClientIds(clientIds))
     yield put(fetchHistoryOfInvolvements('snapshots', snapshotId))
   } catch (error) {
     if (error.status === STATUS_CODES.forbidden) {
@@ -35,4 +37,3 @@ export function* createSnapshotPerson({payload: {person}}) {
 export function* createSnapshotPersonSaga() {
   yield takeEvery(CREATE_SNAPSHOT_PERSON, createSnapshotPerson)
 }
-

--- a/app/javascript/sagas/deleteSnapshotPersonSaga.js
+++ b/app/javascript/sagas/deleteSnapshotPersonSaga.js
@@ -5,16 +5,18 @@ import {
   deletePersonSuccess,
   deletePersonFailure,
 } from 'actions/personCardActions'
-import {fetchRelationships} from 'actions/relationshipsActions'
+import {fetchRelationshipsByClientIds} from 'actions/relationshipsActions'
 import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
+import {getClientIdsSelector} from 'selectors/clientSelectors'
 import {getSnapshotIdValueSelector} from 'selectors/snapshotSelectors'
 
 export function* deleteSnapshotPerson({payload: {id}}) {
   try {
     yield call(destroy, `/api/v1/participants/${id}`)
     yield put(deletePersonSuccess(id))
+    const clientIds = yield select(getClientIdsSelector)
+    yield put(fetchRelationshipsByClientIds(clientIds))
     const snapshotId = yield select(getSnapshotIdValueSelector)
-    yield put(fetchRelationships('snapshots', snapshotId))
     yield put(fetchHistoryOfInvolvements('snapshots', snapshotId))
   } catch (error) {
     yield put(deletePersonFailure(error.responseJSON))
@@ -23,4 +25,3 @@ export function* deleteSnapshotPerson({payload: {id}}) {
 export function* deleteSnapshotPersonSaga() {
   yield takeEvery(DELETE_SNAPSHOT_PERSON, deleteSnapshotPerson)
 }
-

--- a/app/javascript/sagas/fetchRelationshipsSaga.js
+++ b/app/javascript/sagas/fetchRelationshipsSaga.js
@@ -8,13 +8,29 @@ import {
   FETCH_RELATIONSHIPS,
 } from 'actions/actionTypes'
 
-export function* fetchRelationships({payload: {id, type}}) {
+function* fetchRelationshipsForUnitOfWork(type, id) {
   try {
     const response = yield call(get, `/api/v1/${type}/${id}/relationships`)
     yield put(fetchRelationshipsSuccess(response))
   } catch (error) {
     yield put(fetchRelationshipsFailure(error.responseJSON))
   }
+}
+
+function* fetchRelationshipsForClients(ids) {
+  try {
+    const response = yield call(get, `/api/v1/relationships?clientIds=${ids.join(',')}`)
+    yield put(fetchRelationshipsSuccess(response))
+  } catch (error) {
+    yield put(fetchRelationshipsFailure(error.responseJSON))
+  }
+}
+
+export function fetchRelationships({payload: {type, id, ids}}) {
+  if (type === 'clients') {
+    return fetchRelationshipsForClients(ids)
+  }
+  return fetchRelationshipsForUnitOfWork(type, id)
 }
 export function* fetchRelationshipsSaga() {
   yield takeEvery(FETCH_RELATIONSHIPS, fetchRelationships)

--- a/app/javascript/selectors/clientSelectors.js
+++ b/app/javascript/selectors/clientSelectors.js
@@ -1,0 +1,8 @@
+import {List} from 'immutable'
+
+export const getClientIdsSelector = (state) =>
+  state.get('participants', List()).map(
+    (client) => client.get('legacy_id',
+      client.getIn(['legacy_descriptor', 'legacy_id'],
+        null))
+  ).filter(Boolean).toJS()

--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -79,6 +79,10 @@ class ExternalRoutes
       "/authorize/client/#{id}"
     end
 
+    def ferb_api_relationships_path
+      '/clients/relationships'
+    end
+
     def sdm_path
       'https://ca.sdmdata.org'
     end

--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -79,8 +79,9 @@ class ExternalRoutes
       "/authorize/client/#{id}"
     end
 
-    def ferb_api_relationships_path
-      '/clients/relationships'
+    def ferb_api_relationships_path(ids)
+      csv_ids = ids.join(',')
+      "/clients/relationships?clientIds=#{csv_ids}"
     end
 
     def sdm_path

--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -79,9 +79,8 @@ class ExternalRoutes
       "/authorize/client/#{id}"
     end
 
-    def ferb_api_relationships_path(ids)
-      csv_ids = ids.join(',')
-      "/clients/relationships?clientIds=#{csv_ids}"
+    def ferb_api_relationships_path
+      '/clients/relationships'
     end
 
     def sdm_path

--- a/app/lib/json_api.rb
+++ b/app/lib/json_api.rb
@@ -13,12 +13,14 @@ class JsonAPI # :nodoc:
   end
 
   # rubocop:disable MethodLength
-  def self.make_api_call(security_token, url, method, payload = nil)
+  def self.make_api_call(security_token, url, method, payload = nil, params = nil)
     connection.send(method) do |req|
       req.url url
       req.headers['Content-Type'] = CONTENT_TYPE unless method == :get
       req.headers['Authorization'] = security_token
       req.body = payload.to_json unless payload.nil?
+      req.options.params_encoder = Faraday::FlatParamsEncoder
+      req.params = params unless params.nil?
     end
   rescue Faraday::Error => e
     raise ApiError,

--- a/app/lib/json_api.rb
+++ b/app/lib/json_api.rb
@@ -12,21 +12,34 @@ class JsonAPI # :nodoc:
     end
   end
 
-  # rubocop:disable MethodLength
-  def self.make_api_call(security_token, url, method, payload = nil, params = nil)
+  def self.make_api_call(security_token, url, method, payload = nil)
     connection.send(method) do |req|
       req.url url
-      req.headers['Content-Type'] = CONTENT_TYPE unless method == :get
       req.headers['Authorization'] = security_token
-      req.body = payload.to_json unless payload.nil?
-      req.options.params_encoder = Faraday::FlatParamsEncoder
-      req.params = params unless params.nil?
+      set_payload(req, method, payload)
     end
   rescue Faraday::Error => e
+    raise_api_error(e.message, payload, url, method)
+  end
+
+  private_class_method def self.raise_api_error(message, payload, url, method)
     raise ApiError,
-      message: e.message,
+      message: message,
       sent_attributes: payload ? payload.to_json : '',
       url: url,
       method: method
+  end
+
+  private_class_method def self.set_payload(req, method, payload)
+    return req if payload.nil?
+
+    if method == :get
+      req.options.params_encoder = Faraday::FlatParamsEncoder
+      req.params = payload
+    else
+      req.headers['Content-Type'] = CONTENT_TYPE
+      req.body = payload.to_json
+    end
+    req
   end
 end

--- a/app/repositories/relationships_repository.rb
+++ b/app/repositories/relationships_repository.rb
@@ -18,8 +18,10 @@ class RelationshipsRepository
 
     FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.ferb_api_relationships_path(client_ids),
-      :get
+      ExternalRoutes.ferb_api_relationships_path,
+      :get,
+      nil,
+      clientIds: client_ids
     ).body
   end
 end

--- a/app/repositories/relationships_repository.rb
+++ b/app/repositories/relationships_repository.rb
@@ -18,7 +18,7 @@ class RelationshipsRepository
 
     FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.ferb_api_relationships_path + '?' + client_ids.join(','),
+      ExternalRoutes.ferb_api_relationships_path + '?clientIds=' + client_ids.join(','),
       :get
     ).body
   end

--- a/app/repositories/relationships_repository.rb
+++ b/app/repositories/relationships_repository.rb
@@ -12,4 +12,14 @@ class RelationshipsRepository
     )
     response.body
   end
+
+  def self.search(security_token, client_ids)
+    return [] if client_ids.blank?
+
+    FerbAPI.make_api_call(
+      security_token,
+      ExternalRoutes.ferb_api_relationships_path + '?' + client_ids.join(','),
+      :get
+    ).body
+  end
 end

--- a/app/repositories/relationships_repository.rb
+++ b/app/repositories/relationships_repository.rb
@@ -18,7 +18,7 @@ class RelationshipsRepository
 
     FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.ferb_api_relationships_path + '?clientIds=' + client_ids.join(','),
+      ExternalRoutes.ferb_api_relationships_path(client_ids),
       :get
     ).body
   end

--- a/app/repositories/relationships_repository.rb
+++ b/app/repositories/relationships_repository.rb
@@ -20,7 +20,6 @@ class RelationshipsRepository
       security_token,
       ExternalRoutes.ferb_api_relationships_path,
       :get,
-      nil,
       clientIds: client_ids
     ).body
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,6 +47,8 @@ Rails.application.routes.draw do
         only: %i[update],
         constraints: Routes::ActiveScreeningsConstraint
 
+      resources :relationships, only: %i[index]
+
       resource :people, only: [:search] do
         collection do
           get 'search'

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -54,6 +54,11 @@ namespace :spec do # rubocop:disable BlockLength
         Rake::Task['spec:intake:parallel'].invoke
       end
     end
+
+    desc 'Run specs without recompiling webpack'
+    task :nopack do
+      system "#{run_in_intake_container('bundle exec rspec')} #{file_list}"
+    end
   end
 
   desc 'Run specs in api container'

--- a/spec/controllers/api/v1/relationships_controller_spec.rb
+++ b/spec/controllers/api/v1/relationships_controller_spec.rb
@@ -69,7 +69,7 @@ describe Api::V1::RelationshipsController do
     it 'responds with success' do
       process :index,
         method: :get,
-        params: { client_ids: client_ids },
+        params: { clientIds: client_ids.join(',') },
         session: session
       expect(JSON.parse(response.body)).to match array_including(
         a_hash_including(

--- a/spec/controllers/api/v1/relationships_controller_spec.rb
+++ b/spec/controllers/api/v1/relationships_controller_spec.rb
@@ -26,7 +26,6 @@ describe Api::V1::RelationshipsController do
   end
 
   describe '#by_screening_id' do
-
     before do
       expect(RelationshipsRepository).to receive(:find_by_screening_id)
         .with(security_token, screening_id)

--- a/spec/controllers/api/v1/relationships_controller_spec.rb
+++ b/spec/controllers/api/v1/relationships_controller_spec.rb
@@ -7,24 +7,25 @@ describe Api::V1::RelationshipsController do
   let(:security_token) { 'my_security_token' }
   let(:session) { { security_token: security_token } }
 
+  let(:expected_json) do
+    [
+      {
+        id: '12',
+        first_name: 'Aubrey',
+        last_name: 'Campbell',
+        relationships: [
+          {
+            first_name: 'Jake',
+            last_name: 'Campbell',
+            relationship: 'Sister',
+            related_person_id: '7'
+          }
+        ]
+      }
+    ].to_json
+  end
+
   describe '#by_screening_id' do
-    let(:expected_json) do
-      [
-        {
-          id: '12',
-          first_name: 'Aubrey',
-          last_name: 'Campbell',
-          relationships: [
-            {
-              first_name: 'Jake',
-              last_name: 'Campbell',
-              relationship: 'Sister',
-              related_person_id: '7'
-            }
-          ]
-        }
-      ].to_json
-    end
 
     before do
       expect(RelationshipsRepository).to receive(:find_by_screening_id)
@@ -36,6 +37,40 @@ describe Api::V1::RelationshipsController do
       process :by_screening_id,
         method: :get,
         params: { id: screening_id },
+        session: session
+      expect(JSON.parse(response.body)).to match array_including(
+        a_hash_including(
+          'id' => '12',
+          'first_name' => 'Aubrey',
+          'last_name' => 'Campbell',
+          'relationships' => array_including(
+            a_hash_including(
+              'first_name' => 'Jake',
+              'last_name' => 'Campbell',
+              'relationship' => 'Sister',
+              'related_person_id' => '7'
+            )
+          )
+        )
+      )
+    end
+  end
+
+  describe '#index' do
+    let(:client_ids) do
+      ['12']
+    end
+
+    before do
+      expect(RelationshipsRepository).to receive(:search)
+        .with(security_token, client_ids)
+        .and_return(expected_json)
+    end
+
+    it 'responds with success' do
+      process :index,
+        method: :get,
+        params: { client_ids: client_ids },
         session: session
       expect(JSON.parse(response.body)).to match array_including(
         a_hash_including(

--- a/spec/features/snapshot/add_remove_people_spec.rb
+++ b/spec/features/snapshot/add_remove_people_spec.rb
@@ -39,12 +39,6 @@ feature 'Adding and removing a person from a snapshot' do
         ExternalRoutes.ferb_api_relationships_path([person.legacy_id])
       )
     ).and_return(json_body([].to_json, status: 200))
-    stub_request(
-      :get,
-      ferb_api_url(
-        ExternalRoutes.ferb_api_relationships_path([])
-      )
-    ).and_return(json_body([].to_json, status: 200))
 
     search_response = PersonSearchResponseBuilder.build do |response|
       response.with_total(1)
@@ -131,15 +125,6 @@ feature 'Adding and removing a person from a snapshot' do
         :get,
         ferb_api_url(
           ExternalRoutes.ferb_api_relationships_path([person.legacy_id])
-        )
-      )
-    ).to have_been_made.times(1)
-
-    expect(
-      a_request(
-        :get,
-        ferb_api_url(
-          ExternalRoutes.ferb_api_relationships_path([])
         )
       )
     ).to have_been_made.times(1)

--- a/spec/features/snapshot/add_remove_people_spec.rb
+++ b/spec/features/snapshot/add_remove_people_spec.rb
@@ -36,8 +36,8 @@ feature 'Adding and removing a person from a snapshot' do
     stub_request(
       :get,
       ferb_api_url(
-        ExternalRoutes.ferb_api_relationships_path([person.legacy_id])
-      )
+        ExternalRoutes.ferb_api_relationships_path
+      ) + "?clientIds=#{person.legacy_id}"
     ).and_return(json_body([].to_json, status: 200))
 
     search_response = PersonSearchResponseBuilder.build do |response|
@@ -124,8 +124,8 @@ feature 'Adding and removing a person from a snapshot' do
       a_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_relationships_path([person.legacy_id])
-        )
+          ExternalRoutes.ferb_api_relationships_path
+        ) + "?clientIds=#{person.legacy_id}"
       )
     ).to have_been_made.times(1)
 

--- a/spec/features/snapshot/add_remove_people_spec.rb
+++ b/spec/features/snapshot/add_remove_people_spec.rb
@@ -16,6 +16,7 @@ feature 'Adding and removing a person from a snapshot' do
       :participant,
       first_name: 'Marge',
       screening_id: snapshot.id,
+      legacy_id: 'ABCDEFGHIJ',
       phone_numbers: [FactoryBot.create(:phone_number, number: '9712876774')],
       languages: %w[French Italian],
       addresses: [FactoryBot.create(:address, state: 'CA')]
@@ -34,8 +35,14 @@ feature 'Adding and removing a person from a snapshot' do
     ).and_return(json_body({}.to_json, status: 200))
     stub_request(
       :get,
-      intake_api_url(
-        ExternalRoutes.intake_api_relationships_by_screening_path(snapshot.id)
+      ferb_api_url(
+        ExternalRoutes.ferb_api_relationships_path([person.legacy_id])
+      )
+    ).and_return(json_body([].to_json, status: 200))
+    stub_request(
+      :get,
+      ferb_api_url(
+        ExternalRoutes.ferb_api_relationships_path([])
       )
     ).and_return(json_body([].to_json, status: 200))
 
@@ -122,11 +129,20 @@ feature 'Adding and removing a person from a snapshot' do
     expect(
       a_request(
         :get,
-        intake_api_url(
-          ExternalRoutes.intake_api_relationships_by_screening_path(snapshot.id)
+        ferb_api_url(
+          ExternalRoutes.ferb_api_relationships_path([person.legacy_id])
         )
       )
-    ).to have_been_made.times(2)
+    ).to have_been_made.times(1)
+
+    expect(
+      a_request(
+        :get,
+        ferb_api_url(
+          ExternalRoutes.ferb_api_relationships_path([])
+        )
+      )
+    ).to have_been_made.times(1)
 
     expect(page).not_to have_content show_participant_card_selector(person.id)
     expect(page).not_to have_content(person.first_name)

--- a/spec/features/snapshot/relationships_snapshot_spec.rb
+++ b/spec/features/snapshot/relationships_snapshot_spec.rb
@@ -28,7 +28,7 @@ feature 'Snapshot relationship card' do
     end
   end
 
-  context 'load relationships from intake api' do
+  context 'load relationships' do
     around do |example|
       Feature.run_with_activated(:release_two) do
         example.run
@@ -102,7 +102,7 @@ feature 'Snapshot relationship card' do
       stub_request(
         :get,
         intake_api_url(
-          ExternalRoutes.intake_api_relationships_by_screening_path(snapshot.id)
+          ExternalRoutes.ferb_api_relationships_path
         )
       ).and_return(json_body(relationships.to_json, status: 200))
 
@@ -130,7 +130,7 @@ feature 'Snapshot relationship card' do
         a_request(
           :get,
           intake_api_url(
-            ExternalRoutes.intake_api_relationships_by_screening_path(snapshot.id)
+            ExternalRoutes.ferb_api_relationships_path
           )
         )
       ).to have_been_made

--- a/spec/features/snapshot/relationships_snapshot_spec.rb
+++ b/spec/features/snapshot/relationships_snapshot_spec.rb
@@ -107,8 +107,8 @@ feature 'Snapshot relationship card' do
       stub_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_relationships_path([participant.id])
-        )
+          ExternalRoutes.ferb_api_relationships_path
+        ) + "?clientIds=#{participant.id}"
       ).and_return(json_body(relationships.to_json, status: 200))
 
       visit snapshot_path(id: participants_screening.id)
@@ -127,8 +127,8 @@ feature 'Snapshot relationship card' do
         a_request(
           :get,
           ferb_api_url(
-            ExternalRoutes.ferb_api_relationships_path([participant.id])
-          )
+            ExternalRoutes.ferb_api_relationships_path
+          ) + "?clientIds=#{participant.id}"
         )
       ).to have_been_made
 

--- a/spec/features/snapshot/relationships_snapshot_spec.rb
+++ b/spec/features/snapshot/relationships_snapshot_spec.rb
@@ -107,7 +107,7 @@ feature 'Snapshot relationship card' do
       stub_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_relationships_path + "?clientIds=#{participant.id}"
+          ExternalRoutes.ferb_api_relationships_path([participant.id])
         )
       ).and_return(json_body(relationships.to_json, status: 200))
 
@@ -127,7 +127,7 @@ feature 'Snapshot relationship card' do
         a_request(
           :get,
           ferb_api_url(
-            ExternalRoutes.ferb_api_relationships_path + "?clientIds=#{participant.id}"
+            ExternalRoutes.ferb_api_relationships_path([participant.id])
           )
         )
       ).to have_been_made

--- a/spec/javascripts/reducers/relationshipsReducerSpec.js
+++ b/spec/javascripts/reducers/relationshipsReducerSpec.js
@@ -16,15 +16,52 @@ describe('relationshipsReducer', () => {
 
   describe('on FETCH_RELATIONSHIPS_COMPLETE', () => {
     it('returns the relationships from the action on success', () => {
-      const relationships = fromJS([{id: 1}, {id: 2}])
+      const relationships = fromJS([
+        {id: 1, legacy_id: 'ABC', relationships: []},
+        {id: 2, legacy_id: 'DEF', relationsihps: []},
+      ])
       const action = fetchRelationshipsSuccess(relationships.toJS())
       expect(relationshipsReducer(List(), action)).toEqualImmutable(relationships)
     })
     it('returns the last state on failure', () => {
-      const oldState = fromJS([{id: 1}])
+      const oldState = fromJS([{id: 1, legacy_id: 'ABC'}])
       const action = fetchRelationshipsFailure()
       expect(relationshipsReducer(oldState, action))
         .toEqual(oldState)
+    })
+    it('sets legacy_id from descriptor', () => {
+      const relationships = [
+        {id: 1, legacy_id: 'ABC'},
+        {id: 2, legacy_descriptor: {legacy_id: 'DEF'}},
+      ]
+      const action = fetchRelationshipsSuccess(relationships)
+      expect(relationshipsReducer(List(), action)).toEqualImmutable(fromJS([
+        {id: 1, legacy_id: 'ABC'},
+        {id: 2, legacy_id: 'DEF', legacy_descriptor: {legacy_id: 'DEF'}},
+      ]))
+    })
+
+    // We need to support this for a little while due to a typo in Ferb
+    it('sets legacy_id from "descirptor"', () => {
+      const relationships = [
+        {id: 1, legacy_id: 'ABC'},
+        {id: 2, legacy_descirptor: {legacy_id: 'DEF'}},
+      ]
+      const action = fetchRelationshipsSuccess(relationships)
+      expect(relationshipsReducer(List(), action)).toEqualImmutable(fromJS([
+        {id: 1, legacy_id: 'ABC'},
+        {id: 2, legacy_id: 'DEF', legacy_descriptor: {legacy_id: 'DEF'}},
+      ]))
+    })
+
+    it('sets relationships from relationship_to', () => {
+      const relationships = [
+        {id: 1, relationship_to: ['ABC']},
+      ]
+      const action = fetchRelationshipsSuccess(relationships)
+      expect(relationshipsReducer(List(), action)).toEqualImmutable(fromJS([
+        {id: 1, relationships: ['ABC']},
+      ]))
     })
   })
 
@@ -44,7 +81,7 @@ describe('relationshipsReducer', () => {
 
   describe('on CLEAR_RELATIONSHIPS', () => {
     it('clears all the relationships from the relationships reducer', () => {
-      const oldState = fromJS([{id: 1}])
+      const oldState = fromJS([{id: 1, legacy_id: 'ABC'}])
       const action = clearRelationships()
       expect(relationshipsReducer(oldState, action).isEmpty()).toEqual(true)
     })

--- a/spec/javascripts/sagas/createSnapshotPersonSagaSpec.js
+++ b/spec/javascripts/sagas/createSnapshotPersonSagaSpec.js
@@ -1,5 +1,5 @@
 import 'babel-polyfill'
-import {takeEvery, put, call} from 'redux-saga/effects'
+import {takeEvery, put, call, select} from 'redux-saga/effects'
 import {post} from 'utils/http'
 import {
   createSnapshotPerson,
@@ -8,7 +8,8 @@ import {
 import {CREATE_SNAPSHOT_PERSON} from 'actions/personCardActions'
 import * as personCardActions from 'actions/personCardActions'
 import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
-import {fetchRelationships} from 'actions/relationshipsActions'
+import {fetchRelationshipsByClientIds} from 'actions/relationshipsActions'
+import {getClientIdsSelector} from 'selectors/clientSelectors'
 
 describe('createSnapshotPersonSaga', () => {
   it('creates participant on CREATE_SNAPSHOT_PERSON', () => {
@@ -18,11 +19,11 @@ describe('createSnapshotPersonSaga', () => {
 })
 
 describe('createSnapshotPerson', () => {
-  const snapashotId = '444'
+  const snapshotId = '444'
   const legacy_descriptor = {legacy_id: '1', legacy_table_name: 'table'}
-  const params = {screening_id: snapashotId, legacy_descriptor}
+  const params = {screening_id: snapshotId, legacy_descriptor}
   const participant = {first_name: 'Michael', ...params}
-  const action = personCardActions.createSnapshotPerson({snapshotId: snapashotId, legacy_descriptor})
+  const action = personCardActions.createSnapshotPerson({snapshotId: snapshotId, legacy_descriptor})
 
   it('creates and puts participant and fetches relationships and history', () => {
     const gen = createSnapshotPerson(action)
@@ -30,11 +31,14 @@ describe('createSnapshotPerson', () => {
     expect(gen.next(participant).value).toEqual(
       put(personCardActions.createPersonSuccess(participant))
     )
-    expect(gen.next(snapashotId).value).toEqual(
-      put(fetchRelationships('snapshots', snapashotId))
+    expect(gen.next().value).toEqual(
+      select(getClientIdsSelector)
     )
-    expect(gen.next(snapashotId).value).toEqual(
-      put(fetchHistoryOfInvolvements('snapshots', snapashotId))
+    expect(gen.next(['1']).value).toEqual(
+      put(fetchRelationshipsByClientIds(['1']))
+    )
+    expect(gen.next(snapshotId).value).toEqual(
+      put(fetchHistoryOfInvolvements('snapshots', snapshotId))
     )
   })
 

--- a/spec/javascripts/sagas/deleteSnapshotPersonSagaSpec.js
+++ b/spec/javascripts/sagas/deleteSnapshotPersonSagaSpec.js
@@ -7,8 +7,9 @@ import {
 } from 'sagas/deleteSnapshotPersonSaga'
 import {DELETE_SNAPSHOT_PERSON} from 'actions/personCardActions'
 import * as personCardActions from 'actions/personCardActions'
-import {fetchRelationships} from 'actions/relationshipsActions'
+import {fetchRelationshipsByClientIds} from 'actions/relationshipsActions'
 import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
+import {getClientIdsSelector} from 'selectors/clientSelectors'
 import {getSnapshotIdValueSelector} from 'selectors/snapshotSelectors'
 
 describe('deleteParticipantSaga', () => {
@@ -29,12 +30,16 @@ describe('deleteParticipant', () => {
       put(personCardActions.deletePersonSuccess(id))
     )
     expect(gen.next().value).toEqual(
+      select(getClientIdsSelector)
+    )
+    const clientIds = ['456', '789']
+    expect(gen.next(clientIds).value).toEqual(
+      put(fetchRelationshipsByClientIds(clientIds))
+    )
+    expect(gen.next().value).toEqual(
       select(getSnapshotIdValueSelector)
     )
     const snapshotId = '444'
-    expect(gen.next(snapshotId).value).toEqual(
-      put(fetchRelationships('snapshots', snapshotId))
-    )
     expect(gen.next(snapshotId).value).toEqual(
       put(fetchHistoryOfInvolvements('snapshots', snapshotId))
     )
@@ -49,4 +54,3 @@ describe('deleteParticipant', () => {
     )
   })
 })
-

--- a/spec/javascripts/sagas/fetchRelationshipsSagaSpec.js
+++ b/spec/javascripts/sagas/fetchRelationshipsSagaSpec.js
@@ -22,7 +22,7 @@ describe('fetchRelationships', () => {
   const type = 'bananas'
   const action = actions.fetchRelationships(type, id)
 
-  it('fetches and puts relationships', () => {
+  it('should fetch and put relationships', () => {
     const gen = fetchRelationships(action)
     expect(gen.next().value).toEqual(
       call(get, '/api/v1/bananas/123/relationships')
@@ -33,7 +33,7 @@ describe('fetchRelationships', () => {
     )
   })
 
-  it('puts errors when errors are thrown', () => {
+  it('should put errors when errors are thrown', () => {
     const gen = fetchRelationships(action)
     expect(gen.next().value).toEqual(
       call(get, '/api/v1/bananas/123/relationships')
@@ -41,6 +41,20 @@ describe('fetchRelationships', () => {
     const error = {responseJSON: 'some error'}
     expect(gen.throw(error).value).toEqual(
       put(actions.fetchRelationshipsFailure('some error'))
+    )
+  })
+
+  it('should fetch by client_ids when provided', () => {
+    const gen = fetchRelationships(
+      actions.fetchRelationshipsByClientIds(['a', 'b', 'c']))
+
+    expect(gen.next().value).toEqual(
+      call(get, '/api/v1/relationships?clientIds=a,b,c')
+    )
+
+    const relationships = [{id: 'a'}, {id: 'b'}, {id: 'c'}]
+    expect(gen.next(relationships).value).toEqual(
+      put(actions.fetchRelationshipsSuccess(relationships))
     )
   })
 })

--- a/spec/javascripts/selectors/clientSelectorsSpec.js
+++ b/spec/javascripts/selectors/clientSelectorsSpec.js
@@ -1,0 +1,43 @@
+import {fromJS} from 'immutable'
+import {getClientIdsSelector} from 'selectors/clientSelectors'
+
+describe('clientSelectors', () => {
+  describe('getClientIdsSelector', () => {
+    it('should select ids from legacy_id field', () => {
+      const state = fromJS({
+        participants: [{
+          legacy_id: 'ABC',
+        }],
+      })
+
+      expect(getClientIdsSelector(state)).toEqual(['ABC'])
+    })
+
+    it('should select ids from legacy_descriptor', () => {
+      const state = fromJS({
+        participants: [{
+          legacy_descriptor: {
+            legacy_id: 'DEF',
+          },
+        }],
+      })
+
+      expect(getClientIdsSelector(state)).toEqual(['DEF'])
+    })
+
+    it('should select multiple clients', () => {
+      const state = fromJS({
+        participants: [{
+          legacy_id: 'ABC',
+        },
+        {
+          legacy_descriptor: {
+            legacy_id: 'DEF',
+          },
+        }],
+      })
+
+      expect(getClientIdsSelector(state)).toEqual(['ABC', 'DEF'])
+    })
+  })
+})

--- a/spec/lib/external_routes_spec.rb
+++ b/spec/lib/external_routes_spec.rb
@@ -97,15 +97,9 @@ describe ExternalRoutes do
   end
 
   describe '.ferb_api_relationships_path' do
-    it 'builds a query with a single client ID' do
-      expect(described_class.ferb_api_relationships_path(['ABC'])).to eq(
-        '/clients/relationships?clientIds=ABC'
-      )
-    end
-
-    it 'builds a comma separated list of ids' do
-      expect(described_class.ferb_api_relationships_path(%w[ABC DEF])).to eq(
-        '/clients/relationships?clientIds=ABC,DEF'
+    it 'returns the base path' do
+      expect(described_class.ferb_api_relationships_path).to eq(
+        '/clients/relationships'
       )
     end
   end

--- a/spec/lib/external_routes_spec.rb
+++ b/spec/lib/external_routes_spec.rb
@@ -96,6 +96,20 @@ describe ExternalRoutes do
     end
   end
 
+  describe '.ferb_api_relationships_path' do
+    it 'builds a query with a single client ID' do
+      expect(described_class.ferb_api_relationships_path(['ABC'])).to eq(
+        '/clients/relationships?clientIds=ABC'
+      )
+    end
+
+    it 'builds a comma separated list of ids' do
+      expect(described_class.ferb_api_relationships_path(%w[ABC DEF])).to eq(
+        '/clients/relationships?clientIds=ABC,DEF'
+      )
+    end
+  end
+
   describe '.ferb_api_lov_path' do
     it 'returns /lov' do
       expect(described_class.ferb_api_lov_path).to eq('/lov')

--- a/spec/lib/json_api_spec.rb
+++ b/spec/lib/json_api_spec.rb
@@ -25,6 +25,21 @@ describe JsonAPI do
       ).to have_been_made
     end
 
+    it 'sends get requests with params to the JSON API' do
+      stub_request(:get, 'http://api_url/api/v1/screening/1?foo=ABC&foo=DEF&bar=BAZ')
+      api_class.make_api_call(
+        security_token,
+        '/api/v1/screening/1',
+        :get,
+        nil,
+        foo: %w[ABC DEF],
+        bar: 'BAZ'
+      )
+      expect(
+        a_request(:get, 'http://api_url/api/v1/screening/1?foo=ABC&foo=DEF&bar=BAZ')
+      ).to have_been_made
+    end
+
     it 'sends post requests to the JSON API' do
       stub_request(:post, 'http://api_url/api/v1/screening').and_return(status: 201)
       api_class.make_api_call(

--- a/spec/lib/json_api_spec.rb
+++ b/spec/lib/json_api_spec.rb
@@ -25,13 +25,12 @@ describe JsonAPI do
       ).to have_been_made
     end
 
-    it 'sends get requests with params to the JSON API' do
+    it 'sends get requests with params instead of a body' do
       stub_request(:get, 'http://api_url/api/v1/screening/1?foo=ABC&foo=DEF&bar=BAZ')
       api_class.make_api_call(
         security_token,
         '/api/v1/screening/1',
         :get,
-        nil,
         foo: %w[ABC DEF],
         bar: 'BAZ'
       )

--- a/spec/repositories/relationships_repository_spec.rb
+++ b/spec/repositories/relationships_repository_spec.rb
@@ -78,7 +78,7 @@ describe RelationshipsRepository do
 
     it 'should return all relationships found for a single id' do
       expect(FerbAPI).to receive(:make_api_call)
-        .with(security_token, '/clients/relationships?EwsPYbG07n', :get)
+        .with(security_token, '/clients/relationships?clientIds=EwsPYbG07n', :get)
         .and_return(single_response)
 
       relationships = described_class.search(security_token, ['EwsPYbG07n'])
@@ -88,8 +88,11 @@ describe RelationshipsRepository do
 
     it 'should return all relationships for multiple clients' do
       expect(FerbAPI).to receive(:make_api_call)
-        .with(security_token, '/clients/relationships?EwsPYbG07n,ABCDEFGHIJ,ZYXWVUTSRQ', :get)
-        .and_return(full_response)
+        .with(
+          security_token,
+          '/clients/relationships?clientIds=EwsPYbG07n,ABCDEFGHIJ,ZYXWVUTSRQ',
+          :get
+        ).and_return(full_response)
 
       relationships = described_class.search(security_token, %w[EwsPYbG07n ABCDEFGHIJ ZYXWVUTSRQ])
 

--- a/spec/repositories/relationships_repository_spec.rb
+++ b/spec/repositories/relationships_repository_spec.rb
@@ -23,7 +23,6 @@ describe RelationshipsRepository do
   end
 
   describe '.search' do
-
     let(:empty_response) do
       double(:response, body: [], status: 200, headers: {})
     end

--- a/spec/repositories/relationships_repository_spec.rb
+++ b/spec/repositories/relationships_repository_spec.rb
@@ -11,7 +11,7 @@ describe RelationshipsRepository do
       double(:response, body: [], status: 200, headers: {})
     end
 
-    it 'returns the relationships for all participants' do
+    it 'should return the relationships for all participants' do
       expect(IntakeAPI).to receive(:make_api_call)
         .with(security_token, "/api/v1/screenings/#{screening_id}/relationships", :get)
         .and_return(response)
@@ -19,6 +19,81 @@ describe RelationshipsRepository do
       relationships = described_class.find_by_screening_id(security_token, screening_id)
 
       expect(relationships).to eq([])
+    end
+  end
+
+  describe '.search' do
+
+    let(:empty_response) do
+      double(:response, body: [], status: 200, headers: {})
+    end
+
+    let(:relationships) do
+      [{
+        id: 'EwsPYbG07n',
+        first_name: 'berry',
+        last_name: 'Badger',
+        relationship_to: [{
+          related_person_first_name: 'amy',
+          related_person_last_name: 'Brownbridge',
+          relationship_context: '',
+          related_person_relationship: '300',
+          indexed_person_relationship: '300',
+          legacy_descriptor: { legacy_id: 'EwsPYbG07n' }
+        }],
+        legacy_descirptor: { legacy_id: 'EwsPYbG07n' }
+      }, {
+        id: 'ABCDEFGHIJ',
+        relationship_to: [],
+        legacy_descirptor: { legacy_id: 'ABCDEFGHIJ' }
+      }, {
+        id: 'ZYXWVUTSRQ',
+        first_name: 'Jon',
+        last_name: 'Snow',
+        relationship_to: [{
+          related_person_first_name: 'Arya',
+          related_person_last_name: 'Stark',
+          relationship_context: '',
+          related_person_relationship: '280',
+          indexed_person_relationship: '280',
+          legacy_descriptor: { legacy_id: 'ZYXWVUTSRQ' }
+        }],
+        legacy_descirptor: { legacy_id: 'ZYXWVUTSRQ' }
+      }]
+    end
+
+    let(:single_response) do
+      double(:response, body: [relationships.first])
+    end
+
+    let(:full_response) do
+      double(:response, body: relationships)
+    end
+
+    it 'should return an empty list when no relationships found' do
+      relationships = described_class.search(security_token, [])
+
+      expect(relationships).to eq([])
+    end
+
+    it 'should return all relationships found for a single id' do
+      expect(FerbAPI).to receive(:make_api_call)
+        .with(security_token, '/clients/relationships?EwsPYbG07n', :get)
+        .and_return(single_response)
+
+      relationships = described_class.search(security_token, ['EwsPYbG07n'])
+
+      expect(relationships).to eq([relationships.first])
+    end
+
+    it 'should return all relationships for multiple clients' do
+      expect(FerbAPI).to receive(:make_api_call)
+        .with(security_token, '/clients/relationships?EwsPYbG07n,ABCDEFGHIJ,ZYXWVUTSRQ', :get)
+        .and_return(full_response)
+
+      relationships = described_class.search(security_token, %w[EwsPYbG07n ABCDEFGHIJ ZYXWVUTSRQ])
+
+      expect(relationships).to eq(relationships)
     end
   end
 end

--- a/spec/repositories/relationships_repository_spec.rb
+++ b/spec/repositories/relationships_repository_spec.rb
@@ -40,11 +40,11 @@ describe RelationshipsRepository do
           indexed_person_relationship: '300',
           legacy_descriptor: { legacy_id: 'EwsPYbG07n' }
         }],
-        legacy_descirptor: { legacy_id: 'EwsPYbG07n' }
+        legacy_descriptor: { legacy_id: 'EwsPYbG07n' }
       }, {
         id: 'ABCDEFGHIJ',
         relationship_to: [],
-        legacy_descirptor: { legacy_id: 'ABCDEFGHIJ' }
+        legacy_descriptor: { legacy_id: 'ABCDEFGHIJ' }
       }, {
         id: 'ZYXWVUTSRQ',
         first_name: 'Jon',
@@ -57,7 +57,7 @@ describe RelationshipsRepository do
           indexed_person_relationship: '280',
           legacy_descriptor: { legacy_id: 'ZYXWVUTSRQ' }
         }],
-        legacy_descirptor: { legacy_id: 'ZYXWVUTSRQ' }
+        legacy_descriptor: { legacy_id: 'ZYXWVUTSRQ' }
       }]
     end
 

--- a/spec/repositories/relationships_repository_spec.rb
+++ b/spec/repositories/relationships_repository_spec.rb
@@ -81,7 +81,6 @@ describe RelationshipsRepository do
           security_token,
           '/clients/relationships',
           :get,
-          nil,
           clientIds: ['EwsPYbG07n']
         ).and_return(single_response)
 
@@ -96,7 +95,6 @@ describe RelationshipsRepository do
           security_token,
           '/clients/relationships',
           :get,
-          nil,
           clientIds: %w[EwsPYbG07n ABCDEFGHIJ ZYXWVUTSRQ]
         ).and_return(full_response)
 

--- a/spec/repositories/relationships_repository_spec.rb
+++ b/spec/repositories/relationships_repository_spec.rb
@@ -77,8 +77,13 @@ describe RelationshipsRepository do
 
     it 'should return all relationships found for a single id' do
       expect(FerbAPI).to receive(:make_api_call)
-        .with(security_token, '/clients/relationships?clientIds=EwsPYbG07n', :get)
-        .and_return(single_response)
+        .with(
+          security_token,
+          '/clients/relationships',
+          :get,
+          nil,
+          clientIds: ['EwsPYbG07n']
+        ).and_return(single_response)
 
       relationships = described_class.search(security_token, ['EwsPYbG07n'])
 
@@ -89,8 +94,10 @@ describe RelationshipsRepository do
       expect(FerbAPI).to receive(:make_api_call)
         .with(
           security_token,
-          '/clients/relationships?clientIds=EwsPYbG07n,ABCDEFGHIJ,ZYXWVUTSRQ',
-          :get
+          '/clients/relationships',
+          :get,
+          nil,
+          clientIds: %w[EwsPYbG07n ABCDEFGHIJ ZYXWVUTSRQ]
         ).and_return(full_response)
 
       relationships = described_class.search(security_token, %w[EwsPYbG07n ABCDEFGHIJ ZYXWVUTSRQ])


### PR DESCRIPTION
### Jira Story

- [Snapshots should not be persisted to postgres INT-1197](https://osi-cwds.atlassian.net/browse/INT-1197)

## Description
This PR is the first step of several in decoupling snapshots from postgres. After adding or removing a user, we fetch all relationships for users currently in the snapshot.* Currently in both snapshots and screenings, we do this by unit-of-work-id, where we query something like `/snapshot/6/relationships`. Since we are not going to persist snapshots to postgres, we will not have a unit of work available to perform that check. Luckily, we have all of the information necessary stored locally in our Redux store. This PR modifies our relationship fetch behavior to fetch relationships via a Ferb `/client/relationships` endpoint which accepts a collection of client IDs, sourced from our snapshot participant data.

* * Fetching only the different relationships is a potential optimization, but it's outside the scope of this story. *

The full scope of INT-1197 involves the following steps. Each step will likely be its own PR.
- [x] Fetch relationships by collection of client IDs rather than by unit of work.
- [ ] Fetch HOI by collection of client IDs rather than by unit of work.
- [ ] Add and remove participants from the snapshot without touching postgres.
- [ ] Create snapshots without creating any unit of work in postgres.

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

While this should be an invisible refactor, I would encourage reviewers to treat it like a breaking change. It touches many parts of the relationship fetching flow from top to bottom.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.*
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

* * I ran most. I need Jenkins to run a couple feature tests for me. *
