### PR TITLE
HOT 1952 Point Intake to Ferb Screening Get

### DIFF
--- a/app/javascript/reducers/allegationsFormReducer.js
+++ b/app/javascript/reducers/allegationsFormReducer.js
@@ -10,12 +10,23 @@ import {
 import {createReducer} from 'utils/createReducer'
 import {List, fromJS} from 'immutable'
 
-const buildAllegations = (allegations) => (
+export const buildFerbAllegations = (allegations) => (
   fromJS(
     allegations.map((allegation) => ({
-      id: allegation.id,
-      victimId: allegation.victim_id,
-      perpetratorId: allegation.perpetrator_id,
+      id: allegation.id.toString(),
+      victimId: allegation.victim_person_id.toString(),
+      perpetratorId: allegation.perpetrator_person_id.toString(),
+      allegationTypes: allegation.types,
+    }))
+  )
+)
+
+const buildApiAllegations = (allegations) => (
+  fromJS(
+    allegations.map((allegation) => ({
+      id: allegation.id.toString(),
+      victimId: allegation.victim_id.toString(),
+      perpetratorId: allegation.perpetrator_id.toString(),
       allegationTypes: allegation.allegation_types,
     }))
   )
@@ -27,7 +38,7 @@ export default createReducer(List(), {
       return state
     } else {
       const {allegations} = screening
-      return buildAllegations(allegations)
+      return buildFerbAllegations(allegations)
     }
   },
   [SET_ALLEGATION_TYPES](state, {payload: {victimId, perpetratorId, allegationTypes}}) {
@@ -36,7 +47,7 @@ export default createReducer(List(), {
     )).push(fromJS({id: null, victimId, perpetratorId, allegationTypes}))
   },
   [RESET_ALLEGATIONS_FORM](_state, {payload: {allegations}}) {
-    return buildAllegations(allegations)
+    return buildApiAllegations(allegations)
   },
   [DELETE_PERSON_COMPLETE](state, {payload: {id}, error}) {
     if (error) {

--- a/app/javascript/reducers/incidentInformationFormReducer.js
+++ b/app/javascript/reducers/incidentInformationFormReducer.js
@@ -16,7 +16,7 @@ export default createReducer(Map(), {
     const {
       incident_date,
       incident_county,
-      address: {street_address, city, state: usState, zip},
+      incident_address: {street_address, city, state: usState, zip},
       location_type,
     } = screening
 

--- a/app/javascript/reducers/screeningReducer.js
+++ b/app/javascript/reducers/screeningReducer.js
@@ -18,19 +18,43 @@ const getScreening = (state, {payload: {screening}, error}) => {
   }
 }
 
-const fetchScreening = (state, {payload: {screening}, error}) => {
+const buildFerbAllegations = (allegations) => (
+  fromJS(
+    allegations.map((allegation) => ({
+      id: allegation.id.toString(),
+      victim_id: allegation.victim_person_id.toString(),
+      perpetrator_id: allegation.perpetrator_person_id.toString(),
+      allegation_types: allegation.types,
+    }))
+  )
+)
+
+const getFerbScreening = (state, {payload: {screening}, error}) => {
   if (error) {
     return state
   } else {
-    const {incident_address: {street_address, city, state: usState, zip}, ...screeningTail} = screening
-    return fromJS({address: {street_address, city, state: usState, zip}, ...screeningTail, fetch_status: 'FETCHED'})
+    const {
+      incident_address: {
+        street_address, city, state: usState, zip,
+      },
+      allegations,
+      ...screeningTail
+    } = screening
+    return fromJS({
+      address: {
+        street_address, city, state: usState, zip,
+      },
+      allegations: buildFerbAllegations(allegations).toJS(),
+      ...screeningTail,
+      fetch_status: 'FETCHED',
+    })
   }
 }
 
 export default createReducer(Map(), {
   [FETCH_SCREENING]: (_state, _action) => Map({fetch_status: 'FETCHING'}),
   [CREATE_SCREENING_COMPLETE]: getScreening,
-  [FETCH_SCREENING_COMPLETE]: fetchScreening,
+  [FETCH_SCREENING_COMPLETE]: getFerbScreening,
   [SAVE_SCREENING_COMPLETE]: getScreening,
   [SUBMIT_SCREENING_COMPLETE]: getScreening,
   [CLEAR_SCREENING]: () => Map(),

--- a/app/javascript/reducers/screeningReducer.js
+++ b/app/javascript/reducers/screeningReducer.js
@@ -18,10 +18,19 @@ const getScreening = (state, {payload: {screening}, error}) => {
   }
 }
 
+const fetchScreening = (state, {payload: {screening}, error}) => {
+  if (error) {
+    return state
+  } else {
+    const {incident_address: {street_address, city, state: usState, zip}, ...screeningTail} = screening
+    return fromJS({address: {street_address, city, state: usState, zip}, ...screeningTail, fetch_status: 'FETCHED'})
+  }
+}
+
 export default createReducer(Map(), {
   [FETCH_SCREENING]: (_state, _action) => Map({fetch_status: 'FETCHING'}),
   [CREATE_SCREENING_COMPLETE]: getScreening,
-  [FETCH_SCREENING_COMPLETE]: getScreening,
+  [FETCH_SCREENING_COMPLETE]: fetchScreening,
   [SAVE_SCREENING_COMPLETE]: getScreening,
   [SUBMIT_SCREENING_COMPLETE]: getScreening,
   [CLEAR_SCREENING]: () => Map(),

--- a/app/lib/ferb_routes.rb
+++ b/app/lib/ferb_routes.rb
@@ -11,6 +11,10 @@ class FerbRoutes
       '/screenings'
     end
 
+    def intake_screening_path(id)
+      "/intake/screenings/#{id}"
+    end
+
     def screening_history_of_involvements_path(id)
       "/screenings/#{id}/history_of_involvements"
     end

--- a/app/repositories/screening_repository.rb
+++ b/app/repositories/screening_repository.rb
@@ -14,12 +14,12 @@ class ScreeningRepository
   end
 
   def self.find(security_token, id)
-    response = IntakeAPI.make_api_call(
+    response = FerbAPI.make_api_call(
       security_token,
-      ExternalRoutes.intake_api_screening_path(id),
+      FerbRoutes.intake_screening_path(id),
       :get
     )
-    Screening.new(response.body)
+    response.body.as_json
   end
 
   def self.update(security_token, screening)

--- a/spec/features/api_response_spec.rb
+++ b/spec/features/api_response_spec.rb
@@ -4,7 +4,9 @@ require 'rails_helper'
 require 'feature/testing'
 
 feature 'API call' do
-  let(:screening) { create :screening, name: 'Little Shop Of Horrors' }
+  let(:screening) do
+    { id: '1' }
+  end
 
   context 'responds with unauthorized error' do
     let(:auth_login_url) { 'http://www.example.com/authn/login?callback=' }
@@ -27,12 +29,12 @@ feature 'API call' do
       )
 
       visit root_path
-      redirect_url = CGI.escape("#{page.current_url.chomp('/')}#{screening_path(screening.id)}")
+      redirect_url = CGI.escape("#{page.current_url.chomp('/')}#{screening_path(screening[:id])}")
       login_url = "#{auth_login_url}#{redirect_url}"
 
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
         .and_return(json_body('I failed', status: 401))
-      visit screening_path(id: screening.id, params: { bar: 'foo' })
+      visit screening_path(id: screening[:id], params: { bar: 'foo' })
 
       # have_current_path waits for the async call to finish, but doesn't verify url params
       # comparing the current_url to login_url compares the full strings
@@ -54,6 +56,6 @@ feature 'API call' do
 
   scenario 'returns a success' do
     stub_and_visit_show_screening(screening)
-    expect(page.current_url).to have_content screening_path(screening.id)
+    expect(page.current_url).to have_content screening_path(screening[:id])
   end
 end

--- a/spec/features/login_spec.rb
+++ b/spec/features/login_spec.rb
@@ -138,8 +138,17 @@ feature 'login' do
   end
 
   scenario 'user uses session access code when communicating to API' do
-    screening = FactoryBot.create(:screening, name: 'My Screening')
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    screening = {
+      id: '1',
+      name: 'My Screening',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [],
+      allegations: [],
+      safety_alerts: ['Firearms in Home']
+    }
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_history_for_screening(screening)
     stub_empty_relationships
@@ -168,19 +177,19 @@ feature 'login' do
     end
 
     Capybara.using_session(:bob) do
-      visit screening_path(screening.id)
+      visit screening_path(screening[:id])
       expect(page).to have_content 'My Screening'
       expect(
-        a_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+        a_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
         .with(headers: { 'Authorization' => bobs_token })
       ).to have_been_made
     end
 
     Capybara.using_session(:alex) do
-      visit screening_path(screening.id)
+      visit screening_path(screening[:id])
       expect(page).to have_content 'My Screening'
       expect(
-        a_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+        a_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
         .with(headers: { 'Authorization' => alexs_token })
       ).to have_been_made
     end
@@ -292,8 +301,17 @@ feature 'login perry v1' do
 
   scenario 'user uses session token when communicating to API' do
     Feature.run_with_activated(:authentication) do
-      screening = FactoryBot.create(:screening, name: 'My Screening')
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      screening = {
+        id: '1',
+        name: 'My Screening',
+        incident_address: {},
+        addresses: [],
+        cross_reports: [],
+        participants: [],
+        allegations: [],
+        safety_alerts: ['Firearms in Home']
+      }
+      stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
         .and_return(json_body(screening.to_json, status: 200))
       stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
         .and_return(json_body([].to_json, status: 200))
@@ -317,19 +335,19 @@ feature 'login perry v1' do
       end
 
       Capybara.using_session(:bob) do
-        visit screening_path(screening.id)
+        visit screening_path(screening[:id])
         expect(page).to have_content 'My Screening'
         expect(
-          a_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+          a_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
           .with(headers: { 'Authorization' => bobs_token })
         ).to have_been_made
       end
 
       Capybara.using_session(:alex) do
-        visit screening_path(screening.id)
+        visit screening_path(screening[:id])
         expect(page).to have_content 'My Screening'
         expect(
-          a_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+          a_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
           .with(headers: { 'Authorization' => alexs_token })
         ).to have_been_made
       end

--- a/spec/features/screening/allegations/show_allegations_spec.rb
+++ b/spec/features/screening/allegations/show_allegations_spec.rb
@@ -17,27 +17,35 @@ feature 'show allegations' do
       first_name: 'Homer',
       last_name: 'Simps',
       date_of_birth: nil)
-    screening = FactoryBot.create(
-      :screening,
-      participants: [marge, homer, lisa]
-    )
-    allegation = FactoryBot.create(
-      :allegation,
-      victim_id: lisa.id,
-      perpetrator_id: marge.id,
-      screening_id: screening.id,
-      allegation_types: ['General neglect', 'Severe neglect']
-    )
-    screening.allegations << allegation
+    allegation = {
+      id: '1',
+      victim_person_id: lisa.id,
+      perpetrator_person_id: marge.id,
+      screening_id: '1',
+      types: ['General neglect', 'Severe neglect']
+    }
+    screening = {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      safety_alerts: [],
+      participants: [
+        marge.as_json.symbolize_keys,
+        homer.as_json.symbolize_keys,
+        lisa.as_json.symbolize_keys
+      ],
+      allegations: [allegation]
+    }
 
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
-    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
       .and_return(json_body({}.to_json, status: 200))
 
-    visit screening_path(id: screening.id)
+    visit screening_path(id: screening[:id])
 
     within '.card.show', text: 'Allegations' do
       within 'thead' do
@@ -96,14 +104,13 @@ feature 'show allegations' do
       :allegation,
       victim_id: lisa.id,
       perpetrator_id: homer.id,
-      screening_id: screening.id,
+      screening_id: screening[:id],
       allegation_types: ['Exploitation']
     )
-    screening.allegations.push(new_allegation)
 
     expect(
-      a_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
-      .with(json_body(as_json_without_root_id(screening).merge('participants' => [])))
+      a_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
+      .with(body: hash_including(allegations: array_including(new_allegation.as_json)))
     ).to have_been_made
   end
 
@@ -117,25 +124,33 @@ feature 'show allegations' do
     homer = FactoryBot.create(:participant, :perpetrator,
       first_name: 'Homer',
       last_name: 'Simpson')
-    screening = FactoryBot.create(
-      :screening,
-      participants: [marge, homer, lisa]
-    )
-    allegation = FactoryBot.create(
-      :allegation,
-      victim_id: lisa.id,
-      perpetrator_id: marge.id,
-      screening_id: screening.id,
-      allegation_types: ['General neglect']
-    )
-    screening.allegations << allegation
+    allegation = {
+      id: '1',
+      victim_person_id: lisa.id,
+      perpetrator_person_id: marge.id,
+      screening_id: '1',
+      types: ['General neglect']
+    }
+    screening = {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      safety_alerts: [],
+      participants: [
+        marge.as_json.symbolize_keys,
+        homer.as_json.symbolize_keys,
+        lisa.as_json.symbolize_keys
+      ],
+      allegations: [allegation]
+    }
 
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
 
-    visit screening_path(id: screening.id)
+    visit screening_path(id: screening[:id])
 
     within '.card.show', text: 'Allegations' do
       within 'tbody tr' do
@@ -148,9 +163,9 @@ feature 'show allegations' do
     stub_request(:delete, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
       .and_return(json_body(nil, status: 204))
 
-    screening.allegations = []
-    screening.participants = [lisa, homer]
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    screening[:allegations] = []
+    screening[:participants] = [lisa.as_json.symbolize_keys, homer.as_json.symbolize_keys]
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
 
     within show_participant_card_selector(marge.id) do
@@ -184,24 +199,28 @@ feature 'show allegations' do
       roles: ['Perpetrator', 'Anonymous Reporter']
     )
     lisa = FactoryBot.create(:participant, :victim, first_name: 'Lisa')
-    screening = FactoryBot.create(
-      :screening,
-      participants: [marge, lisa]
-    )
-    allegation = FactoryBot.create(
-      :allegation,
-      victim_id: lisa.id,
-      perpetrator_id: marge.id,
-      screening_id: screening.id,
-      allegation_types: ['General neglect']
-    )
-    screening.allegations << allegation
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    allegation = {
+      id: '1',
+      victim_person_id: lisa.id,
+      perpetrator_person_id: marge.id,
+      screening_id: '1',
+      types: ['General neglect']
+    }
+    screening = {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      safety_alerts: [],
+      participants: [marge.as_json.symbolize_keys, lisa.as_json.symbolize_keys],
+      allegations: [allegation]
+    }
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
 
-    visit screening_path(id: screening.id)
+    visit screening_path(id: screening[:id])
 
     within '.card.show', text: 'Allegations' do
       within 'tbody tr' do
@@ -219,9 +238,9 @@ feature 'show allegations' do
     stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
       .and_return(json_body(marge.to_json, status: 200))
 
-    screening.allegations = []
-    screening.participants = [lisa, marge]
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    screening[:allegations] = []
+    screening[:participants] = [lisa.as_json.symbolize_keys, marge.as_json.symbolize_keys]
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
 
     within edit_participant_card_selector(marge.id) do
@@ -245,8 +264,8 @@ feature 'show allegations' do
     stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id)))
       .and_return(json_body(marge.to_json, status: 200))
 
-    screening.participants = [lisa, marge]
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    screening[:participants] = [lisa.as_json.symbolize_keys, marge.as_json.symbolize_keys]
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
 
     within edit_participant_card_selector(marge.id) do
@@ -276,16 +295,24 @@ feature 'show allegations' do
   scenario 'saving another card will not persist changes to allegations' do
     marge = FactoryBot.create(:participant, :perpetrator, first_name: 'Marge')
     lisa = FactoryBot.create(:participant, :victim, first_name: 'Lisa')
-    screening = FactoryBot.create(:screening, participants: [marge, lisa])
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    screening = {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      safety_alerts: [],
+      participants: [marge.as_json.symbolize_keys, lisa.as_json.symbolize_keys],
+      allegations: []
+    }
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
 
-    visit screening_path(id: screening.id)
+    visit screening_path(id: screening[:id])
 
-    screening.name = 'Hello'
-    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    screening[:name] = 'Hello'
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
 
     within '.card.show', text: 'Allegations' do
@@ -306,8 +333,8 @@ feature 'show allegations' do
     end
 
     expect(
-      a_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
-      .with(json_body(as_json_without_root_id(screening).merge('participants' => [])))
+      a_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
+      .with(body: hash_including(allegations: []))
     ).to have_been_made
   end
 
@@ -324,19 +351,28 @@ feature 'show allegations' do
       first_name: 'Homer',
       last_name: 'Simps',
       date_of_birth: nil)
-    screening = FactoryBot.create(
-      :screening,
-      participants: [marge, homer, lisa]
-    )
+    screening = {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      safety_alerts: [],
+      participants: [
+        marge.as_json.symbolize_keys,
+        homer.as_json.symbolize_keys,
+        lisa.as_json.symbolize_keys
+      ],
+      allegations: []
+    }
 
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
-    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
       .and_return(json_body({}.to_json, status: 200))
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
 
-    visit screening_path(id: screening.id)
+    visit screening_path(id: screening[:id])
 
     within '.card.show', text: 'Allegations' do
       click_link 'Edit allegations'
@@ -368,14 +404,13 @@ feature 'show allegations' do
       :allegation,
       victim_id: lisa.id,
       perpetrator_id: homer.id,
-      screening_id: screening.id,
+      screening_id: screening[:id],
       allegation_types: ['Exploitation']
     )
-    screening.allegations << new_allegation
 
     expect(
-      a_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
-      .with(json_body(as_json_without_root_id(screening).merge('participants' => [])))
+      a_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
+      .with(body: hash_including(allegations: [new_allegation.as_json.symbolize_keys]))
     ).to have_been_made
   end
 end

--- a/spec/features/screening/allegations_cross_reports_spec.rb
+++ b/spec/features/screening/allegations_cross_reports_spec.rb
@@ -13,32 +13,31 @@ feature 'show cross reports' do
       :participant,
       :victim
     )
-    screening = FactoryBot.create(
-      :screening,
-      id: 1,
-      participants: [perpetrator, victim],
+    screening = {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      participants: [perpetrator.as_json.symbolize_keys, victim.as_json.symbolize_keys],
       allegations: [{
-        screening_id: 1,
-        perpetrator_id: perpetrator.id,
-        victim_id: victim.id,
-        allegation_types: ['Severe neglect']
+        id: '1',
+        screening_id: '1',
+        perpetrator_person_id: perpetrator.id,
+        victim_person_id: victim.id,
+        types: ['Severe neglect']
       }],
-      cross_reports: [
-        CrossReport.new(
-          county_id: 'c41',
-          agencies: [
-            { type: 'LAW_ENFORCEMENT', id: 'LAOFFCODE' }
-          ],
-          method: 'Child Abuse Form'
-        )
-      ]
-    )
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      cross_reports: [{
+        id: '1',
+        county_id: 'c41',
+        agencies: [{ type: 'LAW_ENFORCEMENT', id: 'LAOFFCODE' }],
+        method: 'Child Abuse Form'
+      }]
+    }
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_history_for_screening(screening)
     stub_empty_relationships
     stub_county_agencies('c41')
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     within '#cross-report-card.edit' do
       expect(page).to have_content('must be cross-reported to law enforcement')
@@ -70,40 +69,41 @@ feature 'show cross reports' do
       :participant,
       :victim
     )
-    screening = FactoryBot.create(
-      :screening,
-      id: 1,
-      participants: [perpetrator, victim, victim2],
-      allegations: [
-        {
-          screening_id: 1,
-          perpetrator_id: perpetrator.id,
-          victim_id: victim.id,
-          allegation_types: ['General neglect']
-        },
-        {
-          screening_id: 1,
-          perpetrator_id: perpetrator.id,
-          victim_id: victim2.id,
-          allegation_types: ['At risk, sibling abused']
-        }
+    screening = {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      participants: [
+        perpetrator.as_json.symbolize_keys,
+        victim.as_json.symbolize_keys,
+        victim2.as_json.symbolize_keys
       ],
-      cross_reports: [
-        CrossReport.new(
-          county_id: 'c41',
-          agencies: [
-            { type: 'LAW_ENFORCEMENT', id: 'LAOFFCODE' }
-          ],
-          method: 'Child Abuse Form'
-        )
-      ]
-    )
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      allegations: [{
+        id: '1',
+        screening_id: '1',
+        perpetrator_person_id: perpetrator.id,
+        victim_person_id: victim.id,
+        types: ['General neglect']
+      }, {
+        id: '2',
+        screening_id: 1,
+        perpetrator_person_id: perpetrator.id,
+        victim_person_id: victim2.id,
+        types: ['At risk, sibling abused']
+      }],
+      cross_reports: [{
+        id: '1',
+        county_id: 'c41',
+        agencies: [{ type: 'LAW_ENFORCEMENT', id: 'LAOFFCODE' }],
+        method: 'Child Abuse Form'
+      }]
+    }
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_history_for_screening(screening)
     stub_empty_relationships
     stub_county_agencies('c41')
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     within '#cross-report-card.edit' do
       expect(page).to_not have_content('must be cross-reported to law enforcement')
@@ -128,32 +128,36 @@ feature 'show cross reports' do
       :participant,
       :victim
     )
-    screening = FactoryBot.create(
-      :screening,
-      id: 1,
-      participants: [perpetrator, victim, victim2],
-      allegations: [
-        {
-          screening_id: 1,
-          perpetrator_id: perpetrator.id,
-          victim_id: victim.id,
-          allegation_types: ['Severe neglect']
-        },
-        {
-          screening_id: 1,
-          perpetrator_id: perpetrator.id,
-          victim_id: victim2.id,
-          allegation_types: ['At risk, sibling abused']
-        }
+    screening = {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      participants: [
+        perpetrator.as_json.symbolize_keys,
+        victim.as_json.symbolize_keys,
+        victim2.as_json.symbolize_keys
       ],
+      allegations: [{
+        id: '1',
+        screening_id: '1',
+        perpetrator_person_id: perpetrator.id,
+        victim_person_id: victim.id,
+        types: ['Severe neglect']
+      }, {
+        id: '2',
+        screening_id: 1,
+        perpetrator_person_id: perpetrator.id,
+        victim_person_id: victim2.id,
+        types: ['At risk, sibling abused']
+      }],
       cross_reports: []
-    )
+    }
     stub_county_agencies('c41')
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_history_for_screening(screening)
     stub_empty_relationships
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     within '#cross-report-card.edit' do
       expect(page).to have_content('must be cross-reported to law enforcement')
@@ -166,15 +170,16 @@ feature 'show cross reports' do
       select 'The Sheriff', from: 'Law enforcement agency name'
     end
 
-    screening.cross_reports << {
-      county_id: 'c41',
-      agencies: [
-        { type: 'DISTRICT_ATTORNEY', id: '65Hvp7x01F' },
-        { type: 'LAW_ENFORCEMENT', id: 'BMG2f3J75C' }
-      ]
-    }
-    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
-      .and_return(json_body(screening.to_json, status: 200))
+    api_screening = screening.merge(address: {}, cross_reports: [{
+                                      county_id: 'c41',
+                                      agencies: [
+                                        { type: 'DISTRICT_ATTORNEY', id: '65Hvp7x01F' },
+                                        { type: 'LAW_ENFORCEMENT', id: 'BMG2f3J75C' }
+                                      ]
+                                    }])
+    api_screening.delete(:incident_address)
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
+      .and_return(json_body(api_screening.to_json, status: 200))
     within '#cross-report-card.edit' do
       click_button 'Save'
     end

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -40,6 +40,7 @@ feature 'Create Screening' do
           assignee_staff_id: '1234',
           incident_county: nil,
           indexable: true,
+          incident_address: {},
           addresses: [],
           cross_reports: [],
           participants: [],
@@ -56,7 +57,7 @@ feature 'Create Screening' do
           .and_return(json_body([].to_json, status: 200))
 
         stub_request(
-          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id]))
+          :get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id]))
         ).and_return(json_body(new_screening.to_json, status: 200))
 
         stub_request(:get, auth_validation_url)
@@ -103,6 +104,7 @@ feature 'Create Screening' do
           assignee_staff_id: '1234',
           incident_county: '23',
           indexable: true,
+          incident_address: {},
           addresses: [],
           cross_reports: [],
           participants: [],
@@ -119,7 +121,7 @@ feature 'Create Screening' do
           .and_return(json_body([].to_json, status: 200))
 
         stub_request(
-          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id]))
+          :get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id]))
         ).and_return(json_body(new_screening.to_json, status: 200))
 
         stub_request(:get, auth_validation_url)
@@ -165,6 +167,7 @@ feature 'Create Screening' do
           assignee_staff_id: '1234',
           incident_county: nil,
           indexable: true,
+          incident_address: {},
           addresses: [],
           cross_reports: [],
           participants: [],
@@ -180,7 +183,7 @@ feature 'Create Screening' do
           .and_return(json_body([].to_json, status: 200))
 
         stub_request(
-          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id]))
+          :get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id]))
         ).and_return(json_body(new_screening.to_json, status: 200))
         stub_request(:get, auth_validation_url)
           .and_return(json_body(auth_details.to_json, status: 200))
@@ -212,6 +215,7 @@ feature 'Create Screening' do
           assignee_staff_id: nil,
           incident_county: nil,
           indexable: true,
+          incident_address: {},
           addresses: [],
           cross_reports: [],
           participants: [],
@@ -227,7 +231,7 @@ feature 'Create Screening' do
           .and_return(json_body([].to_json, status: 200))
 
         stub_request(
-          :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id]))
+          :get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id]))
         ).and_return(json_body(new_screening.to_json, status: 200))
 
         stub_request(:get, auth_validation_url)
@@ -254,6 +258,7 @@ feature 'Create Screening' do
       assignee_staff_id: nil,
       incident_county: nil,
       indexable: true,
+      incident_address: {},
       addresses: [],
       cross_reports: [],
       participants: [],
@@ -269,7 +274,7 @@ feature 'Create Screening' do
     stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
       .and_return(json_body([].to_json, status: 200))
 
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening[:id])))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id])))
       .and_return(json_body(new_screening.to_json, status: 200))
 
     visit root_path

--- a/spec/features/screening/history_of_involvement_spec.rb
+++ b/spec/features/screening/history_of_involvement_spec.rb
@@ -5,7 +5,17 @@ require 'spec_helper'
 require 'feature/testing'
 
 feature 'History card' do
-  let(:existing_screening) { FactoryBot.create(:screening) }
+  let(:existing_screening) do
+    {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [],
+      allegations: [],
+      safety_alerts: []
+    }
+  end
 
   context 'with no history of envolvements' do
     scenario 'while editting an existing screening displays the no HOI copy' do
@@ -18,7 +28,7 @@ feature 'History card' do
 
     scenario 'while viewing an existing screening displays the no HOI copy' do
       stub_and_visit_show_screening(existing_screening)
-      visit screening_path(id: existing_screening.id)
+      visit screening_path(id: existing_screening[:id])
 
       within '.card', text: 'History' do
         expect(page).to have_content('Search for people and add them to see their')
@@ -245,23 +255,23 @@ feature 'History card' do
     end
 
     before do
-      existing_screening.participants = [FactoryBot.create(:participant)]
+      existing_screening[:participants] = [FactoryBot.create(:participant).as_json.symbolize_keys]
 
       stub_request(
-        :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+        :get, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
       ).and_return(json_body(existing_screening.to_json))
 
       stub_request(
         :get,
         ferb_api_url(
-          FerbRoutes.screening_history_of_involvements_path(existing_screening.id)
+          FerbRoutes.screening_history_of_involvements_path(existing_screening[:id])
         )
       ).and_return(json_body(screening_involvement.to_json, status: 200))
       stub_empty_relationships
     end
 
     scenario 'copy button' do
-      visit screening_path(id: existing_screening.id)
+      visit screening_path(id: existing_screening[:id])
       within '#history-card.card.show', text: 'History' do
         click_button 'Copy'
       end
@@ -283,7 +293,7 @@ feature 'History card' do
     end
 
     scenario 'viewing a screening' do
-      visit screening_path(id: existing_screening.id)
+      visit screening_path(id: existing_screening[:id])
 
       within '#history-card.card.show', text: 'History' do
         within first('tbody') do
@@ -404,20 +414,20 @@ feature 'History card' do
         a_request(
           :get,
           ferb_api_url(
-            FerbRoutes.screening_history_of_involvements_path(existing_screening.id)
+            FerbRoutes.screening_history_of_involvements_path(existing_screening[:id])
           )
         )
       ).to have_been_made
     end
 
     scenario 'editing a screening' do
-      visit edit_screening_path(id: existing_screening.id)
+      visit edit_screening_path(id: existing_screening[:id])
 
       expect(
         a_request(
           :get,
           ferb_api_url(
-            FerbRoutes.screening_history_of_involvements_path(existing_screening.id)
+            FerbRoutes.screening_history_of_involvements_path(existing_screening[:id])
           )
         )
       ).to have_been_made
@@ -590,7 +600,7 @@ feature 'History card' do
           stub_request(
             :get,
             intake_api_url(
-              ExternalRoutes.intake_api_history_of_involvements_path(existing_screening.id)
+              ExternalRoutes.intake_api_history_of_involvements_path(existing_screening[:id])
             )
           ).and_return(json_body(screening_involvement.to_json, status: 200))
           example.run
@@ -598,13 +608,13 @@ feature 'History card' do
       end
 
       scenario 'editing a screening displays HOI' do
-        visit edit_screening_path(id: existing_screening.id)
+        visit edit_screening_path(id: existing_screening[:id])
 
         expect(
           a_request(
             :get,
             intake_api_url(
-              ExternalRoutes.intake_api_history_of_involvements_path(existing_screening.id)
+              ExternalRoutes.intake_api_history_of_involvements_path(existing_screening[:id])
             )
           )
         ).to have_been_made

--- a/spec/features/screening/narrative_spec.rb
+++ b/spec/features/screening/narrative_spec.rb
@@ -5,18 +5,26 @@ require 'spec_helper'
 require 'factory_bot'
 
 feature 'screening narrative card' do
+  let(:existing_screening) do
+    {
+      id: '1',
+      report_narrative: 'This is my report narrative',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [],
+      allegations: [],
+      safety_alerts: []
+    }
+  end
   scenario 'user edits narrative card from screening show page and cancels' do
-    existing_screening = FactoryBot.create(
-      :screening,
-      report_narrative: 'This is my report narrative'
-    )
     stub_request(
-      :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+      :get, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
     ).and_return(json_body(existing_screening.to_json))
     stub_empty_relationships
     stub_empty_history_for_screening(existing_screening)
 
-    visit screening_path(id: existing_screening.id)
+    visit screening_path(id: existing_screening[:id])
     click_link 'Edit narrative'
 
     within '#narrative-card.edit' do
@@ -37,17 +45,13 @@ feature 'screening narrative card' do
   end
 
   scenario 'user edits narrative card from screening edit page and cancels' do
-    existing_screening = FactoryBot.create(
-      :screening,
-      report_narrative: 'This is my report narrative'
-    )
     stub_request(
-      :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+      :get, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
     ).and_return(json_body(existing_screening.to_json))
     stub_empty_relationships
     stub_empty_history_for_screening(existing_screening)
 
-    visit edit_screening_path(id: existing_screening.id)
+    visit edit_screening_path(id: existing_screening[:id])
 
     within '#narrative-card.edit' do
       expect(page).to have_field('Report Narrative', with: 'This is my report narrative')
@@ -61,17 +65,13 @@ feature 'screening narrative card' do
   end
 
   scenario 'user edits narrative card from screening show page and saves' do
-    existing_screening = FactoryBot.create(
-      :screening,
-      report_narrative: 'This is my report narrative'
-    )
     stub_request(
-      :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+      :get, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
     ).and_return(json_body(existing_screening.to_json))
     stub_empty_relationships
     stub_empty_history_for_screening(existing_screening)
 
-    visit screening_path(id: existing_screening.id)
+    visit screening_path(id: existing_screening[:id])
     click_link 'Edit narrative'
 
     within '#narrative-card.edit' do
@@ -79,11 +79,11 @@ feature 'screening narrative card' do
       fill_in 'Report Narrative', with: 'Trying to fill in with changes'
     end
 
-    existing_screening.report_narrative = 'Trying to fill in with changes'
+    existing_screening[:report_narrative] = 'Trying to fill in with changes'
+    existing_screening[:address] = existing_screening.delete(:incident_address)
     stub_request(
-      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
-    ).with(json_body(as_json_without_root_id(existing_screening)))
-      .and_return(json_body(existing_screening.to_json))
+      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening[:id]))
+    ).and_return(json_body(existing_screening.to_json))
     stub_empty_relationships
     stub_empty_history_for_screening(existing_screening)
 
@@ -93,8 +93,8 @@ feature 'screening narrative card' do
 
     expect(
       a_request(
-        :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
-      ).with(json_body(as_json_without_root_id(existing_screening)))
+        :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening[:id]))
+      )
     ).to have_been_made
     stub_empty_relationships
     stub_empty_history_for_screening(existing_screening)
@@ -105,28 +105,24 @@ feature 'screening narrative card' do
   end
 
   scenario 'user edits narrative card from screening edit page and saves' do
-    existing_screening = FactoryBot.create(
-      :screening,
-      report_narrative: 'This is my report narrative'
-    )
     stub_request(
-      :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+      :get, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
     ).and_return(json_body(existing_screening.to_json))
     stub_empty_relationships
     stub_empty_history_for_screening(existing_screening)
 
-    visit edit_screening_path(id: existing_screening.id)
+    visit edit_screening_path(id: existing_screening[:id])
 
     within '#narrative-card.edit' do
       expect(page).to have_field('Report Narrative', with: 'This is my report narrative')
       fill_in 'Report Narrative', with: 'Trying to fill in with changes'
     end
 
-    existing_screening.report_narrative = 'Trying to fill in with changes'
+    existing_screening[:report_narrative] = 'Trying to fill in with changes'
+    existing_screening[:address] = existing_screening.delete(:incident_address)
     stub_request(
-      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
-    ).with(json_body(as_json_without_root_id(existing_screening)))
-      .and_return(json_body(existing_screening.to_json))
+      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening[:id]))
+    ).and_return(json_body(existing_screening.to_json))
     stub_empty_relationships
     stub_empty_history_for_screening(existing_screening)
 
@@ -136,8 +132,8 @@ feature 'screening narrative card' do
 
     expect(
       a_request(
-        :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
-      ).with(json_body(as_json_without_root_id(existing_screening)))
+        :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening[:id]))
+      )
     ).to have_been_made
 
     within '#narrative-card.show' do

--- a/spec/features/screening/participant/address_spec.rb
+++ b/spec/features/screening/participant/address_spec.rb
@@ -5,9 +5,18 @@ require 'spec_helper'
 
 feature 'Participant Address' do
   let(:marge) { FactoryBot.create(:participant) }
-  let(:screening) { FactoryBot.create(:screening, participants: [marge]) }
+  let(:screening) do
+    {
+      id: '1',
+      incident_address: {},
+      cross_reports: [],
+      allegations: [],
+      safety_alerts: [],
+      participants: [marge.as_json.symbolize_keys]
+    }
+  end
   before do
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_request(
       :put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id))
@@ -17,7 +26,7 @@ feature 'Participant Address' do
   end
 
   scenario 'adding a new address to a participant' do
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     within edit_participant_card_selector(marge.id) do
       click_button 'Add new address'
@@ -49,7 +58,7 @@ feature 'Participant Address' do
   end
 
   scenario 'list of address types is correct' do
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
     within edit_participant_card_selector(marge.id) do
       click_button 'Add new address'
       expect(page).to have_select('Address Type', options: [

--- a/spec/features/screening/participant/delete_participant_spec.rb
+++ b/spec/features/screening/participant/delete_participant_spec.rb
@@ -6,10 +6,19 @@ require 'feature/testing'
 
 feature 'Delete Participant' do
   let(:participant) { FactoryBot.create(:participant) }
-  let(:screening) { FactoryBot.create(:screening, participants: [participant]) }
+  let(:screening) do
+    {
+      id: '1',
+      cross_reports: [],
+      allegations: [],
+      incident_address: {},
+      safety_alerts: [],
+      participants: [participant.as_json.symbolize_keys]
+    }
+  end
 
   before do
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_request(
       :delete, intake_api_url(ExternalRoutes.intake_api_participant_path(participant.id))
@@ -19,14 +28,14 @@ feature 'Delete Participant' do
   end
 
   scenario 'removing a participant from an existing screening in edit mode' do
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     within edit_participant_card_selector(participant.id) do
       expect(page).to have_content(participant.first_name)
     end
 
-    screening.participants = []
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    screening[:participants] = []
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
 
     within edit_participant_card_selector(participant.id) do
@@ -41,10 +50,10 @@ feature 'Delete Participant' do
   end
 
   scenario 'removing a participant from an existing screening in show mode' do
-    visit screening_path(id: screening.id)
+    visit screening_path(id: screening[:id])
 
-    screening.participants = []
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    screening[:participants] = []
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
 
     within show_participant_card_selector(participant.id) do

--- a/spec/features/screening/participant/phone_number_spec.rb
+++ b/spec/features/screening/participant/phone_number_spec.rb
@@ -6,10 +6,19 @@ require 'spec_helper'
 feature 'Participant Phone Number' do
   let(:existing_phone_number) { PhoneNumber.new(id: '1', number: '9175555555', type: 'Work') }
   let(:marge) { FactoryBot.create(:participant, phone_numbers: [existing_phone_number]) }
-  let(:screening) { FactoryBot.create(:screening, participants: [marge]) }
+  let(:screening) do
+    {
+      id: '1',
+      incident_address: {},
+      cross_reports: [],
+      allegations: [],
+      safety_alerts: [],
+      participants: [marge.as_json.symbolize_keys]
+    }
+  end
 
   before do
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_request(
       :put, intake_api_url(ExternalRoutes.intake_api_participant_path(marge.id))
@@ -19,7 +28,7 @@ feature 'Participant Phone Number' do
   end
 
   scenario 'adding a new phone number to a participant' do
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     marge.phone_numbers << PhoneNumber.new(number: '7894561245', type: 'Home')
 
@@ -43,7 +52,7 @@ feature 'Participant Phone Number' do
   end
 
   scenario 'editing a phone number from a participant' do
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     marge.phone_numbers.first.number = '7894561245'
 
@@ -64,7 +73,7 @@ feature 'Participant Phone Number' do
   end
 
   scenario 'deleting an existing phone number from a participant' do
-    visit screening_path(id: screening.id)
+    visit screening_path(id: screening[:id])
 
     within show_participant_card_selector(marge.id) do
       expect(page).to have_content('(917) 555-5555')
@@ -86,7 +95,7 @@ feature 'Participant Phone Number' do
   end
 
   scenario 'filling phone number with a combinaiton of valid and invalid characters' do
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     within edit_participant_card_selector(marge.id) do
       within '.card-body' do

--- a/spec/features/screening/participant/race_ethnicity_spec.rb
+++ b/spec/features/screening/participant/race_ethnicity_spec.rb
@@ -20,10 +20,18 @@ feature 'Race & Ethnicity' do
       ethnicity: { hispanic_latino_origin: 'Declined to answer', ethnicity_detail: [] }
     )
   end
-  let(:screening) { FactoryBot.create(:screening, participants: [marge, homer]) }
+  let(:screening) do
+    {
+      id: '1',
+      incident_address: {},
+      cross_reports: [],
+      allegations: [],
+      participants: [marge.as_json.symbolize_keys, homer.as_json.symbolize_keys]
+    }
+  end
 
   before do
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_history_for_screening(screening)
     stub_empty_relationships
@@ -31,7 +39,7 @@ feature 'Race & Ethnicity' do
 
   context 'when changing to abandoned, unknown, declined' do
     it 'disables and unselects the other checkboxes' do
-      visit edit_screening_path(id: screening.id)
+      visit edit_screening_path(id: screening[:id])
       within edit_participant_card_selector(marge.id) do
         within '#race' do
           expect(find('input[value="Asian"]')).to be_checked
@@ -90,7 +98,7 @@ feature 'Race & Ethnicity' do
 
   context 'when changing to race or ethnicity' do
     it 'enables and allows selection of the other checkboxes' do
-      visit edit_screening_path(id: screening.id)
+      visit edit_screening_path(id: screening[:id])
       within edit_participant_card_selector(homer.id) do
         within '#race' do
           expect(find('input[value="Unknown"]')).to be_checked

--- a/spec/features/screening/participant/show_participant_spec.rb
+++ b/spec/features/screening/participant/show_participant_spec.rb
@@ -38,21 +38,25 @@ feature 'Show Screening' do
     },
     languages: %w[Korean Lao Hawaiian]
   )
-  existing_screening = FactoryBot.create(
-    :screening,
-    participants: [existing_participant]
-  )
+  existing_screening = {
+    id: '1',
+    incident_address: {},
+    cross_reports: [],
+    allegations: [],
+    safety_alerts: [],
+    participants: [existing_participant.as_json.symbolize_keys]
+  }
 
   before do
     stub_request(
-      :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+      :get, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
     ).and_return(json_body(existing_screening.to_json, status: 200))
     stub_empty_history_for_screening(existing_screening)
     stub_empty_relationships
   end
 
   scenario 'showing existing participant' do
-    visit screening_path(id: existing_screening.id)
+    visit screening_path(id: existing_screening[:id])
 
     within show_participant_card_selector(existing_participant.id) do
       within '.card-header' do
@@ -95,16 +99,16 @@ feature 'Show Screening' do
   context 'has participant of hispanic/latino origin but with no ethnicity details' do
     before do
       existing_participant.ethnicity[:ethnicity_detail] = []
-      existing_screening.participants = [existing_participant]
+      existing_screening[:participants] = [existing_participant]
       stub_request(
-        :get, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
+        :get, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
       ).and_return(json_body(existing_screening.to_json, status: 200))
       stub_empty_history_for_screening(existing_screening)
       stub_empty_relationships
     end
 
     scenario('display only hispanic/latino origin') do
-      visit screening_path(id: existing_screening.id)
+      visit screening_path(id: existing_screening[:id])
       within show_participant_card_selector(existing_participant.id) do
         within '.card-body' do
           expect(page).to have_content('Hispanic/Latino Origin Yes')
@@ -121,21 +125,25 @@ feature 'Show Screening' do
       approximate_age: 10,
       approximate_age_units: 'Months'
     )
-    approximate_screening = FactoryBot.create(
-      :screening,
-      participants: [approximate_participant]
-    )
+    approximate_screening = {
+      id: '1',
+      incident_address: {},
+      cross_reports: [],
+      allegations: [],
+      safety_alerts: [],
+      participants: [approximate_participant.as_json.symbolize_keys]
+    }
 
     before do
       stub_request(
-        :get, intake_api_url(ExternalRoutes.intake_api_screening_path(approximate_screening.id))
+        :get, ferb_api_url(FerbRoutes.intake_screening_path(approximate_screening[:id]))
       ).and_return(json_body(approximate_screening.to_json, status: 200))
       stub_empty_history_for_screening(approximate_screening)
       stub_empty_relationships
     end
 
     scenario 'shows approximate age and hides date of birth' do
-      visit screening_path(id: approximate_screening.id)
+      visit screening_path(id: approximate_screening[:id])
 
       within show_participant_card_selector(approximate_participant.id) do
         within '.card-body' do
@@ -148,7 +156,7 @@ feature 'Show Screening' do
   end
 
   scenario 'editing an existing participant on the show page' do
-    visit screening_path(id: existing_screening.id)
+    visit screening_path(id: existing_screening[:id])
 
     within show_participant_card_selector(existing_participant.id) do
       click_link 'Edit person'

--- a/spec/features/screening/screening_information/character_limits_spec.rb
+++ b/spec/features/screening/screening_information/character_limits_spec.rb
@@ -5,15 +5,25 @@ require 'spec_helper'
 require 'factory_bot'
 
 feature 'screening information card' do
-  let(:screening) { FactoryBot.create(:screening) }
+  let(:screening) do
+    {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [],
+      allegations: [],
+      safety_alerts: []
+    }
+  end
   let(:character_buffet) { 'C am-r\'o’n1234567890!@#$%^&*(),./;"[]' }
 
   scenario 'character limitations by field' do
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     within '#screening-information-card.edit' do
       fill_in 'Title/Name of Screening', with: character_buffet

--- a/spec/features/screening/screening_information_spec.rb
+++ b/spec/features/screening/screening_information_spec.rb
@@ -6,24 +6,30 @@ require 'factory_bot'
 
 feature 'screening information card' do
   let(:screening) do
-    FactoryBot.create(
-      :screening,
+    {
+      id: '1',
       name: 'James',
       assignee: 'Lisa',
       started_at: '2016-08-13T10:00:00.000Z',
       ended_at: '2016-08-15T11:00:00.000Z',
-      communication_method: 'mail'
-    )
+      communication_method: 'mail',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [],
+      allegations: [],
+      safety_alerts: []
+    }
   end
 
   before(:each) do
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
-    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
   end
 
   scenario 'user edits screening details and save the card' do
@@ -46,7 +52,7 @@ feature 'screening information card' do
       click_button 'Save'
     end
 
-    screening.assign_attributes(
+    screening.merge!(
       name: 'Cameron',
       assignee: 'Mariko',
       communication_method: 'phone',
@@ -54,15 +60,14 @@ feature 'screening information card' do
       ended_at: '2016-08-17T10:00:00.000Z'
     )
 
-    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
       .with(json_body(as_json_without_root_id(screening)))
       .and_return(json_body(screening.to_json))
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
 
     expect(
-      a_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
-      .with(json_body(as_json_without_root_id(screening)))
+      a_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
     ).to have_been_made
   end
 

--- a/spec/features/screening/validations/allegations_sibling_at_risk_validations_spec.rb
+++ b/spec/features/screening/validations/allegations_sibling_at_risk_validations_spec.rb
@@ -12,32 +12,41 @@ feature 'Allegations Sibling At Risk Validations' do
   let(:victim) { FactoryBot.create(:participant, :victim) }
   let(:victim2) { FactoryBot.create(:participant, :victim) }
   let(:screening) do
-    FactoryBot.create(
-      :screening,
-      participants: [perpetrator, perpetrator2, victim, victim2]
-    )
+    {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      safety_alerts: [],
+      participants: [
+        perpetrator.as_json.symbolize_keys,
+        perpetrator2.as_json.symbolize_keys,
+        victim.as_json.symbolize_keys,
+        victim2.as_json.symbolize_keys
+      ],
+      allegations: []
+    }
   end
 
   context 'when allegations have no types' do
     let(:allegations) do
-      [
-        FactoryBot.create(
-          :allegation,
-          victim_id: victim.id,
-          perpetrator_id: perpetrator.id,
-          screening_id: screening.id
-        ),
-        FactoryBot.create(
-          :allegation,
-          victim_id: victim2.id,
-          perpetrator_id: perpetrator.id,
-          screening_id: screening.id
-        )
-      ]
+      [{
+        id: '1',
+        victim_person_id: victim.id,
+        perpetrator_person_id: perpetrator.id,
+        screening_id: screening[:id],
+        types: []
+      }, {
+        id: '2',
+        victim_person_id: victim2.id,
+        perpetrator_person_id: perpetrator.id,
+        screening_id: screening[:id],
+        types: ['General neglect']
+      }]
     end
 
     before do
-      screening.allegations = allegations
+      # screening[:allegations] = allegations
       stub_and_visit_edit_screening(screening)
     end
 
@@ -60,12 +69,19 @@ feature 'Allegations Sibling At Risk Validations' do
       within '.card.edit', text: 'Allegations' do
         fill_in_react_select "allegations_#{victim.id}_#{perpetrator.id}",
           with: 'At risk, sibling abused'
+        allegations.first[:types] = ['At risk, sibling abused']
         expect(page).to have_content(sibling_at_risk_error)
-        allegations.first.allegation_types = ['At risk, sibling abused']
         stub_screening_put_request_with_anything_and_return(
           screening,
           with_updated_attributes: {
-            allegations: allegations
+            allegations: allegations.collect do |allegation|
+              {
+                allegation_types: allegation[:types],
+                victim_id: allegation[:victim_person_id],
+                perpetrator_id: allegation[:perpetrator_person_id],
+                screening_id: screening[:id]
+              }
+            end
           }
         )
 
@@ -89,12 +105,19 @@ feature 'Allegations Sibling At Risk Validations' do
         fill_in_react_select "allegations_#{victim2.id}_#{perpetrator.id}",
           with: 'General neglect'
         expect(page).not_to have_content(sibling_at_risk_error)
-        allegations.first.allegation_types = ['At risk, sibling abused']
-        allegations.second.allegation_types = ['General neglect']
+        allegations.first[:types] = ['At risk, sibling abused']
+        allegations.second[:types] = ['General neglect']
         stub_screening_put_request_with_anything_and_return(
           screening,
           with_updated_attributes: {
-            allegations: allegations
+            allegations: allegations.collect do |allegation|
+              {
+                allegation_types: allegation[:types],
+                victim_id: allegation[:victim_person_id],
+                perpetrator_id: allegation[:perpetrator_person_id],
+                screening_id: screening[:id]
+              }
+            end
           }
         )
 
@@ -111,26 +134,23 @@ feature 'Allegations Sibling At Risk Validations' do
 
   context 'when allegations have only sibling at risk' do
     let(:allegations) do
-      [
-        FactoryBot.create(
-          :allegation,
-          victim_id: victim.id,
-          perpetrator_id: perpetrator.id,
-          screening_id: screening.id,
-          allegation_types: ['At risk, sibling abused']
-        ),
-        FactoryBot.create(
-          :allegation,
-          victim_id: victim2.id,
-          perpetrator_id: perpetrator.id,
-          screening_id: screening.id,
-          allegation_types: ['At risk, sibling abused']
-        )
-      ]
+      [{
+        id: '1',
+        victim_person_id: victim.id,
+        perpetrator_person_id: perpetrator.id,
+        screening_id: screening[:id],
+        types: ['At risk, sibling abused']
+      }, {
+        id: '2',
+        victim_person_id: victim2.id,
+        perpetrator_person_id: perpetrator.id,
+        screening_id: screening[:id],
+        types: ['At risk, sibling abused']
+      }]
     end
 
     before do
-      screening.allegations = allegations
+      screening[:allegations] = allegations
       stub_and_visit_edit_screening(screening)
     end
 
@@ -153,12 +173,19 @@ feature 'Allegations Sibling At Risk Validations' do
         expect(page).to have_content(sibling_at_risk_error)
         fill_in_react_select "allegations_#{victim2.id}_#{perpetrator.id}", with: 'General neglect'
         expect(page).not_to have_content(sibling_at_risk_error)
-        allegations.first.allegation_types = ['At risk, sibling abused', 'Physical abuse']
-        allegations.second.allegation_types = ['At risk, sibling abused', 'General neglect']
+        allegations.first[:types] = ['At risk, sibling abused', 'Physical abuse']
+        allegations.second[:types] = ['At risk, sibling abused', 'General neglect']
         stub_screening_put_request_with_anything_and_return(
           screening,
           with_updated_attributes: {
-            allegations: allegations
+            allegations: allegations.collect do |allegation|
+              {
+                allegation_types: allegation[:types],
+                victim_id: allegation[:victim_person_id],
+                perpetrator_id: allegation[:perpetrator_person_id],
+                screening_id: screening[:id]
+              }
+            end
           }
         )
 
@@ -175,26 +202,23 @@ feature 'Allegations Sibling At Risk Validations' do
 
   context 'when some have sibling at risk and other with abuse' do
     let(:allegations) do
-      [
-        FactoryBot.create(
-          :allegation,
-          victim_id: victim.id,
-          perpetrator_id: perpetrator.id,
-          screening_id: screening.id,
-          allegation_types: ['At risk, sibling abused']
-        ),
-        FactoryBot.create(
-          :allegation,
-          victim_id: victim2.id,
-          perpetrator_id: perpetrator.id,
-          screening_id: screening.id,
-          allegation_types: ['Physical abuse']
-        )
-      ]
+      [{
+        id: '1',
+        victim_person_id: victim.id,
+        perpetrator_person_id: perpetrator.id,
+        screening_id: screening[:id],
+        types: ['At risk, sibling abused']
+      }, {
+        id: '2',
+        victim_person_id: victim2.id,
+        perpetrator_person_id: perpetrator.id,
+        screening_id: screening[:id],
+        types: ['Physical abuse']
+      }]
     end
 
     before do
-      screening.allegations = allegations
+      screening[:allegations] = allegations
       stub_and_visit_edit_screening(screening)
     end
 
@@ -212,19 +236,17 @@ feature 'Allegations Sibling At Risk Validations' do
 
   context 'when one victim has multiple allegations against a perp and is at risk' do
     let(:allegations) do
-      [
-        FactoryBot.create(
-          :allegation,
-          victim_id: victim.id,
-          perpetrator_id: perpetrator.id,
-          screening_id: screening.id,
-          allegation_types: ['At risk, sibling abused', 'General neglect']
-        )
-      ]
+      [{
+        id: '1',
+        victim_person_id: victim.id,
+        perpetrator_person_id: perpetrator.id,
+        screening_id: screening[:id],
+        types: ['At risk, sibling abused', 'General neglect']
+      }]
     end
 
     before do
-      screening.allegations = allegations
+      screening[:allegations] = allegations
       stub_and_visit_edit_screening(screening)
     end
 
@@ -246,20 +268,27 @@ feature 'Allegations Sibling At Risk Validations' do
         expect(page).to have_content(sibling_at_risk_error)
         fill_in_react_select "allegations_#{victim2.id}_#{perpetrator.id}", with: 'Physical abuse'
         expect(page).not_to have_content(sibling_at_risk_error)
-        allegations.first.allegation_types = [
+        allegations.first[:types] = [
           'At risk, sibling abused', 'General neglect', 'Exploitation'
         ]
-        allegations << FactoryBot.build(
-          :allegation,
-          victim_id: victim2.id,
-          perpetrator_id: perpetrator.id,
-          screening_id: screening.id,
-          allegation_types: ['Physical abuse']
-        )
+        allegations << {
+          id: '1',
+          victim_person_id: victim2.id,
+          perpetrator_person_id: perpetrator.id,
+          screening_id: screening[:id],
+          types: ['Physical abuse']
+        }
         stub_screening_put_request_with_anything_and_return(
           screening,
           with_updated_attributes: {
-            allegations: allegations
+            allegations: allegations.collect do |allegation|
+              {
+                allegation_types: allegation[:types],
+                victim_id: allegation[:victim_person_id],
+                perpetrator_id: allegation[:perpetrator_person_id],
+                screening_id: screening[:id]
+              }
+            end
           }
         )
 
@@ -276,26 +305,23 @@ feature 'Allegations Sibling At Risk Validations' do
 
   context 'when two allegations against two perps for one victim who is marked at risk' do
     let(:allegations) do
-      [
-        FactoryBot.create(
-          :allegation,
-          victim_id: victim.id,
-          perpetrator_id: perpetrator.id,
-          screening_id: screening.id,
-          allegation_types: ['At risk, sibling abused', 'General neglect']
-        ),
-        FactoryBot.create(
-          :allegation,
-          victim_id: victim.id,
-          perpetrator_id: perpetrator2.id,
-          screening_id: screening.id,
-          allegation_types: ['Exploitation']
-        )
-      ]
+      [{
+        id: '1',
+        victim_person_id: victim.id,
+        perpetrator_person_id: perpetrator.id,
+        screening_id: screening[:id],
+        types: ['At risk, sibling abused', 'General neglect']
+      }, {
+        id: '2',
+        victim_person_id: victim.id,
+        perpetrator_person_id: perpetrator2.id,
+        screening_id: screening[:id],
+        types: ['Exploitation']
+      }]
     end
 
     before do
-      screening.allegations = allegations
+      screening[:allegations] = allegations
       stub_and_visit_edit_screening(screening)
     end
 
@@ -318,25 +344,32 @@ feature 'Allegations Sibling At Risk Validations' do
       stub_request(:put, intake_api_url(ExternalRoutes.intake_api_participant_path(victim.id)))
         .and_return(json_body(victim.to_json, status: 200))
 
-      new_allegation = FactoryBot.create(
-        :allegation,
-        victim_id: victim2.id,
-        perpetrator_id: perpetrator.id,
-        screening_id: screening.id,
-        allegation_types: ['Physical abuse']
-      )
+      new_allegation = {
+        id: '1',
+        victim_person_id: victim2.id,
+        perpetrator_person_id: perpetrator.id,
+        screening_id: screening[:id],
+        types: ['Physical abuse']
+      }
 
       within '.card.edit', text: 'Allegations' do
         expect(page).to have_content(sibling_at_risk_error)
         fill_in_react_select "allegations_#{victim2.id}_#{perpetrator.id}", with: 'Physical abuse'
         expect(page).not_to have_content(sibling_at_risk_error)
-        allegations.first.allegation_types = ['At risk, sibling abused', 'General neglect']
-        allegations.second.allegation_types = ['Exploitation', 'Physical abuse']
+        allegations.first[:types] = ['At risk, sibling abused', 'General neglect']
+        allegations.second[:types] = ['Exploitation', 'Physical abuse']
         allegations << new_allegation
         stub_screening_put_request_with_anything_and_return(
           screening,
           with_updated_attributes: {
-            allegations: allegations
+            allegations: allegations.collect do |allegation|
+              {
+                allegation_types: allegation[:types],
+                victim_id: allegation[:victim_person_id],
+                perpetrator_id: allegation[:perpetrator_person_id],
+                screening_id: screening[:id]
+              }
+            end
           }
         )
 

--- a/spec/features/screening/validations/allegations_validations_spec.rb
+++ b/spec/features/screening/validations/allegations_validations_spec.rb
@@ -7,24 +7,22 @@ feature 'Allegations Validations' do
   scenario 'User sees that allegations are required when decision is promote to referral' do
     perpetrator = FactoryBot.create(:participant, :perpetrator)
     victim = FactoryBot.create(:participant, :victim)
-    screening = FactoryBot.create(
-      :screening,
-      participants: [perpetrator, victim],
+    screening = {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      allegations: [],
+      safety_alerts: [],
+      participants: [perpetrator.as_json.symbolize_keys, victim.as_json.symbolize_keys],
       screening_decision: 'promote_to_referral'
-    )
-    allegation = FactoryBot.create(
-      :allegation,
-      victim_id: victim.id,
-      perpetrator_id: perpetrator.id,
-      screening_id: screening.id
-    )
-    screening.allegations << allegation
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    }
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_history_for_screening(screening)
     stub_empty_relationships
 
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     error_message = 'must include at least one allegation'
 

--- a/spec/features/screening/validations/cross_reports_validations_spec.rb
+++ b/spec/features/screening/validations/cross_reports_validations_spec.rb
@@ -6,17 +6,21 @@ require 'factory_bot'
 
 feature 'Cross Reports Validations' do
   let(:screening) do
-    FactoryBot.create(
-      :screening, cross_reports: [
-        FactoryBot.create(
-          :cross_report,
-          county_id: 'c41',
-          agencies: [
-            FactoryBot.create(:agency, id: nil, type: 'COUNTY_LICENSING')
-          ]
-        )
-      ]
-    )
+    {
+      id: '1',
+      incident_address: {},
+      allegations: [],
+      participants: [],
+      safety_alerts: [],
+      cross_reports: [{
+        id: '1',
+        county_id: 'c41',
+        agencies: [{
+          id: nil,
+          type: 'COUNTY_LICENSING'
+        }]
+      }]
+    }
   end
 
   context 'on the edit page' do
@@ -47,10 +51,12 @@ feature 'Cross Reports Validations' do
       context 'save with an agency' do
         before do
           stub_county_agencies('c41')
-          screening.cross_reports[0].agencies[0].id = 'EYIS9Nh75C'
+          screening[:cross_reports][0][:agencies][0][:id] = 'EYIS9Nh75C'
           stub_and_visit_edit_screening(screening)
-          stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
-            .and_return(json_body(screening.to_json, status: 201))
+          stub_request(
+            :put,
+            intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id]))
+          ).and_return(json_body(screening.to_json, status: 201))
         end
         scenario 'shows no error when filled in' do
           select 'Hoverment Agency', from: 'County licensing agency name'

--- a/spec/features/screening/validations/incident_information_validations_spec.rb
+++ b/spec/features/screening/validations/incident_information_validations_spec.rb
@@ -5,7 +5,16 @@ require 'spec_helper'
 require 'factory_bot'
 
 feature 'Incident Information Validations' do
-  let(:screening) { FactoryBot.create(:screening) }
+  let(:screening) do
+    {
+      id: '1',
+      incident_address: {},
+      cross_reports: [],
+      participants: [],
+      allegations: [],
+      safety_alerts: []
+    }
+  end
   let(:error_message) { 'The incident date and time cannot be in the future.' }
 
   context 'On the edit page' do
@@ -26,7 +35,15 @@ feature 'Incident Information Validations' do
 
       context 'with a screening saved with incident date in the future' do
         let(:screening) do
-          FactoryBot.create(:screening, incident_date: 30.years.from_now)
+          {
+            id: '1',
+            incident_address: {},
+            cross_reports: [],
+            participants: [],
+            allegations: [],
+            safety_alerts: [],
+            incident_date: 30.years.from_now
+          }
         end
         let(:valid_date) { 20.years.ago.iso8601 }
 
@@ -56,7 +73,15 @@ feature 'Incident Information Validations' do
 
     context 'for a screening that has incident date in the future' do
       let(:screening) do
-        FactoryBot.create :screening, incident_date: 5.years.from_now
+        {
+          id: '1',
+          incident_address: {},
+          cross_reports: [],
+          participants: [],
+          allegations: [],
+          safety_alerts: [],
+          incident_date: 5.years.from_now
+        }
       end
 
       scenario 'user sees error messages for invalid incident date on page load' do

--- a/spec/features/screening/validations/narrative_validations_spec.rb
+++ b/spec/features/screening/validations/narrative_validations_spec.rb
@@ -5,19 +5,29 @@ require 'spec_helper'
 require 'factory_bot'
 
 feature 'Narrative Card Validations' do
-  let(:screening) { FactoryBot.create(:screening, report_narrative: '') }
+  let(:screening) do
+    {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [],
+      allegations: [],
+      report_narrative: ''
+    }
+  end
   let(:error_message) { 'Please enter a narrative.' }
 
   context 'on the edit page' do
     before do
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
         .and_return(json_body(screening.to_json, status: 200))
-      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
         .and_return(json_body(screening.to_json, status: 200))
       stub_empty_relationships
       stub_empty_history_for_screening(screening)
 
-      visit edit_screening_path(id: screening.id)
+      visit edit_screening_path(id: screening[:id])
 
       # TODO: remove this once we can consistently have a fresh page for these specs
       page.driver.browser.navigate.refresh

--- a/spec/features/screening/validations/person_age_validation_spec.rb
+++ b/spec/features/screening/validations/person_age_validation_spec.rb
@@ -5,10 +5,18 @@ require 'spec_helper'
 
 feature 'Person Information Validations' do
   let(:screening) do
-    FactoryBot.create :screening,
-      participants: [person],
+    {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [person.as_json.symbolize_keys],
+      allegations: [],
+      report_narrative: '',
       started_at: Time.new(2018, 12, 13)
+    }
   end
+
   let(:person_name) { "#{person.first_name} #{person.last_name}" }
 
   before do

--- a/spec/features/screening/validations/person_name_validation_spec.rb
+++ b/spec/features/screening/validations/person_name_validation_spec.rb
@@ -5,10 +5,18 @@ require 'spec_helper'
 
 feature 'Person Information Validations' do
   let(:screening) do
-    FactoryBot.create :screening,
-      participants: [person],
+    {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [person.as_json.symbolize_keys],
+      allegations: [],
+      report_narrative: '',
       started_at: Time.new(2018, 12, 13)
+    }
   end
+
   let(:person_name) { "#{person.first_name} #{person.last_name}" }
 
   before do

--- a/spec/features/screening/validations/person_ssn_validation_spec.rb
+++ b/spec/features/screening/validations/person_ssn_validation_spec.rb
@@ -5,10 +5,18 @@ require 'spec_helper'
 
 feature 'Person Information Validations' do
   let(:screening) do
-    FactoryBot.create :screening,
-      participants: [person],
+    {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [person.as_json.symbolize_keys],
+      allegations: [],
+      report_narrative: '',
       started_at: Time.new(2018, 12, 13)
+    }
   end
+
   let(:person_name) { "#{person.first_name} #{person.last_name}" }
 
   before do

--- a/spec/features/screening/validations/screening_decision_validations_spec.rb
+++ b/spec/features/screening/validations/screening_decision_validations_spec.rb
@@ -10,23 +10,18 @@ feature 'Screening Decision Validations' do
   let(:screening_decision_detail) { nil }
   let(:additional_information) { nil }
   let(:screening) do
-    FactoryBot.create(
-      :screening,
-      participants: [perpetrator, victim],
+    {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      allegations: [],
+      safety_alerts: [],
+      participants: [perpetrator.as_json.symbolize_keys, victim.as_json.symbolize_keys],
       screening_decision_detail: screening_decision_detail,
       additional_information: additional_information,
       screening_decision: screening_decision
-    )
-  end
-
-  before do
-    allegation = FactoryBot.create(
-      :allegation,
-      victim_id: victim.id,
-      perpetrator_id: perpetrator.id,
-      screening_id: screening.id
-    )
-    screening.allegations << allegation
+    }
   end
 
   context 'When page is opened in edit mode' do
@@ -236,7 +231,7 @@ feature 'Screening Decision Validations' do
       let(:screening_decision) { nil }
 
       scenario 'do not show error on restriction_rationale' do
-        stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+        stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
           .and_return(json_body(screening.to_json, status: 200))
         blur_field
         should_not_have_content error_message, inside: '#decision-card.edit'

--- a/spec/features/screening/validations/screening_information_validations_spec.rb
+++ b/spec/features/screening/validations/screening_information_validations_spec.rb
@@ -5,7 +5,17 @@ require 'spec_helper'
 require 'factory_bot'
 
 feature 'Screening Information Validations' do
-  let(:screening) { FactoryBot.create(:screening) }
+  let(:screening) do
+    {
+      id: '1',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [],
+      allegations: [],
+      safety_alerts: []
+    }
+  end
 
   context 'On the edit page' do
     before do
@@ -85,8 +95,18 @@ feature 'Screening Information Validations' do
 
       context 'with a screening saved with end date in the future' do
         let(:screening) do
-          FactoryBot.create(:screening, ended_at: 30.years.from_now)
+          {
+            id: '1',
+            incident_address: {},
+            addresses: [],
+            cross_reports: [],
+            participants: [],
+            allegations: [],
+            started_at: Time.now,
+            ended_at: 30.years.from_now
+          }
         end
+
         let(:valid_date) { 20.years.ago.iso8601 }
 
         scenario 'show card shows errors until the date is not in the future' do
@@ -133,7 +153,18 @@ feature 'Screening Information Validations' do
       end
 
       context 'with a screening that also has an end date' do
-        let(:screening) { FactoryBot.create :screening, ended_at: 10.years.ago }
+        let(:screening) do
+          {
+            id: '1',
+            incident_address: {},
+            addresses: [],
+            cross_reports: [],
+            participants: [],
+            allegations: [],
+            started_at: Time.now,
+            ended_at: 10.years.ago
+          }
+        end
 
         scenario 'displays an error if the user enters a start date that is after the end date' do
           validate_message_as_user_interacts_with_date_field(
@@ -148,7 +179,15 @@ feature 'Screening Information Validations' do
 
       context 'with a screening saved with start date in the future' do
         let(:screening) do
-          FactoryBot.create(:screening, started_at: 20.years.from_now)
+          {
+            id: '1',
+            incident_address: {},
+            addresses: [],
+            cross_reports: [],
+            participants: [],
+            allegations: [],
+            started_at: 20.years.from_now
+          }
         end
 
         scenario 'show card shows errors until the date is not in the future' do
@@ -163,7 +202,16 @@ feature 'Screening Information Validations' do
 
       context 'With a screening saved with start dates after the end date' do
         let(:screening) do
-          FactoryBot.create(:screening, started_at: 10.years.ago, ended_at: 20.years.ago)
+          {
+            id: '1',
+            incident_address: {},
+            addresses: [],
+            cross_reports: [],
+            participants: [],
+            allegations: [],
+            started_at: 10.years.ago,
+            ended_at: 20.years.ago
+          }
         end
 
         scenario 'show card shows errors until the start date is before the end date' do
@@ -186,12 +234,12 @@ feature 'Screening Information Validations' do
   context 'On the show page' do
     let(:show_card) { '#screening-information-card.show' }
     before do
-      stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+      stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
         .and_return(json_body(screening.to_json, status: 200))
       stub_empty_relationships
       stub_empty_history_for_screening(screening)
 
-      visit screening_path(id: screening.id)
+      visit screening_path(id: screening[:id])
     end
 
     scenario 'user sees error messages for required fields page load' do
@@ -202,7 +250,17 @@ feature 'Screening Information Validations' do
 
     context 'for a screening that has a saved dates in the future' do
       let(:screening) do
-        FactoryBot.create :screening, started_at: 5.years.from_now, ended_at: 10.years.from_now
+        {
+          id: '1',
+          incident_address: {},
+          addresses: [],
+          cross_reports: [],
+          participants: [],
+          allegations: [],
+          safety_alerts: [],
+          started_at: 5.years.from_now,
+          ended_at: 10.years.from_now
+        }
       end
 
       scenario 'user sees error messages for dates being in the future on page load' do
@@ -213,7 +271,17 @@ feature 'Screening Information Validations' do
 
     context 'for a screening saved with the start date after the end date' do
       let(:screening) do
-        FactoryBot.create :screening, started_at: 5.years.ago, ended_at: 10.years.ago
+        {
+          id: '1',
+          incident_address: {},
+          addresses: [],
+          cross_reports: [],
+          participants: [],
+          allegations: [],
+          safety_alerts: [],
+          started_at: 5.years.ago,
+          ended_at: 10.years.ago
+        }
       end
 
       scenario 'user sees error messages for start date being after end date page load' do

--- a/spec/features/screening/worker_safety_spec.rb
+++ b/spec/features/screening/worker_safety_spec.rb
@@ -5,12 +5,18 @@ require 'spec_helper'
 require 'factory_bot'
 
 feature 'worker safety card' do
-  scenario 'user edits worker safety card from screening show page and cancels' do
-    existing_screening = FactoryBot.create(
-      :screening,
+  let(:existing_screening) do
+    {
+      id: '1',
+      incident_address: {},
+      allegations: [],
+      cross_reports: [],
+      participants: [],
       safety_information: 'Important safety stuff',
       safety_alerts: ['Dangerous Environment']
-    )
+    }
+  end
+  scenario 'user edits worker safety card from screening show page and cancels' do
     stub_and_visit_show_screening(existing_screening)
     click_link 'Edit worker safety'
 
@@ -38,8 +44,7 @@ feature 'worker safety card' do
   end
 
   scenario 'user edits worker safety card from screening edit page and cancels' do
-    existing_screening = FactoryBot.create(
-      :screening,
+    existing_screening.merge!(
       safety_information: 'Important safety stuff',
       safety_alerts: ['Dangerous Environment']
     )
@@ -63,8 +68,7 @@ feature 'worker safety card' do
   end
 
   scenario 'user edits worker safety card from screening show page and saves' do
-    existing_screening = FactoryBot.create(
-      :screening,
+    existing_screening.merge!(
       safety_information: 'Important safety stuff',
       safety_alerts: ['Dangerous Environment']
     )
@@ -80,12 +84,12 @@ feature 'worker safety card' do
       fill_in_react_select 'Worker Safety Alerts', with: ['Firearms in Home']
     end
 
-    existing_screening.safety_information = 'Something else'
-    existing_screening.safety_alerts = ['Dangerous Environment', 'Firearms in Home']
+    existing_screening[:safety_information] = 'Something else'
+    existing_screening[:safety_alerts] = ['Dangerous Environment', 'Firearms in Home']
+    existing_screening[:address] = existing_screening.delete(:incident_address)
     stub_request(
-      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
-    ).with(json_body(as_json_without_root_id(existing_screening)))
-      .and_return(json_body(existing_screening.to_json))
+      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening[:id]))
+    ).and_return(json_body(existing_screening.to_json))
 
     within '#worker-safety-card.edit' do
       click_button 'Save'
@@ -93,8 +97,8 @@ feature 'worker safety card' do
 
     expect(
       a_request(
-        :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
-      ).with(json_body(as_json_without_root_id(existing_screening)))
+        :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening[:id]))
+      )
     ).to have_been_made
 
     within '#worker-safety-card.show' do
@@ -105,8 +109,7 @@ feature 'worker safety card' do
   end
 
   scenario 'user edits worker safety card from screening edit page and saves' do
-    existing_screening = FactoryBot.create(
-      :screening,
+    existing_screening.merge!(
       safety_information: 'Important safety stuff',
       safety_alerts: ['Dangerous Environment']
     )
@@ -123,12 +126,12 @@ feature 'worker safety card' do
         with: ['Severe Mental Health Status'], exit_key: :tab
     end
 
-    existing_screening.safety_information = 'Something else'
-    existing_screening.safety_alerts = ['Dangerous Environment', 'Firearms in Home']
+    existing_screening[:safety_information] = 'Something else'
+    existing_screening[:safety_alerts] = ['Dangerous Environment', 'Firearms in Home']
+    existing_screening[:address] = existing_screening.delete(:incident_address)
     stub_request(
-      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
-    ).with(json_body(as_json_without_root_id(existing_screening)))
-      .and_return(json_body(existing_screening.to_json))
+      :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening[:id]))
+    ).and_return(json_body(existing_screening.to_json))
 
     within '#worker-safety-card.edit' do
       click_button 'Save'
@@ -136,8 +139,8 @@ feature 'worker safety card' do
 
     expect(
       a_request(
-        :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening.id))
-      ).with(json_body(as_json_without_root_id(existing_screening)))
+        :put, intake_api_url(ExternalRoutes.intake_api_screening_path(existing_screening[:id]))
+      )
     ).to have_been_made
 
     within '#worker-safety-card.show' do

--- a/spec/features/snapshot/create_snapshot_spec.rb
+++ b/spec/features/snapshot/create_snapshot_spec.rb
@@ -100,15 +100,15 @@ feature 'Create Snapshot' do
 
   context 'both snapshot and screening are enabled' do
     let(:new_screening) do
-      FactoryBot.create(
-        :screening,
-        indexable: true,
-        reference: 'DQJIYK',
-        safety_alerts: [],
-        safety_information: nil,
-        address: { city: nil },
-        assignee: nil
-      )
+      {
+        id: '1',
+        incident_address: {},
+        addresses: [],
+        cross_reports: [],
+        participants: [],
+        allegations: [],
+        safety_alerts: []
+      }
     end
 
     before do
@@ -126,7 +126,7 @@ feature 'Create Snapshot' do
       stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
         .and_return(json_body(new_screening.to_json, status: 201))
       stub_request(
-        :get, intake_api_url(ExternalRoutes.intake_api_screening_path(new_screening.id))
+        :get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id]))
       ).and_return(json_body(new_screening.to_json, status: 200))
       click_button 'Start Screening'
 
@@ -141,10 +141,14 @@ feature 'Create Snapshot' do
         end
       end
       stub_person_search(search_term: 'Ma', person_response: search_response)
-      person = FactoryBot.create(:participant, first_name: 'Marge', screening_id: new_screening.id)
+      person = FactoryBot.create(
+        :participant,
+        first_name: 'Marge',
+        screening_id: new_screening[:id]
+      )
       stub_request(
         :post,
-        intake_api_url(ExternalRoutes.intake_api_screening_people_path(new_screening.id))
+        intake_api_url(ExternalRoutes.intake_api_screening_people_path(new_screening[:id]))
       ).and_return(json_body(person.to_json, status: 201))
 
       within '#search-card', text: 'Search' do

--- a/spec/features/system_codes_spec.rb
+++ b/spec/features/system_codes_spec.rb
@@ -10,7 +10,7 @@ feature 'System codes' do
       .and_return(json_body({ id: '1' }.to_json, status: 200))
     stub_request(:get, ferb_api_url(FerbRoutes.lov_path))
       .and_return(json_body([].to_json, status: 200))
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(1)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(1)))
       .and_return(json_body({}.to_json, status: 200))
     stub_request(:get, ferb_api_url(FerbRoutes.screening_history_of_involvements_path(1)))
       .and_return(json_body([].to_json, status: 200))

--- a/spec/javascripts/reducers/allegationsFormReducerSpec.js
+++ b/spec/javascripts/reducers/allegationsFormReducerSpec.js
@@ -18,7 +18,7 @@ describe('narrativeFormReducer', () => {
 
   describe('on FETCH_SCREENING_COMPLETE', () => {
     it('returns the allegations form', () => {
-      const allegations = [{id: '123', victim_id: '1', perpetrator_id: '2', allegation_types: ['General neglect']}]
+      const allegations = [{id: '123', victim_person_id: '1', perpetrator_person_id: '2', types: ['General neglect']}]
       const action = fetchScreeningSuccess({allegations})
       expect(allegationsFormReducer(List(), action)).toEqualImmutable(
         fromJS([

--- a/spec/javascripts/reducers/incidentInformationFormReducerSpec.js
+++ b/spec/javascripts/reducers/incidentInformationFormReducerSpec.js
@@ -33,7 +33,7 @@ describe('incidentInformationFormReducer', () => {
       const screening = {
         incident_date: 'new incident date',
         incident_county: 'new incident county',
-        address: {
+        incident_address: {
           city: 'new city',
           state: 'new state',
           street_address: 'new street address',

--- a/spec/javascripts/reducers/screeningReducerSpec.js
+++ b/spec/javascripts/reducers/screeningReducerSpec.js
@@ -45,10 +45,25 @@ describe('screeningReducer', () => {
 
   describe('on FETCH_SCREENING_COMPLETE', () => {
     it('returns the screening from the action on success', () => {
-      const screening = {id: '1'}
+      const screening = {
+        id: '1',
+        incident_date: null,
+        incident_county: null,
+        incident_address: {},
+        location_type: null,
+        allegations: [],
+      }
       const action = fetchScreeningSuccess(screening)
       expect(screeningReducer(Map(), action)).toEqualImmutable(
-        Map({id: '1', fetch_status: 'FETCHED'})
+        fromJS({
+          id: '1',
+          incident_date: null,
+          incident_county: null,
+          address: {street_address: undefined, city: undefined, state: undefined, zip: undefined},
+          location_type: null,
+          allegations: [],
+          fetch_status: 'FETCHED',
+        })
       )
     })
     it('returns the last state on failure', () => {

--- a/spec/javascripts/store/storeSpec.js
+++ b/spec/javascripts/store/storeSpec.js
@@ -73,13 +73,20 @@ describe('Store', () => {
       name: 'Mock screening',
       participants: [{id: '2', legacy_id: '3', screening_id: '1'}],
       allegations: [],
-      address: {},
+      incident_address: {},
     })
     const participants = screening.get('participants')
     const action = fetchScreeningSuccess(screening.toJS())
     store.dispatch(action)
     expect(store.getState().get('screening')).toEqualImmutable(
-      screening.set('fetch_status', 'FETCHED')
+      fromJS({
+        id: '1',
+        name: 'Mock screening',
+        participants: [{id: '2', legacy_id: '3', screening_id: '1'}],
+        allegations: [],
+        address: {street_address: undefined, city: undefined, state: undefined, zip: undefined},
+        fetch_status: 'FETCHED',
+      })
     )
     expect(store.getState().get('participants')).toEqualImmutable(participants)
   })

--- a/spec/repositories/screening_repository_spec.rb
+++ b/spec/repositories/screening_repository_spec.rb
@@ -31,15 +31,15 @@ describe ScreeningRepository do
     end
 
     before do
-      expect(IntakeAPI).to receive(:make_api_call)
-        .with(security_token, "/api/v1/screenings/#{screening_id}", :get)
+      expect(FerbAPI).to receive(:make_api_call)
+        .with(security_token, "/intake/screenings/#{screening_id}", :get)
         .and_return(response)
     end
 
     it 'returns the existing screening' do
       existing_screening = described_class.find(security_token, screening_id)
-      expect(existing_screening.id).to eq(screening_id)
-      expect(existing_screening.name).to eq('Existing Screening')
+      expect(existing_screening['id']).to eq(screening_id)
+      expect(existing_screening['name']).to eq('Existing Screening')
     end
   end
 

--- a/spec/support/helpers/screening_helpers.rb
+++ b/spec/support/helpers/screening_helpers.rb
@@ -53,24 +53,24 @@ module ScreeningHelpers
   end
 
   def stub_and_visit_edit_screening(screening)
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
 
-    visit edit_screening_path(id: screening.id)
+    visit edit_screening_path(id: screening[:id])
 
     # TODO: remove this once we can consistently have a fresh page for these specs
     page.driver.browser.navigate.refresh
   end
 
   def stub_and_visit_show_screening(screening)
-    stub_request(:get, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
     stub_empty_relationships
     stub_empty_history_for_screening(screening)
 
-    visit screening_path(id: screening.id)
+    visit screening_path(id: screening[:id])
 
     # TODO: remove this once we can consistently have a fresh page for these specs
     page.driver.browser.navigate.refresh

--- a/spec/support/helpers/webmock_helpers.rb
+++ b/spec/support/helpers/webmock_helpers.rb
@@ -7,9 +7,10 @@ module WebmockHelpers
     screening,
     with_updated_attributes: {}
   )
-    screening.assign_attributes(with_updated_attributes)
-    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening.id)))
-      .and_return(json_body(screening.to_json))
+    api_response = screening.merge(with_updated_attributes)
+    api_response.delete(:incident_address)
+    stub_request(:put, intake_api_url(ExternalRoutes.intake_api_screening_path(screening[:id])))
+      .and_return(json_body(api_response.to_json))
   end
 
   def stub_person_find(id:, person_response:)


### PR DESCRIPTION
### Jira Story

- [Point Intake to Ferb for Screening 'Get' HOT-1952](https://osi-cwds.atlassian.net/browse/HOT-1952)

## Description
These changes are to get the screening from Ferb instead of Intake API. The Screenings are currently being created through Ferb, and being updated and retrieved through Intake API. This change is to retrieve them through Ferb.

## Notes:
- Some of the implementation code is temporary and will be removed after implementing update. Specifically, the parts in the reducers that deal with responses from both Intake API and Ferb.
- Some of the test code is temporary and will be changed after implementing:
-- using `particpant.as_json.symbolize_keys` as the factoried objects are being converted to JSON to be used in the response. I figured, we can gradually remove the factories or modify them as we see fit. Its too much work to do it all at once.
-- removing the `stub_request().with(body: payload)` and `expect(a_request().with(body: payload))`. The request body and response from Intake API is different than Ferb. After implementing update, we will get from Ferb, and update using Ferb, and we can expect as a response the same screening we are sending. Therefore, I think it makes more sense to remove these for now, then to complicate the tests temporarily.
-- adding modifications to `api_screening` when stubbing, such as deleting incident_address
- Stubbing screenings currently requires empty objects and arrays for cards we are not stubbing. IMO the front end should not explode if the api sends back nothing instead of and empty array in the JSON. A side effect would be that we don't have to stub empty parts of the responses in our tests. I am open to making this change now.

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [x] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

