### PR TITLE
fixed the bug values are now being cleared in incident information sh…

### DIFF
--- a/app/javascript/selectors/screening/incidentInformationFormSelector.js
+++ b/app/javascript/selectors/screening/incidentInformationFormSelector.js
@@ -42,7 +42,7 @@ export const getScreeningWithEditsSelector = createSelector(
   (screening, incidentDate, incidentCounty, address, locationType) => (
     screening.set('incident_date', incidentDate)
       .set('incident_county', incidentCounty)
-      .set('address', (screening.get('address') || Map()).map((value, key) => (address.get(key) || value)))
+      .set('address', (screening.get('address') || Map()).map((value, key) => (address.get(key) || null)))
       .set('location_type', locationType)
   )
 )

--- a/spec/features/screening/edit_screening_spec.rb
+++ b/spec/features/screening/edit_screening_spec.rb
@@ -319,6 +319,7 @@ feature 'individual card save' do
 
   scenario 'unchanged attributes are not blanked' do
     within '#incident-information-card', text: 'Incident Information' do
+      existing_screening.address.assign_attributes(id: nil)
       updated_screening = as_json_without_root_id(
         existing_screening
       ).merge(incident_date: '1996-02-12')
@@ -461,7 +462,8 @@ feature 'individual card save' do
         city: 'Modesto',
         state: 'TX',
         zip: '57575',
-        type: nil
+        type: nil,
+        id: nil
       )
       existing_screening.incident_date = '1996-02-12'
 

--- a/spec/features/screening/incident_information_spec.rb
+++ b/spec/features/screening/incident_information_spec.rb
@@ -32,9 +32,8 @@ feature 'screening incident information card' do
   end
 
   scenario 'screening<->address edit merging should not override unchanged values' do
-    existing_screening.address.assign_attributes(
-      street_address: '33 Whatever'
-    )
+    existing_screening.address.assign_attributes(street_address: '33 Whatever',
+                                                 id: nil)
     stub_request(
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).with(json_body(as_json_without_root_id(existing_screening)))
@@ -78,6 +77,7 @@ feature 'screening incident information card' do
     end
 
     existing_screening.assign_attributes(incident_date: '2015-10-05')
+    existing_screening.address.assign_attributes(id: nil)
     stub_request(
       :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
     ).with(json_body(as_json_without_root_id(existing_screening)))


### PR DESCRIPTION
…ow mode

Ghost data in zip

- [INT-1040](https://osi-cwds.atlassian.net/browse/INT-1040)

## Description
Values in the incident information show mode are not cleared when the input values in the incident information edit mode are cleared

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

