### PR TITLE
INT 1746 Point Intake to Ferb Screening Create

### DIFF
--- a/app/controllers/api/v1/screenings_controller.rb
+++ b/app/controllers/api/v1/screenings_controller.rb
@@ -43,13 +43,6 @@ module Api
       ].freeze
 
       def create
-        new_screening = Screening.new(
-          reference: LUID.generate.first,
-          assignee: build_assignee_name(session),
-          assignee_staff_id: build_staff_id(session),
-          incident_county: build_incident_county(session),
-          indexable: true
-        )
         screening = ScreeningRepository.create(session[:security_token], new_screening)
         render json: screening
       end
@@ -112,6 +105,21 @@ module Api
           ("- #{user_details.county}" if user_details.county)
         ]
         assignee_details.join(' ').gsub(/\s+/, ' ').strip
+      end
+
+      def new_screening
+        {
+          reference: LUID.generate.first,
+          assignee: build_assignee_name(session),
+          assignee_staff_id: build_staff_id(session),
+          incident_county: build_incident_county(session),
+          indexable: true
+        }.merge(empty_screening_fields)
+      end
+
+      def empty_screening_fields
+        { addresses: [], cross_reports: [], participants: [],
+          allegations: [], incident_address: {} }
       end
     end
   end

--- a/app/lib/ferb_routes.rb
+++ b/app/lib/ferb_routes.rb
@@ -3,6 +3,10 @@
 # The external Ferb routes will be accessible from here.
 class FerbRoutes
   class << self
+    def intake_screenings_path
+      '/intake/screenings'
+    end
+
     def screenings_path
       '/screenings'
     end

--- a/app/models/screening.rb
+++ b/app/models/screening.rb
@@ -26,6 +26,7 @@ class Screening # :nodoc:
   attribute :started_at
   attribute :indexable
   attribute :address, Address, default: ->(_, _) { Address.new }
+  attribute :addresses, Array[Address], default: ->(_, _) { [] }
   attribute :assignee, String
   attribute :cross_reports, Array[CrossReport]
   attribute :participants, Array[Participant]

--- a/app/repositories/screening_repository.rb
+++ b/app/repositories/screening_repository.rb
@@ -4,9 +4,9 @@
 # resource via the API
 class ScreeningRepository
   def self.create(security_token, screening)
-    response = IntakeAPI.make_api_call(
+    response = FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.intake_api_screenings_path,
+      FerbRoutes.intake_screenings_path,
       :post,
       screening.as_json(except: 'id')
     )

--- a/app/repositories/screening_repository.rb
+++ b/app/repositories/screening_repository.rb
@@ -8,9 +8,9 @@ class ScreeningRepository
       security_token,
       ExternalRoutes.intake_api_screenings_path,
       :post,
-      screening.as_json.except('id')
+      screening.as_json(except: 'id')
     )
-    Screening.new(response.body)
+    response.body.to_json
   end
 
   def self.find(security_token, id)

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -33,28 +33,30 @@ feature 'Create Screening' do
       scenario 'via start screening link' do
         user_name_display = 'Joe B. Cool - Mendocino'
         allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-        new_screening = FactoryBot.create(
-          :screening,
+        new_screening = {
+          id: '1',
           reference: 'DQJIYK',
-          safety_alerts: [],
-          safety_information: nil,
-          address: { city: nil },
           assignee: user_name_display,
           assignee_staff_id: '1234',
-          indexable: true
-        )
+          incident_county: nil,
+          indexable: true,
+          addresses: [],
+          cross_reports: [],
+          participants: [],
+          allegations: []
+        }
 
         stub_empty_history_for_screening(new_screening)
         stub_empty_relationships
-        stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
-          .with(body: as_json_without_root_id(new_screening))
+        stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
+          .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
           .and_return(json_body(new_screening.to_json, status: 201))
 
         stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
           .and_return(json_body([].to_json, status: 200))
 
         stub_request(
-          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id))
+          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id]))
         ).and_return(json_body(new_screening.to_json, status: 200))
 
         stub_request(:get, auth_validation_url)
@@ -67,7 +69,7 @@ feature 'Create Screening' do
         click_button 'Start Screening'
 
         within '.page-header-mast' do
-          expect(page).to have_content("Screening #{new_screening.id}")
+          expect(page).to have_content("Screening #{new_screening[:id]}")
         end
 
         expect(page).to have_field(
@@ -94,29 +96,30 @@ feature 'Create Screening' do
       scenario 'via start screening link' do
         user_name_display = 'Joe B. Cool - Mendocino'
         allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-        new_screening = FactoryBot.create(
-          :screening,
-          incident_county: '23',
+        new_screening = {
+          id: '1',
           reference: 'DQJIYK',
-          safety_alerts: [],
-          safety_information: nil,
-          address: { city: nil },
           assignee: user_name_display,
           assignee_staff_id: '1234',
-          indexable: true
-        )
+          incident_county: '23',
+          indexable: true,
+          addresses: [],
+          cross_reports: [],
+          participants: [],
+          allegations: []
+        }
 
         stub_empty_history_for_screening(new_screening)
         stub_empty_relationships
-        stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
-          .with(body: as_json_without_root_id(new_screening))
+        stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
+          .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
           .and_return(json_body(new_screening.to_json, status: 201))
 
         stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
           .and_return(json_body([].to_json, status: 200))
 
         stub_request(
-          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id))
+          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id]))
         ).and_return(json_body(new_screening.to_json, status: 200))
 
         stub_request(:get, auth_validation_url)
@@ -129,7 +132,7 @@ feature 'Create Screening' do
         click_button 'Start Screening'
 
         within '.page-header-mast' do
-          expect(page).to have_content("Screening #{new_screening.id}")
+          expect(page).to have_content("Screening #{new_screening[:id]}")
         end
 
         expect(page).to have_select('Incident County', selected: 'Mendocino', disabled: true)
@@ -155,27 +158,29 @@ feature 'Create Screening' do
       scenario 'via start screening link' do
         user_name_display = 'Joe Cool - Mendocino'
         allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-        new_screening = FactoryBot.create(
-          :screening,
+        new_screening = {
+          id: '1',
           reference: 'DQJIYK',
-          safety_alerts: [],
-          safety_information: nil,
-          address: { city: nil },
           assignee: user_name_display,
           assignee_staff_id: '1234',
-          indexable: true
-        )
+          incident_county: nil,
+          indexable: true,
+          addresses: [],
+          cross_reports: [],
+          participants: [],
+          allegations: []
+        }
         stub_empty_history_for_screening(new_screening)
         stub_empty_relationships
-        stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
-          .with(body: as_json_without_root_id(new_screening))
+        stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
+          .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
           .and_return(json_body(new_screening.to_json, status: 201))
 
         stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
           .and_return(json_body([].to_json, status: 200))
 
         stub_request(
-          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id))
+          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id]))
         ).and_return(json_body(new_screening.to_json, status: 200))
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
@@ -186,7 +191,7 @@ feature 'Create Screening' do
         click_button 'Start Screening'
 
         within '.page-header-mast' do
-          expect(page).to have_content("Screening #{new_screening.id}")
+          expect(page).to have_content("Screening #{new_screening[:id]}")
         end
 
         expect(page).to have_field(
@@ -200,27 +205,29 @@ feature 'Create Screening' do
     context 'no user information' do
       scenario 'via start screening link' do
         allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-        new_screening = FactoryBot.create(
-          :screening,
+        new_screening = {
+          id: '1',
           reference: 'DQJIYK',
-          safety_alerts: [],
-          safety_information: nil,
-          address: { city: nil },
           assignee: nil,
           assignee_staff_id: nil,
-          indexable: true
-        )
+          incident_county: nil,
+          indexable: true,
+          addresses: [],
+          cross_reports: [],
+          participants: [],
+          allegations: []
+        }
         stub_empty_history_for_screening(new_screening)
         stub_empty_relationships
-        stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
-          .with(body: as_json_without_root_id(new_screening))
+        stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
+          .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
           .and_return(json_body(new_screening.to_json, status: 201))
 
         stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
           .and_return(json_body([].to_json, status: 200))
 
         stub_request(
-          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id))
+          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id]))
         ).and_return(json_body(new_screening.to_json, status: 200))
 
         stub_request(:get, auth_validation_url)
@@ -230,7 +237,7 @@ feature 'Create Screening' do
         click_button 'Start Screening'
 
         within '.page-header-mast' do
-          expect(page).to have_content("Screening #{new_screening.id}")
+          expect(page).to have_content("Screening #{new_screening[:id]}")
         end
 
         expect(page).to have_field('Assigned Social Worker', with: '', disabled: false)
@@ -240,25 +247,29 @@ feature 'Create Screening' do
 
   scenario 'via start screening link' do
     allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-    new_screening = FactoryBot.create(
-      :screening,
+    new_screening = {
+      id: '1',
       reference: 'DQJIYK',
-      safety_alerts: [],
-      safety_information: nil,
-      address: { city: nil },
       assignee: nil,
-      indexable: true
-    )
+      assignee_staff_id: nil,
+      incident_county: nil,
+      indexable: true,
+      addresses: [],
+      cross_reports: [],
+      participants: [],
+      allegations: []
+    }
+
     stub_empty_history_for_screening(new_screening)
     stub_empty_relationships
-    stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
-      .with(body: as_json_without_root_id(new_screening))
+    stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
+      .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
       .and_return(json_body(new_screening.to_json, status: 201))
 
     stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
       .and_return(json_body([].to_json, status: 200))
 
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id)))
+    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id])))
       .and_return(json_body(new_screening.to_json, status: 200))
 
     visit root_path
@@ -266,12 +277,12 @@ feature 'Create Screening' do
 
     expect(
       a_request(
-        :post, intake_api_url(ExternalRoutes.intake_api_screenings_path)
-      ).with(body: as_json_without_root_id(new_screening))
+        :post, ferb_api_url(FerbRoutes.intake_screenings_path)
+      ).with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
     ).to have_been_made
 
     within '.page-header-mast' do
-      expect(page).to have_content("Screening #{new_screening.id}")
+      expect(page).to have_content("Screening #{new_screening[:id]}")
     end
   end
 end

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -412,25 +412,29 @@ feature 'searching a participant in autocompleter' do
 
     scenario 'clear search input on navigation' do
       allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-      new_screening = FactoryBot.create(
-        :screening,
+      new_screening = {
+        id: '1',
         reference: 'DQJIYK',
-        safety_alerts: [],
-        safety_information: nil,
-        address: { city: nil },
         assignee: nil,
-        indexable: true
-      )
+        assignee_staff_id: nil,
+        incident_county: nil,
+        indexable: true,
+        addresses: [],
+        cross_reports: [],
+        participants: [],
+        allegations: []
+      }
       stub_empty_history_for_screening(new_screening)
       stub_empty_relationships
-      stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
-        .with(body: as_json_without_root_id(new_screening))
+      stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
+        .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
         .and_return(json_body(new_screening.to_json, status: 201))
 
       stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
         .and_return(json_body([].to_json, status: 200))
 
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id)))
+      stub_request(:get,
+        intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id])))
         .and_return(json_body(new_screening.to_json, status: 200))
 
       visit root_path
@@ -448,7 +452,8 @@ feature 'searching a participant in autocompleter' do
 
       stub_empty_history_for_screening(new_screening)
       stub_empty_relationships
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id)))
+      stub_request(:get,
+        intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id])))
         .and_return(json_body(new_screening.to_json, status: 200))
 
       page.go_forward

--- a/spec/features/snapshot/create_snapshot_spec.rb
+++ b/spec/features/snapshot/create_snapshot_spec.rb
@@ -123,7 +123,7 @@ feature 'Create Snapshot' do
 
       stub_empty_history_for_screening(new_screening)
       stub_empty_relationships
-      stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
+      stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
         .and_return(json_body(new_screening.to_json, status: 201))
       stub_request(
         :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id))

--- a/spec/features/snapshot/history_of_involvement_spec.rb
+++ b/spec/features/snapshot/history_of_involvement_spec.rb
@@ -218,7 +218,7 @@ feature 'Snapshot History of Involvement' do
 
     scenario 'clicking the Start Over button clears history table' do
       second_snapshot = FactoryBot.create(:screening)
-      stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
+      stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
         .and_return(json_body(second_snapshot.to_json, status: 201))
       within '#history-card.card.show' do
         expect(page).to have_content('Referral')

--- a/spec/features/system_codes_spec.rb
+++ b/spec/features/system_codes_spec.rb
@@ -6,9 +6,13 @@ feature 'System codes' do
   scenario 'system codes are fetch once per page load' do
     stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
       .and_return(json_body([].to_json, status: 200))
-    stub_request(:post, intake_api_url(ExternalRoutes.intake_api_screenings_path))
-      .and_return(json_body([].to_json, status: 200))
+    stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
+      .and_return(json_body({ id: '1' }.to_json, status: 200))
     stub_request(:get, ferb_api_url(FerbRoutes.lov_path))
+      .and_return(json_body([].to_json, status: 200))
+    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(1)))
+      .and_return(json_body({}.to_json, status: 200))
+    stub_request(:get, ferb_api_url(FerbRoutes.screening_history_of_involvements_path(1)))
       .and_return(json_body([].to_json, status: 200))
     visit root_path
     click_button 'Start Screening'

--- a/spec/repositories/screening_repository_spec.rb
+++ b/spec/repositories/screening_repository_spec.rb
@@ -9,18 +9,18 @@ describe ScreeningRepository do
   describe '.create' do
     let(:screening_id) { '11' }
     let(:response) { double(:response, body: { 'id' => screening_id, 'name' => 'New Screening' }) }
-    let(:screening) { double(:screening, as_json: { 'id' => nil, 'name' => 'New Screening' }) }
+    let(:screening) { double(:screening, as_json: { 'name' => 'New Screening' }) }
 
     before do
-      expect(IntakeAPI).to receive(:make_api_call)
-        .with(security_token, '/api/v1/screenings', :post, 'name' => 'New Screening')
+      expect(FerbAPI).to receive(:make_api_call)
+        .with(security_token, '/intake/screenings', :post, 'name' => 'New Screening')
         .and_return(response)
     end
 
     it 'returns the created screening' do
-      created_screening = described_class.create(security_token, screening)
-      expect(created_screening.id).to eq(screening_id)
-      expect(created_screening.name).to eq('New Screening')
+      created_screening = JSON.parse(described_class.create(security_token, screening))
+      expect(created_screening['id']).to eq(screening_id)
+      expect(created_screening['name']).to eq('New Screening')
     end
   end
 


### PR DESCRIPTION
### Jira Story

- [Name of Story INT-1746](https://osi-cwds.atlassian.net/browse/INT-1746)

## Description
In the effort to phase out Intake API we need to create screenings using the new Ferb endpoint.

Originally, we were going to switch create, update, and get to Ferb at the same time. Since there are some complexities due to changes in api implementation and contract, we are planning to roll them out one at a time. That will make for smaller stories and smaller PRs.
## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

