### PR TITLE
Disable webpack-dev-server host check in development

### DIFF
--- a/config/webpack/development.js
+++ b/config/webpack/development.js
@@ -30,6 +30,7 @@ module.exports = merge(sharedConfig, {
     compress: true,
     headers: { 'Access-Control-Allow-Origin': '*' },
     historyApiFallback: true,
+    disableHostCheck: true,
     watchOptions: {
       ignored: /node_modules/
     }


### PR DESCRIPTION
Webpack-dev-server doesn't like running on port 0.0.0.0, which is
where we run it. This sometimes causes errors when running the
integrated test environment, and so adding this check should get
it to keep working.

I did not run linting, feature tests, etc for this. It is a one line config change that won't affect production environments.

### Jira Story

- No story

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->
This is a development configuration change.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
