### PR TITLE
INT-1197 (2) - Fetch HOI for Snapshot by Client IDs

### DIFF
--- a/app/controllers/api/v1/history_of_involvements_controller.rb
+++ b/app/controllers/api/v1/history_of_involvements_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # HOI controller handles endpoints that fetch history of involvements
+    class HistoryOfInvolvementsController < ApiController
+      def by_client_ids
+        client_ids = params[:clientIds]&.split ','
+        hois = HistoryOfInvolvementsRepository.search(session[:security_token], client_ids)
+        render json: hois
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/investigations/contacts_controller.rb
+++ b/app/controllers/api/v1/investigations/contacts_controller.rb
@@ -21,7 +21,7 @@ module Api
         def create
           contact = FerbAPI.make_api_call(
             session['security_token'],
-            ExternalRoutes.ferb_api_investigations_contacts_path(investigation_id),
+            FerbRoutes.investigations_contacts_path(investigation_id),
             :post,
             contact_params.as_json
           )
@@ -31,7 +31,7 @@ module Api
         def show
           contact = FerbAPI.make_api_call(
             session['security_token'],
-            ExternalRoutes.ferb_api_investigations_contact_path(investigation_id, params[:id]),
+            FerbRoutes.investigations_contact_path(investigation_id, params[:id]),
             :get
           )
           render json: contact.body, status: contact.status
@@ -40,7 +40,7 @@ module Api
         def update
           contact = FerbAPI.make_api_call(
             session['security_token'],
-            ExternalRoutes.ferb_api_investigations_contact_path(investigation_id, params[:id]),
+            FerbRoutes.investigations_contact_path(investigation_id, params[:id]),
             :put,
             contact_params.as_json
           )

--- a/app/controllers/api/v1/investigations_controller.rb
+++ b/app/controllers/api/v1/investigations_controller.rb
@@ -10,7 +10,7 @@ module Api
       def show
         investigation = FerbAPI.make_api_call(
           session['security_token'],
-          ExternalRoutes.ferb_api_investigation_path(params[:id]),
+          FerbRoutes.investigation_path(params[:id]),
           :get
         )
         render json: investigation.body, status: investigation.status

--- a/app/controllers/api/v1/system_codes_controller.rb
+++ b/app/controllers/api/v1/system_codes_controller.rb
@@ -10,7 +10,7 @@ module Api
       def index
         response = FerbAPI.make_api_call(
           session['security_token'],
-          ExternalRoutes.ferb_api_lov_path,
+          FerbRoutes.lov_path,
           :get
         )
         render json: response.body, status: response.status
@@ -19,7 +19,7 @@ module Api
       def cross_report_agency
         response = FerbAPI.make_api_call(
           session['security_token'],
-          "#{ExternalRoutes.ferb_api_cross_report_agency}?countyId=#{params[:county_id]}",
+          "#{FerbRoutes.cross_report_agency}?countyId=#{params[:county_id]}",
           :get
         )
         render json: response.body, status: response.status

--- a/app/javascript/actions/historyOfInvolvementActions.js
+++ b/app/javascript/actions/historyOfInvolvementActions.js
@@ -16,3 +16,6 @@ export function fetchHistoryOfInvolvementsFailure(error) {
 export function fetchHistoryOfInvolvements(type, id) {
   return {type: FETCH_HISTORY_OF_INVOLVEMENTS, payload: {type, id}}
 }
+export function fetchHistoryOfInvolvementsByClientIds(ids) {
+  return {type: FETCH_HISTORY_OF_INVOLVEMENTS, payload: {type: 'clients', ids}}
+}

--- a/app/javascript/sagas/createSnapshotPersonSaga.js
+++ b/app/javascript/sagas/createSnapshotPersonSaga.js
@@ -5,7 +5,7 @@ import {
   createPersonSuccess,
   createPersonFailure,
 } from 'actions/personCardActions'
-import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
+import {fetchHistoryOfInvolvementsByClientIds} from 'actions/historyOfInvolvementActions'
 import {fetchRelationshipsByClientIds} from 'actions/relationshipsActions'
 import {getClientIdsSelector} from 'selectors/clientSelectors'
 
@@ -25,7 +25,7 @@ export function* createSnapshotPerson({payload: {person}}) {
     yield put(createPersonSuccess(response))
     const clientIds = yield select(getClientIdsSelector)
     yield put(fetchRelationshipsByClientIds(clientIds))
-    yield put(fetchHistoryOfInvolvements('snapshots', snapshotId))
+    yield put(fetchHistoryOfInvolvementsByClientIds(clientIds))
   } catch (error) {
     if (error.status === STATUS_CODES.forbidden) {
       yield call(alert, 'You are not authorized to add this person.')

--- a/app/javascript/sagas/deleteSnapshotPersonSaga.js
+++ b/app/javascript/sagas/deleteSnapshotPersonSaga.js
@@ -6,9 +6,8 @@ import {
   deletePersonFailure,
 } from 'actions/personCardActions'
 import {fetchRelationshipsByClientIds} from 'actions/relationshipsActions'
-import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
+import {fetchHistoryOfInvolvementsByClientIds} from 'actions/historyOfInvolvementActions'
 import {getClientIdsSelector} from 'selectors/clientSelectors'
-import {getSnapshotIdValueSelector} from 'selectors/snapshotSelectors'
 
 export function* deleteSnapshotPerson({payload: {id}}) {
   try {
@@ -16,8 +15,7 @@ export function* deleteSnapshotPerson({payload: {id}}) {
     yield put(deletePersonSuccess(id))
     const clientIds = yield select(getClientIdsSelector)
     yield put(fetchRelationshipsByClientIds(clientIds))
-    const snapshotId = yield select(getSnapshotIdValueSelector)
-    yield put(fetchHistoryOfInvolvements('snapshots', snapshotId))
+    yield put(fetchHistoryOfInvolvementsByClientIds(clientIds))
   } catch (error) {
     yield put(deletePersonFailure(error.responseJSON))
   }

--- a/app/javascript/sagas/fetchHistoryOfInvolvementsSaga.js
+++ b/app/javascript/sagas/fetchHistoryOfInvolvementsSaga.js
@@ -8,13 +8,29 @@ import {
   FETCH_HISTORY_OF_INVOLVEMENTS,
 } from 'actions/actionTypes'
 
-export function* fetchHistoryOfInvolvements({payload: {id, type}}) {
+function* fetchHistoryForUnitOfWork(type, id) {
   try {
     const response = yield call(get, `/api/v1/${type}/${id}/history_of_involvements`)
     yield put(fetchHistoryOfInvolvementsSuccess(response))
   } catch (error) {
     yield put(fetchHistoryOfInvolvementsFailure(error.responseJSON))
   }
+}
+
+function* fetchHistoryForClients(ids) {
+  try {
+    const response = yield call(get, `/api/v1/history_of_involvements?clientIds=${ids.join(',')}`)
+    yield put(fetchHistoryOfInvolvementsSuccess(response))
+  } catch (error) {
+    yield put(fetchHistoryOfInvolvementsFailure(error.responseJSON))
+  }
+}
+
+export function fetchHistoryOfInvolvements({payload: {type, id, ids}}) {
+  if (type === 'clients') {
+    return fetchHistoryForClients(ids)
+  }
+  return fetchHistoryForUnitOfWork(type, id)
 }
 export function* fetchHistoryOfInvolvementsSaga() {
   yield takeEvery(FETCH_HISTORY_OF_INVOLVEMENTS, fetchHistoryOfInvolvements)

--- a/app/javascript/selectors/clientSelectors.js
+++ b/app/javascript/selectors/clientSelectors.js
@@ -2,7 +2,7 @@ import {List} from 'immutable'
 
 export const getClientIdsSelector = (state) =>
   state.get('participants', List()).map(
-    (client) => client.get('legacy_id',
-      client.getIn(['legacy_descriptor', 'legacy_id'],
-        null))
+    (client) =>
+      client.get('legacy_id') ||
+      client.getIn(['legacy_descriptor', 'legacy_id'])
   ).filter(Boolean).toJS()

--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -47,46 +47,6 @@ class ExternalRoutes
       '/dora/people-summary/person-summary/_search'
     end
 
-    def ferb_api_investigation_path(id)
-      "/investigations/#{id}"
-    end
-
-    def ferb_api_investigations_contacts_path(id)
-      "/investigations/#{id}/contacts"
-    end
-
-    def ferb_api_investigations_contact_path(investigation_id, contact_id)
-      "/investigations/#{investigation_id}/contacts/#{contact_id}"
-    end
-
-    def ferb_api_screening_history_of_involvements_path(id)
-      "/screenings/#{id}/history_of_involvements"
-    end
-
-    def ferb_api_lov_path
-      '/lov'
-    end
-
-    def ferb_api_cross_report_agency
-      '/cross_report_agency'
-    end
-
-    def ferb_api_staff_path(id)
-      "/staffpersons/#{id}"
-    end
-
-    def ferb_api_client_authorization_path(id)
-      "/authorize/client/#{id}"
-    end
-
-    def ferb_api_relationships_path
-      '/clients/relationships'
-    end
-
-    def ferb_api_history_of_involvements_path
-      '/clients/history_of_involvements'
-    end
-
     def sdm_path
       'https://ca.sdmdata.org'
     end

--- a/app/lib/external_routes.rb
+++ b/app/lib/external_routes.rb
@@ -83,6 +83,10 @@ class ExternalRoutes
       '/clients/relationships'
     end
 
+    def ferb_api_history_of_involvements_path
+      '/clients/history_of_involvements'
+    end
+
     def sdm_path
       'https://ca.sdmdata.org'
     end

--- a/app/lib/ferb_routes.rb
+++ b/app/lib/ferb_routes.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# The external Ferb routes will be accessible from here.
+class FerbRoutes
+  class << self
+    def investigation_path(id)
+      "/investigations/#{id}"
+    end
+
+    def investigations_contacts_path(id)
+      "/investigations/#{id}/contacts"
+    end
+
+    def investigations_contact_path(investigation_id, contact_id)
+      "/investigations/#{investigation_id}/contacts/#{contact_id}"
+    end
+
+    def screening_history_of_involvements_path(id)
+      "/screenings/#{id}/history_of_involvements"
+    end
+
+    def lov_path
+      '/lov'
+    end
+
+    def cross_report_agency
+      '/cross_report_agency'
+    end
+
+    def staff_path(id)
+      "/staffpersons/#{id}"
+    end
+
+    def client_authorization_path(id)
+      "/authorize/client/#{id}"
+    end
+
+    def relationships_path
+      '/clients/relationships'
+    end
+
+    def history_of_involvements_path
+      '/clients/history_of_involvements'
+    end
+  end
+end

--- a/app/repositories/history_of_involvements_repository.rb
+++ b/app/repositories/history_of_involvements_repository.rb
@@ -8,7 +8,7 @@ class HistoryOfInvolvementsRepository
 
     FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.ferb_api_history_of_involvements_path,
+      FerbRoutes.history_of_involvements_path,
       :get,
       clientIds: client_ids
     ).body

--- a/app/repositories/history_of_involvements_repository.rb
+++ b/app/repositories/history_of_involvements_repository.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# HistoryOfInvolvementsRepository is a service class responsible for retrieval
+# of HOI information from upstream APIs like Ferb
+class HistoryOfInvolvementsRepository
+  def self.search(security_token, client_ids)
+    return { cases: [], referrals: [], screenings: [] } if client_ids.blank?
+
+    FerbAPI.make_api_call(
+      security_token,
+      ExternalRoutes.ferb_api_history_of_involvements_path,
+      :get,
+      clientIds: client_ids
+    ).body
+  end
+end

--- a/app/repositories/participant_repository.rb
+++ b/app/repositories/participant_repository.rb
@@ -55,7 +55,7 @@ class ParticipantRepository
   private_class_method def self.authorize(security_token, legacy_id)
     return if legacy_id.blank?
 
-    route = ExternalRoutes.ferb_api_client_authorization_path(legacy_id)
+    route = FerbRoutes.client_authorization_path(legacy_id)
 
     begin
       FerbAPI.make_api_call(security_token, route, :get)

--- a/app/repositories/relationships_repository.rb
+++ b/app/repositories/relationships_repository.rb
@@ -18,7 +18,7 @@ class RelationshipsRepository
 
     FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.ferb_api_relationships_path,
+      FerbRoutes.relationships_path,
       :get,
       clientIds: client_ids
     ).body

--- a/app/repositories/screening_repository.rb
+++ b/app/repositories/screening_repository.rb
@@ -50,7 +50,7 @@ class ScreeningRepository
       path = ExternalRoutes.intake_api_history_of_involvements_path(id)
     else
       api = FerbAPI
-      path = ExternalRoutes.ferb_api_screening_history_of_involvements_path(id)
+      path = FerbRoutes.screening_history_of_involvements_path(id)
     end
     response = api.make_api_call(security_token, path, :get)
     response.body

--- a/app/repositories/staff_repository.rb
+++ b/app/repositories/staff_repository.rb
@@ -6,7 +6,7 @@ class StaffRepository
   def self.find(security_token, id)
     response = FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.ferb_api_staff_path(id),
+      FerbRoutes.staff_path(id),
       :get
     )
     Staff.new(response.body)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,7 @@ Rails.application.routes.draw do
         constraints: Routes::ActiveScreeningsConstraint
 
       resources :relationships, only: %i[index]
+      get :history_of_involvements, to: 'history_of_involvements#by_client_ids'
 
       resource :people, only: [:search] do
         collection do

--- a/lib/tasks/spec.rake
+++ b/lib/tasks/spec.rake
@@ -48,6 +48,12 @@ namespace :spec do # rubocop:disable BlockLength
       system "#{webpack?} #{run_in_intake_container(cmd)} #{file_list}"
     end
 
+    desc 'Run specs in parallel, and serialize the output'
+    task :verbose do
+      cmd = 'bundle exec parallel_rspec -m 2 --serialize-stdout -- -f documentation --'
+      system "#{webpack?} #{run_in_intake_container(cmd)} #{file_list}"
+    end
+
     desc 'Run ALL THE SPECS, LINT, & KARMA!!!'
     task :full do
       if system('bin/lint') && system('bin/karma')

--- a/spec/controllers/api/v1/history_of_involvements_controller_spec.rb
+++ b/spec/controllers/api/v1/history_of_involvements_controller_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe Api::V1::HistoryOfInvolvementsController do
+  let(:security_token) { 'blanket' }
+  let(:session) { { security_token: security_token } }
+
+  let(:expected_json) do
+    {
+      cases: ['ABC'],
+      referrals: ['DEF'],
+      screenings: ['GHI']
+    }.to_json
+  end
+
+  describe '#by_client_ids' do
+    let(:client_ids) do
+      ['12']
+    end
+
+    before do
+      expect(HistoryOfInvolvementsRepository).to receive(:search)
+        .with(security_token, client_ids)
+        .and_return(expected_json)
+    end
+
+    it 'should respond with success' do
+      process :by_client_ids,
+        method: :get,
+        params: { clientIds: client_ids.join(',') },
+        session: session
+      expect(JSON.parse(response.body)).to match a_hash_including(
+        'cases' => ['ABC'],
+        'referrals' => ['DEF'],
+        'screenings' => ['GHI']
+      )
+    end
+  end
+end

--- a/spec/features/contacts/create_investigation_contact_spec.rb
+++ b/spec/features/contacts/create_investigation_contact_spec.rb
@@ -20,7 +20,7 @@ feature 'Create Investigation Contact' do
 
   before do
     stub_request(
-      :get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
+      :get, ferb_api_url(FerbRoutes.investigation_path(investigation_id))
     ).and_return(json_body({ people: people }.to_json, status: 200))
     visit new_investigation_contact_path(investigation_id: investigation_id)
   end
@@ -48,8 +48,8 @@ feature 'Create Investigation Contact' do
     expect(page).to have_select('Purpose', selected: 'Contact purpose 1')
 
     contact_id = 'new_contact_id'
-    show_path = ExternalRoutes.ferb_api_investigations_contact_path(investigation_id, contact_id)
-    create_path = ExternalRoutes.ferb_api_investigations_contacts_path(investigation_id)
+    show_path = FerbRoutes.investigations_contact_path(investigation_id, contact_id)
+    create_path = FerbRoutes.investigations_contacts_path(investigation_id)
     persisted_contact = { legacy_descriptor: { legacy_id: contact_id } }
     stub_request(:post, ferb_api_url(create_path)).and_return(
       json_body(persisted_contact.to_json, status: 201)
@@ -89,8 +89,8 @@ feature 'Create Investigation Contact' do
 
   scenario 'saving with communication method not set to in-person save location as office' do
     contact_id = 'new_contact_id'
-    show_path = ExternalRoutes.ferb_api_investigations_contact_path(investigation_id, contact_id)
-    create_path = ExternalRoutes.ferb_api_investigations_contacts_path(investigation_id)
+    show_path = FerbRoutes.investigations_contact_path(investigation_id, contact_id)
+    create_path = FerbRoutes.investigations_contacts_path(investigation_id)
     persisted_contact = { legacy_descriptor: { legacy_id: contact_id } }
     stub_request(:post, ferb_api_url(create_path)).and_return(
       json_body(persisted_contact.to_json, status: 201)
@@ -105,7 +105,7 @@ feature 'Create Investigation Contact' do
     fill_in 'Contact Notes', with: 'This was an attempted contact'
     click_button 'Save'
     expect(
-      a_request(:post, ferb_api_url(ExternalRoutes.ferb_api_investigations_contacts_path('123ABC')))
+      a_request(:post, ferb_api_url(FerbRoutes.investigations_contacts_path('123ABC')))
       .with(
         body: {
           started_at: '2016-08-17T10:00:00.000Z',

--- a/spec/features/contacts/edit_investigation_contact_spec.rb
+++ b/spec/features/contacts/edit_investigation_contact_spec.rb
@@ -36,11 +36,11 @@ feature 'Edit Investigation Contact' do
     }
   end
   let(:investigation_show_url) do
-    investigation_show_path = ExternalRoutes.ferb_api_investigation_path(investigation_id)
+    investigation_show_path = FerbRoutes.investigation_path(investigation_id)
     ferb_api_url(investigation_show_path)
   end
   let(:contact_show_url) do
-    contact_show_path = ExternalRoutes.ferb_api_investigations_contact_path(
+    contact_show_path = FerbRoutes.investigations_contact_path(
       investigation_id, contact_id
     )
     ferb_api_url(contact_show_path)

--- a/spec/features/contacts/show_investigation_contact_spec.rb
+++ b/spec/features/contacts/show_investigation_contact_spec.rb
@@ -29,11 +29,11 @@ feature 'Show Investigation Contact' do
     }
   end
   let(:investigation_show_url) do
-    investigation_show_path = ExternalRoutes.ferb_api_investigation_path(investigation_id)
+    investigation_show_path = FerbRoutes.investigation_path(investigation_id)
     ferb_api_url(investigation_show_path)
   end
   let(:contact_show_url) do
-    contact_show_path = ExternalRoutes.ferb_api_investigations_contact_path(
+    contact_show_path = FerbRoutes.investigations_contact_path(
       investigation_id, contact_id
     )
     ferb_api_url(contact_show_path)

--- a/spec/features/contacts/validation_spec.rb
+++ b/spec/features/contacts/validation_spec.rb
@@ -20,7 +20,7 @@ feature 'Validate Investigation Contact' do
   before do
     investigation_id = '123ABC'
     stub_request(
-      :get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
+      :get, ferb_api_url(FerbRoutes.investigation_path(investigation_id))
     ).and_return(
       json_body(
         {

--- a/spec/features/errors_spec.rb
+++ b/spec/features/errors_spec.rb
@@ -58,7 +58,7 @@ feature 'error pages' do
 
   context 'investigation does not exist' do
     scenario 'renders not found error page' do
-      stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(1)))
+      stub_request(:get, ferb_api_url(FerbRoutes.investigation_path(1)))
         .and_return(json_body('Investigation is not found!!', status: 404))
       stub_empty_history_for_screening(id: 1)
       visit investigation_path(id: 1)
@@ -72,7 +72,7 @@ feature 'error pages' do
 
   context 'contact does not exist' do
     scenario 'renders not found error page' do
-      stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_investigations_contact_path(1, 1)))
+      stub_request(:get, ferb_api_url(FerbRoutes.investigations_contact_path(1, 1)))
         .and_return(json_body('investigation contact is not found!!', status: 404))
       visit investigation_contact_path(investigation_id: 1, id: 1)
       expect(page).to have_text('Sorry, this is not the page you want.')

--- a/spec/features/investigations/allegations_spec.rb
+++ b/spec/features/investigations/allegations_spec.rb
@@ -19,7 +19,7 @@ feature 'Show Investigation' do
       }
     ]
     stub_request(
-      :get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
+      :get, ferb_api_url(FerbRoutes.investigation_path(investigation_id))
     ).and_return(json_body({ allegations: allegations }.to_json, status: 200))
     visit investigation_path(id: investigation_id)
 

--- a/spec/features/investigations/contact_log_spec.rb
+++ b/spec/features/investigations/contact_log_spec.rb
@@ -49,7 +49,7 @@ feature 'Contact Log' do
     }
   end
   let(:investigation_show_url) do
-    ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
+    ferb_api_url(FerbRoutes.investigation_path(investigation_id))
   end
   before do
     stub_request(:get, investigation_show_url)

--- a/spec/features/investigations/history_of_involvement_spec.rb
+++ b/spec/features/investigations/history_of_involvement_spec.rb
@@ -8,7 +8,7 @@ feature 'Investigation History of Involvement' do
 
   before do
     stub_request(
-      :get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
+      :get, ferb_api_url(FerbRoutes.investigation_path(investigation_id))
     ).and_return(json_body({ history_of_involvement: hoi }.to_json, status: 200))
   end
 

--- a/spec/features/investigations/relationships_spec.rb
+++ b/spec/features/investigations/relationships_spec.rb
@@ -10,7 +10,7 @@ feature 'Investigation Relationship Card' do
   before do
     stub_request(
       :get,
-      ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
+      ferb_api_url(FerbRoutes.investigation_path(investigation_id))
     ).and_return(json_body({ relationships: relationships }.to_json), status: 200)
   end
 

--- a/spec/features/investigations/show_investigation_spec.rb
+++ b/spec/features/investigations/show_investigation_spec.rb
@@ -36,7 +36,7 @@ feature 'Show Investigation' do
         safety_information: 'Animal is a tiger'
       }
       stub_request(
-        :get, ferb_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
+        :get, ferb_api_url(FerbRoutes.investigation_path(investigation_id))
       ).and_return(json_body({ screening_summary: screening_summary }.to_json, status: 200))
       visit investigation_path(id: investigation_id)
       within '.page-header-mast' do
@@ -84,7 +84,7 @@ feature 'Show Investigation' do
       expect(
         a_request(
           :get,
-          intake_api_url(ExternalRoutes.ferb_api_investigation_path(investigation_id))
+          intake_api_url(FerbRoutes.investigation_path(investigation_id))
         )
       ).to_not have_been_made
       expect(page).to have_content('Sorry, this is not the page you want')

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -36,7 +36,7 @@ feature 'login' do
   end
 
   context 'user provides valid security access code', browser: :poltergeist do
-    let(:staff_url) { ferb_api_url(ExternalRoutes.ferb_api_staff_path(1234)) }
+    let(:staff_url) { ferb_api_url(FerbRoutes.staff_path(1234)) }
     before do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .and_return(json_body(screening_results, status: 200))
@@ -232,7 +232,7 @@ feature 'login perry v1' do
   end
 
   context 'user provides valid security token', browser: :poltergeist do
-    let(:staff_url) { ferb_api_url(ExternalRoutes.ferb_api_staff_path(1234)) }
+    let(:staff_url) { ferb_api_url(FerbRoutes.staff_path(1234)) }
     before do
       stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .and_return(json_body(screening_results, status: 200))

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -60,7 +60,7 @@ feature 'Create Screening' do
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
 
-        stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
+        stub_request(:get, ferb_api_url(FerbRoutes.staff_path('1234')))
           .and_return(json_body(user_details.to_json, status: 200))
 
         visit root_path(token: 123)
@@ -122,7 +122,7 @@ feature 'Create Screening' do
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
 
-        stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
+        stub_request(:get, ferb_api_url(FerbRoutes.staff_path('1234')))
           .and_return(json_body(user_details.to_json, status: 200))
 
         visit root_path(token: 123)
@@ -179,7 +179,7 @@ feature 'Create Screening' do
         ).and_return(json_body(new_screening.to_json, status: 200))
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
-        stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_staff_path('1234')))
+        stub_request(:get, ferb_api_url(FerbRoutes.staff_path('1234')))
           .and_return(json_body(user_details.to_json, status: 200))
 
         visit root_path(token: 123)

--- a/spec/features/screening/history_of_involvement_spec.rb
+++ b/spec/features/screening/history_of_involvement_spec.rb
@@ -254,7 +254,7 @@ feature 'History card' do
       stub_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_screening_history_of_involvements_path(existing_screening.id)
+          FerbRoutes.screening_history_of_involvements_path(existing_screening.id)
         )
       ).and_return(json_body(screening_involvement.to_json, status: 200))
       stub_empty_relationships_for_screening(existing_screening)
@@ -404,7 +404,7 @@ feature 'History card' do
         a_request(
           :get,
           ferb_api_url(
-            ExternalRoutes.ferb_api_screening_history_of_involvements_path(existing_screening.id)
+            FerbRoutes.screening_history_of_involvements_path(existing_screening.id)
           )
         )
       ).to have_been_made
@@ -417,7 +417,7 @@ feature 'History card' do
         a_request(
           :get,
           ferb_api_url(
-            ExternalRoutes.ferb_api_screening_history_of_involvements_path(existing_screening.id)
+            FerbRoutes.screening_history_of_involvements_path(existing_screening.id)
           )
         )
       ).to have_been_made

--- a/spec/features/screening/history_of_involvement_spec.rb
+++ b/spec/features/screening/history_of_involvement_spec.rb
@@ -543,9 +543,9 @@ feature 'History card' do
         Feature.run_with_activated(:hoi_from_intake_api) do
           screenings[0][:county_name] = 'el_dorado'
           screenings[0][:county] = nil
-          screenings[0][:assigned_social_worker] = { first_name: nil, last_name: 'Bob Smith' }
+          screenings[0][:assigned_social_worker] = { first_name: 'Bob', last_name: 'Smith' }
           screenings[0][:reporter] = { first_name: 'Alex', last_name: 'Hanson' }
-          screenings[0][:all_people][0][:last_name] = 'Bob Smith'
+          screenings[0][:all_people][0][:last_name] = 'Smith'
           screenings[1][:county_name] = 'el_dorado'
           screenings[1][:county] = nil
           referrals[0][:response_time] = 'Immediate'

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -237,7 +237,6 @@ feature 'Create participant' do
         )
       )).and_return(status: 200)
 
-    puts created_participant_homer.to_json
     stub_request(:post,
       intake_api_url(ExternalRoutes.intake_api_screening_people_path(existing_screening.id)))
       .and_return(json_body(created_participant_homer.to_json, status: 201))

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -232,7 +232,7 @@ feature 'Create participant' do
     created_participant_homer = FactoryBot.create(:participant, participant_homer.as_json)
     stub_request(:get,
       ferb_api_url(
-        ExternalRoutes.ferb_api_client_authorization_path(
+        FerbRoutes.client_authorization_path(
           created_participant_homer.legacy_descriptor.legacy_id
         )
       )).and_return(status: 200)
@@ -250,7 +250,7 @@ feature 'Create participant' do
     end
     expect(a_request(:get,
       ferb_api_url(
-        ExternalRoutes.ferb_api_client_authorization_path(
+        FerbRoutes.client_authorization_path(
           created_participant_homer.legacy_descriptor.legacy_id
         )
       )))
@@ -318,7 +318,7 @@ feature 'Create participant' do
                     body: { staffId: '123', privileges: ['Sensitive Persons'] }.to_json)
       stub_request(:get, %r{https?://.*/authn/validate\?token=#{insensitive_token}})
         .and_return(status: 200, body: { staffId: '123', privileges: [] }.to_json)
-      stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_staff_path('123')))
+      stub_request(:get, ferb_api_url(FerbRoutes.staff_path('123')))
         .and_return(json_body({ staffId: '123', first_name: 'Bob', last_name: 'Boberson',
                                 county: 'San Francisco' }.to_json, status: 200))
     end
@@ -360,7 +360,7 @@ feature 'Create participant' do
           )
           stub_request(:get,
             ferb_api_url(
-              ExternalRoutes.ferb_api_client_authorization_path(
+              FerbRoutes.client_authorization_path(
                 participant_homer.legacy_descriptor.legacy_id
               )
             )).and_return(status: 200)
@@ -435,7 +435,7 @@ feature 'Create participant' do
           )
           stub_request(:get,
             ferb_api_url(
-              ExternalRoutes.ferb_api_client_authorization_path(
+              FerbRoutes.client_authorization_path(
                 participant_homer.legacy_descriptor.legacy_id
               )
             )).and_return(status: 200)

--- a/spec/features/screening/relationships_card_spec.rb
+++ b/spec/features/screening/relationships_card_spec.rb
@@ -362,8 +362,7 @@ feature 'Relationship card' do
               expect(
                 a_request(:get,
                   ferb_api_url(
-                    ExternalRoutes
-                      .ferb_api_screening_history_of_involvements_path(participants_screening.id)
+                    FerbRoutes.screening_history_of_involvements_path(participants_screening.id)
                   ))
               ).to have_been_made.twice
 

--- a/spec/features/snapshot/add_remove_people_spec.rb
+++ b/spec/features/snapshot/add_remove_people_spec.rb
@@ -27,12 +27,7 @@ feature 'Adding and removing a person from a snapshot' do
     stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
       .and_return(json_body(snapshot.to_json, status: 201))
     stub_system_codes
-    stub_request(
-      :get,
-      ferb_api_url(
-        ExternalRoutes.ferb_api_screening_history_of_involvements_path(snapshot.id)
-      )
-    ).and_return(json_body({}.to_json, status: 200))
+    stub_empty_history_for_clients [person.legacy_id]
     stub_request(
       :get,
       ferb_api_url(
@@ -115,10 +110,10 @@ feature 'Adding and removing a person from a snapshot' do
       a_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_screening_history_of_involvements_path(snapshot.id)
-        )
+          ExternalRoutes.ferb_api_history_of_involvements_path
+        ) + "?clientIds=#{person.legacy_id}"
       )
-    ).to have_been_made.times(2)
+    ).to have_been_made.times(1)
 
     expect(
       a_request(

--- a/spec/features/snapshot/add_remove_people_spec.rb
+++ b/spec/features/snapshot/add_remove_people_spec.rb
@@ -31,7 +31,7 @@ feature 'Adding and removing a person from a snapshot' do
     stub_request(
       :get,
       ferb_api_url(
-        ExternalRoutes.ferb_api_relationships_path
+        FerbRoutes.relationships_path
       ) + "?clientIds=#{person.legacy_id}"
     ).and_return(json_body([].to_json, status: 200))
 
@@ -110,7 +110,7 @@ feature 'Adding and removing a person from a snapshot' do
       a_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_history_of_involvements_path
+          FerbRoutes.history_of_involvements_path
         ) + "?clientIds=#{person.legacy_id}"
       )
     ).to have_been_made.times(1)
@@ -119,7 +119,7 @@ feature 'Adding and removing a person from a snapshot' do
       a_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_relationships_path
+          FerbRoutes.relationships_path
         ) + "?clientIds=#{person.legacy_id}"
       )
     ).to have_been_made.times(1)

--- a/spec/features/snapshot/create_snapshot_spec.rb
+++ b/spec/features/snapshot/create_snapshot_spec.rb
@@ -28,7 +28,6 @@ feature 'Create Snapshot' do
     end
 
     scenario 'via start snapshot link' do
-      stub_empty_history_for_screening(new_snapshot)
       stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .with(body: as_json_without_root_id(new_snapshot))
         .and_return(json_body(new_snapshot.to_json, status: 201))
@@ -64,7 +63,7 @@ feature 'Create Snapshot' do
       click_button 'Start Snapshot'
 
       stub_empty_relationships_for_screening(new_snapshot)
-      stub_empty_history_for_screening(new_snapshot)
+      stub_empty_history_for_clients []
       search_response = PersonSearchResponseBuilder.build do |response|
         response.with_total(1)
         response.with_hits do
@@ -112,7 +111,6 @@ feature 'Create Snapshot' do
     end
 
     scenario 'a new snapshot is created if the user visits the snapshot page directly' do
-      stub_empty_history_for_screening(new_snapshot)
       stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .with(body: as_json_without_root_id(new_snapshot))
         .and_return(json_body(new_snapshot.to_json, status: 201))
@@ -136,7 +134,6 @@ feature 'Create Snapshot' do
     end
 
     scenario 'user creates a new snapshot by clicking the Start Over button' do
-      stub_empty_history_for_screening(new_snapshot)
       stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
         .and_return(json_body(new_snapshot.to_json, status: 201))
 

--- a/spec/features/snapshot/create_snapshot_spec.rb
+++ b/spec/features/snapshot/create_snapshot_spec.rb
@@ -127,7 +127,7 @@ feature 'Create Snapshot' do
         a_request(
           :get,
           ferb_api_url(
-            ExternalRoutes.ferb_api_screening_history_of_involvements_path(new_snapshot.id)
+            FerbRoutes.screening_history_of_involvements_path(new_snapshot.id)
           )
         )
       ).not_to have_been_made
@@ -153,7 +153,7 @@ feature 'Create Snapshot' do
         a_request(
           :get,
           ferb_api_url(
-            ExternalRoutes.ferb_api_screening_history_of_involvements_path(second_snapshot.id)
+            FerbRoutes.screening_history_of_involvements_path(second_snapshot.id)
           )
         )
       ).not_to have_been_made

--- a/spec/features/snapshot/create_snapshot_spec.rb
+++ b/spec/features/snapshot/create_snapshot_spec.rb
@@ -62,8 +62,6 @@ feature 'Create Snapshot' do
       visit root_path
       click_button 'Start Snapshot'
 
-      stub_empty_relationships_for_screening(new_snapshot)
-      stub_empty_history_for_clients []
       search_response = PersonSearchResponseBuilder.build do |response|
         response.with_total(1)
         response.with_hits do
@@ -80,6 +78,13 @@ feature 'Create Snapshot' do
         :post,
         intake_api_url(ExternalRoutes.intake_api_screening_people_path(new_snapshot.id))
       ).and_return(json_body(person.to_json, status: 201))
+      stub_request(
+        :get,
+        ferb_api_url(
+          FerbRoutes.relationships_path
+        ) + "?clientIds=#{person.legacy_descriptor.legacy_id}"
+      ).and_return(json_body([].to_json, status: 200))
+      stub_empty_history_for_clients [person.legacy_descriptor.legacy_id]
 
       within '#search-card', text: 'Search' do
         fill_in 'Search for clients', with: 'Ma'

--- a/spec/features/snapshot/history_of_involvement_spec.rb
+++ b/spec/features/snapshot/history_of_involvement_spec.rb
@@ -181,7 +181,7 @@ feature 'Snapshot History of Involvement' do
       stub_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_relationships_path
+          FerbRoutes.relationships_path
         ) + "?clientIds=#{person.legacy_descriptor.legacy_id}"
       ).and_return(json_body([].to_json, status: 200))
 
@@ -198,7 +198,7 @@ feature 'Snapshot History of Involvement' do
       stub_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_history_of_involvements_path
+          FerbRoutes.history_of_involvements_path
         ) + "?clientIds=#{person.legacy_descriptor.legacy_id}"
       ).and_return(json_body(history.to_json, status: 200))
 
@@ -354,7 +354,7 @@ feature 'Snapshot History of Involvement' do
         a_request(
           :get,
           ferb_api_url(
-            ExternalRoutes.ferb_api_history_of_involvements_path
+            FerbRoutes.history_of_involvements_path
           ) + "?clientIds=#{person.legacy_descriptor.legacy_id}"
         )
       ).to have_been_made
@@ -374,7 +374,7 @@ feature 'Snapshot History of Involvement' do
       stub_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_relationships_path
+          FerbRoutes.relationships_path
         ) + "?clientIds=#{person.legacy_descriptor.legacy_id}"
       ).and_return(json_body([].to_json, status: 200))
 
@@ -391,7 +391,7 @@ feature 'Snapshot History of Involvement' do
       stub_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_history_of_involvements_path
+          FerbRoutes.history_of_involvements_path
         ) + "?clientIds=#{person.legacy_descriptor.legacy_id}"
       ).and_return(json_body(history.to_json, status: 200))
 
@@ -415,7 +415,7 @@ feature 'Snapshot History of Involvement' do
         a_request(
           :get,
           ferb_api_url(
-            ExternalRoutes.ferb_api_history_of_involvements_path
+            FerbRoutes.history_of_involvements_path
           ) + "?clientIds=#{person.legacy_descriptor.legacy_id}"
         )
       ).to have_been_made

--- a/spec/features/snapshot/relationships_snapshot_spec.rb
+++ b/spec/features/snapshot/relationships_snapshot_spec.rb
@@ -74,12 +74,7 @@ feature 'Snapshot relationship card' do
         intake_api_url(ExternalRoutes.intake_api_screening_path(participants_screening.id))
       ).and_return(json_body(participants_screening.to_json))
 
-      stub_request(
-        :get,
-        ferb_api_url(
-          ExternalRoutes.ferb_api_screening_history_of_involvements_path(snapshot.id)
-        )
-      ).and_return(json_body([].to_json, status: 200))
+      stub_empty_history_for_clients([participant.id])
 
       search_response = PersonSearchResponseBuilder.build do |response|
         response.with_total(1)

--- a/spec/features/snapshot/relationships_snapshot_spec.rb
+++ b/spec/features/snapshot/relationships_snapshot_spec.rb
@@ -102,7 +102,7 @@ feature 'Snapshot relationship card' do
       stub_request(
         :get,
         ferb_api_url(
-          ExternalRoutes.ferb_api_relationships_path
+          FerbRoutes.relationships_path
         ) + "?clientIds=#{participant.id}"
       ).and_return(json_body(relationships.to_json, status: 200))
 
@@ -122,7 +122,7 @@ feature 'Snapshot relationship card' do
         a_request(
           :get,
           ferb_api_url(
-            ExternalRoutes.ferb_api_relationships_path
+            FerbRoutes.relationships_path
           ) + "?clientIds=#{participant.id}"
         )
       ).to have_been_made

--- a/spec/features/system_codes_spec.rb
+++ b/spec/features/system_codes_spec.rb
@@ -8,10 +8,10 @@ feature 'System codes' do
       .and_return(json_body([].to_json, status: 200))
     stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
       .and_return(json_body([].to_json, status: 200))
-    stub_request(:get, ferb_api_url(ExternalRoutes.ferb_api_lov_path))
+    stub_request(:get, ferb_api_url(FerbRoutes.lov_path))
       .and_return(json_body([].to_json, status: 200))
     visit root_path
     click_button 'Start Screening'
-    expect(a_request(:get, ferb_api_url(ExternalRoutes.ferb_api_lov_path))).to have_been_made.once
+    expect(a_request(:get, ferb_api_url(FerbRoutes.lov_path))).to have_been_made.once
   end
 end

--- a/spec/javascripts/sagas/createSnapshotPersonSagaSpec.js
+++ b/spec/javascripts/sagas/createSnapshotPersonSagaSpec.js
@@ -7,7 +7,7 @@ import {
 } from 'sagas/createSnapshotPersonSaga'
 import {CREATE_SNAPSHOT_PERSON} from 'actions/personCardActions'
 import * as personCardActions from 'actions/personCardActions'
-import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
+import {fetchHistoryOfInvolvementsByClientIds} from 'actions/historyOfInvolvementActions'
 import {fetchRelationshipsByClientIds} from 'actions/relationshipsActions'
 import {getClientIdsSelector} from 'selectors/clientSelectors'
 
@@ -38,7 +38,7 @@ describe('createSnapshotPerson', () => {
       put(fetchRelationshipsByClientIds(['1']))
     )
     expect(gen.next(snapshotId).value).toEqual(
-      put(fetchHistoryOfInvolvements('snapshots', snapshotId))
+      put(fetchHistoryOfInvolvementsByClientIds(['1']))
     )
   })
 

--- a/spec/javascripts/sagas/createSnapshotSagaSpec.js
+++ b/spec/javascripts/sagas/createSnapshotSagaSpec.js
@@ -41,4 +41,3 @@ describe('createSnapshot', () => {
     )
   })
 })
-

--- a/spec/javascripts/sagas/deleteSnapshotPersonSagaSpec.js
+++ b/spec/javascripts/sagas/deleteSnapshotPersonSagaSpec.js
@@ -8,9 +8,8 @@ import {
 import {DELETE_SNAPSHOT_PERSON} from 'actions/personCardActions'
 import * as personCardActions from 'actions/personCardActions'
 import {fetchRelationshipsByClientIds} from 'actions/relationshipsActions'
-import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
+import {fetchHistoryOfInvolvementsByClientIds} from 'actions/historyOfInvolvementActions'
 import {getClientIdsSelector} from 'selectors/clientSelectors'
-import {getSnapshotIdValueSelector} from 'selectors/snapshotSelectors'
 
 describe('deleteParticipantSaga', () => {
   it('deletes participant on DELETE_PERSON', () => {
@@ -37,11 +36,7 @@ describe('deleteParticipant', () => {
       put(fetchRelationshipsByClientIds(clientIds))
     )
     expect(gen.next().value).toEqual(
-      select(getSnapshotIdValueSelector)
-    )
-    const snapshotId = '444'
-    expect(gen.next(snapshotId).value).toEqual(
-      put(fetchHistoryOfInvolvements('snapshots', snapshotId))
+      put(fetchHistoryOfInvolvementsByClientIds(clientIds))
     )
   })
 

--- a/spec/javascripts/sagas/fetchHistoryOfInvolvementsSagaSpec.js
+++ b/spec/javascripts/sagas/fetchHistoryOfInvolvementsSagaSpec.js
@@ -45,15 +45,9 @@ describe('fetchHistoryOfInvolvements', () => {
   })
 
   it('should fetch by client_ids when provided', () => {
-    const action = {
-      type: 'FETCH_HISTORY_OF_INVOLVEMENTS',
-      payload: {
-        type: 'clients',
-        ids: ['ABC', '123'],
-      },
-    }
-
-    const gen = fetchHistoryOfInvolvements(action)
+    const gen = fetchHistoryOfInvolvements(
+      actions.fetchHistoryOfInvolvementsByClientIds(['ABC', '123'])
+    )
 
     expect(gen.next().value).toEqual(
       call(get, '/api/v1/history_of_involvements?clientIds=ABC,123')

--- a/spec/javascripts/sagas/fetchHistoryOfInvolvementsSagaSpec.js
+++ b/spec/javascripts/sagas/fetchHistoryOfInvolvementsSagaSpec.js
@@ -22,7 +22,7 @@ describe('fetchHistoryOfInvolvements', () => {
   const type = 'bananas'
   const action = actions.fetchHistoryOfInvolvements(type, id)
 
-  it('fetches and puts involvements', () => {
+  it('should fetch and put involvements', () => {
     const gen = fetchHistoryOfInvolvements(action)
     expect(gen.next().value).toEqual(
       call(get, '/api/v1/bananas/123/history_of_involvements')
@@ -33,7 +33,7 @@ describe('fetchHistoryOfInvolvements', () => {
     )
   })
 
-  it('puts errors when errors are thrown', () => {
+  it('should put errors when errors are thrown', () => {
     const gen = fetchHistoryOfInvolvements(action)
     expect(gen.next().value).toEqual(
       call(get, '/api/v1/bananas/123/history_of_involvements')
@@ -41,6 +41,27 @@ describe('fetchHistoryOfInvolvements', () => {
     const error = {responseJSON: 'some error'}
     expect(gen.throw(error).value).toEqual(
       put(actions.fetchHistoryOfInvolvementsFailure('some error'))
+    )
+  })
+
+  it('should fetch by client_ids when provided', () => {
+    const action = {
+      type: 'FETCH_HISTORY_OF_INVOLVEMENTS',
+      payload: {
+        type: 'clients',
+        ids: ['ABC', '123'],
+      },
+    }
+
+    const gen = fetchHistoryOfInvolvements(action)
+
+    expect(gen.next().value).toEqual(
+      call(get, '/api/v1/history_of_involvements?clientIds=ABC,123')
+    )
+
+    const hoi = {cases: ['a'], referrals: ['b'], screenings: ['c']}
+    expect(gen.next(hoi).value).toEqual(
+      put(actions.fetchHistoryOfInvolvementsSuccess(hoi))
     )
   })
 })

--- a/spec/javascripts/selectors/clientSelectorsSpec.js
+++ b/spec/javascripts/selectors/clientSelectorsSpec.js
@@ -25,6 +25,19 @@ describe('clientSelectors', () => {
       expect(getClientIdsSelector(state)).toEqual(['DEF'])
     })
 
+    it('should bypass null legacy_ids', () => {
+      const state = fromJS({
+        participants: [{
+          legacy_id: null,
+          legacy_descriptor: {
+            legacy_id: 'DEF',
+          },
+        }],
+      })
+
+      expect(getClientIdsSelector(state)).toEqual(['DEF'])
+    })
+
     it('should select multiple clients', () => {
       const state = fromJS({
         participants: [{

--- a/spec/lib/external_routes_spec.rb
+++ b/spec/lib/external_routes_spec.rb
@@ -73,48 +73,4 @@ describe ExternalRoutes do
       )
     end
   end
-
-  describe '.ferb_api_staff_path' do
-    it 'returns /staffpersons/:id' do
-      expect(described_class.ferb_api_staff_path(24)).to eq('/staffpersons/24')
-    end
-  end
-
-  describe '.ferb_api_screening_history_of_involvements_path' do
-    it 'returns /screenings/:id/history_of_involvements' do
-      expect(described_class.ferb_api_screening_history_of_involvements_path(82)).to eq(
-        '/screenings/82/history_of_involvements'
-      )
-    end
-  end
-
-  describe '.ferb_api_investigations_contacts_path' do
-    it 'returns /investigations/:id/contacts' do
-      expect(described_class.ferb_api_investigations_contacts_path(33)).to eq(
-        '/investigations/33/contacts'
-      )
-    end
-  end
-
-  describe '.ferb_api_relationships_path' do
-    it 'returns the base path' do
-      expect(described_class.ferb_api_relationships_path).to eq(
-        '/clients/relationships'
-      )
-    end
-  end
-
-  describe '.ferb_api_history_of_involvements_path' do
-    it 'returns the base path' do
-      expect(described_class.ferb_api_history_of_involvements_path).to eq(
-        '/clients/history_of_involvements'
-      )
-    end
-  end
-
-  describe '.ferb_api_lov_path' do
-    it 'returns /lov' do
-      expect(described_class.ferb_api_lov_path).to eq('/lov')
-    end
-  end
 end

--- a/spec/lib/external_routes_spec.rb
+++ b/spec/lib/external_routes_spec.rb
@@ -104,6 +104,14 @@ describe ExternalRoutes do
     end
   end
 
+  describe '.ferb_api_history_of_involvements_path' do
+    it 'returns the base path' do
+      expect(described_class.ferb_api_history_of_involvements_path).to eq(
+        '/clients/history_of_involvements'
+      )
+    end
+  end
+
   describe '.ferb_api_lov_path' do
     it 'returns /lov' do
       expect(described_class.ferb_api_lov_path).to eq('/lov')

--- a/spec/lib/ferb_routes_spec.rb
+++ b/spec/lib/ferb_routes_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe FerbRoutes do
+  describe '.staff_path' do
+    it 'returns /staffpersons/:id' do
+      expect(described_class.staff_path(24)).to eq('/staffpersons/24')
+    end
+  end
+
+  describe '.screening_history_of_involvements_path' do
+    it 'returns /screenings/:id/history_of_involvements' do
+      expect(described_class.screening_history_of_involvements_path(82)).to eq(
+        '/screenings/82/history_of_involvements'
+      )
+    end
+  end
+
+  describe '.investigations_contacts_path' do
+    it 'returns /investigations/:id/contacts' do
+      expect(described_class.investigations_contacts_path(33)).to eq(
+        '/investigations/33/contacts'
+      )
+    end
+  end
+
+  describe '.relationships_path' do
+    it 'returns the base path' do
+      expect(described_class.relationships_path).to eq(
+        '/clients/relationships'
+      )
+    end
+  end
+
+  describe '.history_of_involvements_path' do
+    it 'returns the base path' do
+      expect(described_class.history_of_involvements_path).to eq(
+        '/clients/history_of_involvements'
+      )
+    end
+  end
+
+  describe '.lov_path' do
+    it 'returns /lov' do
+      expect(described_class.lov_path).to eq('/lov')
+    end
+  end
+end

--- a/spec/repositories/history_of_involvements_repository_spec.rb
+++ b/spec/repositories/history_of_involvements_repository_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe HistoryOfInvolvementsRepository do
+  let(:security_token) { 'my_security_token' }
+
+  describe '.search' do
+    let(:empty_hoi) do
+      {
+        cases: [],
+        referrals: [],
+        screenings: []
+      }
+    end
+
+    let(:hoi) do
+      {
+        cases: [{
+          id: 'ABC'
+        }],
+        referrals: [{
+          id: 'DEF'
+        }],
+        screenings: [{
+          id: 'GHI'
+        }]
+      }
+    end
+    let(:hoi_response) do
+      double(:response, body: hoi, status: 200, headers: {})
+    end
+
+    it 'should return an empty HOI when no relationships found' do
+      hois = described_class.search(security_token, [])
+
+      expect(hois).to eq(empty_hoi)
+    end
+
+    it 'should return an HOI for a single id' do
+      expect(FerbAPI).to receive(:make_api_call)
+        .with(
+          security_token,
+          '/clients/history_of_involvements',
+          :get,
+          clientIds: ['EwsPYbG07n']
+        ).and_return(hoi_response)
+
+      relationships = described_class.search(security_token, ['EwsPYbG07n'])
+
+      expect(relationships).to eq(hoi)
+    end
+
+    it 'should return an HOI for multiple clients' do
+      expect(FerbAPI).to receive(:make_api_call)
+        .with(
+          security_token,
+          '/clients/history_of_involvements',
+          :get,
+          clientIds: %w[EwsPYbG07n ABCDEFGHIJ ZYXWVUTSRQ]
+        ).and_return(hoi_response)
+
+      relationships = described_class.search(security_token, %w[EwsPYbG07n ABCDEFGHIJ ZYXWVUTSRQ])
+
+      expect(relationships).to eq(hoi)
+    end
+  end
+end

--- a/spec/support/helpers/county_agencies_helper.rb
+++ b/spec/support/helpers/county_agencies_helper.rb
@@ -42,7 +42,7 @@ module CountyAgenciesHelpers
     ]
     stub_request(
       :get,
-      /#{ExternalRoutes.ferb_api_cross_report_agency}\?countyId=#{county_id}/
+      /#{FerbRoutes.cross_report_agency}\?countyId=#{county_id}/
     ).and_return(
       json_body(county_agencies, status: 200)
     )

--- a/spec/support/helpers/screening_helpers.rb
+++ b/spec/support/helpers/screening_helpers.rb
@@ -38,7 +38,7 @@ module ScreeningHelpers
                    end
     stub_request(
       :get,
-      ferb_api_url(ExternalRoutes.ferb_api_screening_history_of_involvements_path(screening_id))
+      ferb_api_url(FerbRoutes.screening_history_of_involvements_path(screening_id))
     ).and_return(json_body(response.to_json, status: 200))
   end
 
@@ -47,7 +47,7 @@ module ScreeningHelpers
     stub_request(
       :get,
       ferb_api_url(
-        ExternalRoutes.ferb_api_history_of_involvements_path
+        FerbRoutes.history_of_involvements_path
       ) + "?#{params}"
     ).and_return(json_body({ cases: [], referrals: [], screenings: [] }.to_json, status: 200))
   end

--- a/spec/support/helpers/screening_helpers.rb
+++ b/spec/support/helpers/screening_helpers.rb
@@ -42,6 +42,16 @@ module ScreeningHelpers
     ).and_return(json_body(response.to_json, status: 200))
   end
 
+  def stub_empty_history_for_clients(ids)
+    params = ids.map { |id| "clientIds=#{id}" }.join '&'
+    stub_request(
+      :get,
+      ferb_api_url(
+        ExternalRoutes.ferb_api_history_of_involvements_path
+      ) + "?#{params}"
+    ).and_return(json_body({ cases: [], referrals: [], screenings: [] }.to_json, status: 200))
+  end
+
   def stub_and_visit_edit_screening(screening)
     stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
       .and_return(json_body(screening.to_json, status: 200))

--- a/spec/support/helpers/system_code_helpers.rb
+++ b/spec/support/helpers/system_code_helpers.rb
@@ -181,7 +181,7 @@ module SystemCodeHelpers
   end
 
   def stub_system_codes
-    stub_request(:get, /#{ExternalRoutes.ferb_api_lov_path}/).and_return(
+    stub_request(:get, /#{FerbRoutes.lov_path}/).and_return(
       json_body(system_codes, status: 200)
     )
   end


### PR DESCRIPTION
### Jira Story

- [Snapshots should not be persisted to postgres INT-1197](https://osi-cwds.atlassian.net/browse/INT-1197)

## Description
This PR is the second step to decoupling Snapshot from Postgres. After adding or removing a user, we fetch the HOI for those users currently in the snapshot. Currently, we do this by unit of work ID, e.g. `/snapshot/X/history_of_involvements`. This PR makes a new Rails route to fetch HOI by client IDs via Ferb's `/client/history_of_involvements` endpoint and uses that route in Snapshot.

The full scope of INT-1197 involves the following steps. Each step will likely be its own PR.
- [x] ~Fetch relationships by collection of client IDs rather than by unit of work.~ #593
- [x] Fetch HOI by collection of client IDs rather than by unit of work.
- [ ] Add and remove participants from the snapshot without touching postgres.
- [ ] Create snapshots without creating any unit of work in postgres.

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

While this should be an invisible refactor, I would encourage reviewers to treat it like a breaking change. It touches many parts of the HOI fetching flow from top to bottom.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project. *(Excepting some feature tests. Thanks, Jenkins)*
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

## Additional Notes:

If you review commit by commit, I added some messages here and there that may help. The HOI feature test commit has lots of changes, and I think there is still a lot more refactoring we could do to simplify HOI processing.
