### PR TITLE
Int 573 zip code not returning NS search results correctly

### DIFF
--- a/app/javascript/selectors/screening/personShowSelectors.js
+++ b/app/javascript/selectors/screening/personShowSelectors.js
@@ -10,6 +10,7 @@ import {isRequiredIfCreate, combineCompact} from 'utils/validator'
 import {getAddressTypes, systemCodeDisplayValue} from 'selectors/systemCodeSelectors'
 import {phoneNumberFormatter} from 'utils/phoneNumberFormatter'
 import {getSSNErrors} from 'utils/ssnValidator'
+import {zipFormatter} from '../../utils/zipFormatter'
 import moment from 'moment'
 
 const getPersonSelector = (state, personId) =>
@@ -176,7 +177,7 @@ export const getPersonFormattedAddressesSelector = (state, personId) => (
         street: address.get('street_address'),
         city: address.get('city'),
         state: formattedState(address.get('state')),
-        zip: address.get('zip'),
+        zip: zipFormatter(address.get('zip')),
         type: systemCodeDisplayValue(address.get('type'), getAddressTypes(state)) || address.get('type'),
       })
     )

--- a/app/javascript/utils/peopleSearchHelper.js
+++ b/app/javascript/utils/peopleSearchHelper.js
@@ -2,6 +2,7 @@ import {Map, List, fromJS} from 'immutable'
 import {buildSelector} from 'selectors'
 import {systemCodeDisplayValue} from 'selectors/systemCodeSelectors'
 import {returnLastKnownAddress} from './returnLastKnownAddress'
+import {zipFormatter} from '../utils/zipFormatter'
 
 export const mapLanguages = (state, result) => buildSelector(
   (state) => state.get('languages'),
@@ -54,7 +55,7 @@ const buildAddressMap = (addressTypes, address) => {
   return Map({
     city: address.get('city'),
     state: address.get('state_code'),
-    zip: address.get('zip'),
+    zip: zipFormatter(address.get('zip')),
     type: type ? type : '',
     streetAddress: `${address.get('street_number') || ''} ${address.get('street_name')}`,
   })

--- a/app/javascript/utils/zipFormatter.js
+++ b/app/javascript/utils/zipFormatter.js
@@ -1,0 +1,6 @@
+export const zipFormatter = (zip) => {
+  if (zip && zip === '0') {
+    return ''
+  }
+  return zip
+}

--- a/spec/javascripts/utils/zipFormaterSpec.js
+++ b/spec/javascripts/utils/zipFormaterSpec.js
@@ -1,0 +1,10 @@
+import {zipFormatter} from 'utils/zipFormatter'
+
+describe('zipFormatter ', () => {
+  it('should return an 12345 when zip 12345 is returned from search', () => {
+    expect(zipFormatter('95833')).toEqual('95833')
+  })
+  it('should return an empty string when zip 0 is returned from search', () => {
+    expect(zipFormatter('0')).toEqual('')
+  })
+})


### PR DESCRIPTION

- [INT-573-Zip code not returning in NS search result correctly](https://osi-cwds.atlassian.net/browse/INT-573)

## Description
When zip is 0 from the Elastic search it should show empty instead of 0 in the search results and same empty should be shown on the person card view.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lin/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

