### PR TITLE
FIT-38 create base imgs to speed builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,6 @@
-FROM ruby:2.4.0
-
-RUN apt-get update -y
-RUN apt-get install -y apt-transport-https
-
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
-
-RUN apt-get update -y
-RUN apt-get upgrade -y
-
-RUN  apt-get install -y \
-    build-essential \
-    sudo \
-    iceweasel \
-    chromium \
-    xvfb \
-    chrpath \
-    libssl-dev \
-    libxft-dev \
-    libfreetype6 \
-    libfreetype6-dev \
-    libfontconfig1 \
-    libfontconfig1-dev \
-    yarn \
-    bzip2
-
-RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-RUN apt-get install -y nodejs
-
+FROM cwds/intake_base_image:latest
 ENV APP_HOME /ca_intake
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
-
-ADD https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 $APP_HOME
-ADD ./bin/install_phantomjs $APP_HOME/install_phantomjs
-RUN $APP_HOME/install_phantomjs
-
-ARG GECKODRIVER_VERSION=0.18.0
-RUN wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
-  && rm -rf /opt/geckodriver \
-  && tar -C /opt -zxf /tmp/geckodriver.tar.gz \
-  && rm /tmp/geckodriver.tar.gz \
-  && mv /opt/geckodriver /opt/geckodriver-$GECKODRIVER_VERSION \
-  && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION \
-  && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver
-
 ENV DISPLAY :1
 ENV BUNDLE_PATH /ruby_gems

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,41 +1,7 @@
-FROM ruby:2.4.0
-RUN \
-  apt-get update -y && \
-  apt-get upgrade -y && \
-  apt-get install -y \
-    build-essential \
-    sudo \
-    iceweasel \
-    chromium \
-    xvfb
-
-RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
-RUN apt-get install -y nodejs
-
-LABEL application=intake_accelerator
-
+FROM cwds/intake_testing_base_image:latest
 ENV APP_HOME /ca_intake
 RUN mkdir $APP_HOME
 WORKDIR $APP_HOME
-
-ADD https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 $APP_HOME
-ADD ./bin/install_phantomjs $APP_HOME/install_phantomjs
-RUN $APP_HOME/install_phantomjs
-
-ARG GECKODRIVER_VERSION=0.18.0
-RUN wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
-  && rm -rf /opt/geckodriver \
-  && tar -C /opt -zxf /tmp/geckodriver.tar.gz \
-  && rm /tmp/geckodriver.tar.gz \
-  && mv /opt/geckodriver /opt/geckodriver-$GECKODRIVER_VERSION \
-  && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION \
-  && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver
-
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
-RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-RUN \
-  apt-get update -y && \
-  apt-get install -y yarn
 
 ENV BUNDLE_PATH /ca_intake/ruby_gems
 
@@ -44,5 +10,5 @@ COPY scripts/build.sh /usr/local/bin/build.sh
 RUN chmod +x /usr/local/bin/build.sh
 
 COPY . ./
-RUN bundle install -j24
+RUN bundle install -j8
 RUN yarn


### PR DESCRIPTION
### Jira Story

- [FIT-38](https://osi-cwds.atlassian.net/browse/FIT-38)

## Description
Using a pre bundled image as base for our test containers, the builds will end sooner.
This change makes use of pre-existing docker images as base so there's no need to wait for ubuntu packages. 

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 

Not needed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

