### PR TITLE
SNAP-37 - Set max-size of avatar picture

### DIFF
--- a/app/assets/stylesheets/helpers.scss
+++ b/app/assets/stylesheets/helpers.scss
@@ -208,6 +208,11 @@
   .profile-picture .image-caption {
     position: relative;
   }
+
+  .avatar-picture {
+    max-height: 15rem;
+    max-width: 15rem;
+  }
 }
 
 @media (min-width: 992px) and (max-width: 1199px) {

--- a/app/javascript/views/people/PersonInformationShow.jsx
+++ b/app/javascript/views/people/PersonInformationShow.jsx
@@ -20,7 +20,7 @@ const PersonInformationShow = ({
   <div>
     { alertErrorMessage && <AlertErrorMessage message={alertErrorMessage} /> }
     <div className='row'>
-      <div className='col-md-2'><img src={AvatarImg}/></div>
+      <div className='col-md-2 avatar-picture'><img src={AvatarImg}/></div>
       <div className='col-md-10'>
         {legacySource &&
             <div className='row'><div className='col-md-12'><span>{legacySource}</span></div></div>


### PR DESCRIPTION
### Jira Story

- [Fix in SnapShot 1.1 INT-622 Photo placeholder to be responsive based on screen size. IS NOT being responsive SNAP-37](https://osi-cwds.atlassian.net/browse/SNAP-37)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This sets the max-size of the avatar picture on the person info
card. This covers the screensize band from 0 to 991px, or more
accurately from 768px to 991px, since react-wood-duck already set
the same max size on smaller screens.

This is necessary to patch here, since we are using a _slightly_
different card component to react-wood-duck, but some of the shared
styles do still apply here.

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->
Bug fix, small style change. See screenshots attached in Jira.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

