### PR TITLE
Use one headless Xvfb server per test process with reuse

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,8 +35,8 @@ RSpec.configure do |config|
   config.before :suite do
     if ENV['USE_XVFB'] == 'true'
       require 'headless'
-      @headless_manager = Headless.new(reuse: false)
-      @headless_manager.start
+      display = 100 + ENV['TEST_ENV_NUMBER'].to_i
+      Headless.new(display: display, reuse: true, destroy_at_exit: false).start
     end
   end
 
@@ -46,7 +46,8 @@ RSpec.configure do |config|
   end
 
   config.after :suite do
-    @headless_manager.destroy if @headless_manager && ENV['USE_XVFB'] == 'true'
+    display = 100 + ENV['TEST_ENV_NUMBER'].to_i
+    Headless.new(display: display, reuse: true, destroy_at_exit: false).destroy
   end
 
   # rspec-expectations config goes here. You can use an alternate


### PR DESCRIPTION
[INT_1568]

### Jira Story

- [Support Intake PR builds and Master build INT-1568](https://osi-cwds.atlassian.net/browse/INT-1568)

## Description
Change headless to use one Xvfb server per test process

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
This is changing test setup

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

