### PR TITLE
SNAP-52 Clear search results when starting over a Snapshot

### DIFF
--- a/app/javascript/snapshots/SnapshotPage.jsx
+++ b/app/javascript/snapshots/SnapshotPage.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import {connect} from 'react-redux'
 import {createSnapshot, clearSnapshot} from 'actions/snapshotActions'
 import {clearPeople, createSnapshotPerson} from 'actions/personCardActions'
+import {clear as clearSearch, setSearchTerm} from 'actions/peopleSearchActions'
 import {clearHistoryOfInvolvement} from 'actions/historyOfInvolvementActions'
 import {clearRelationships} from 'actions/relationshipsActions'
 import PersonSearchFormContainer from 'containers/common/PersonSearchFormContainer'
@@ -117,7 +118,7 @@ const mapStateToProps = (state) => ({
   participants: state.get('participants').toJS(),
 })
 
-const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch) => ({
   createSnapshot: () => dispatch(createSnapshot()),
   createSnapshotPerson: (id) => dispatch(createSnapshotPerson(id)),
   startOver: () => {
@@ -125,6 +126,8 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(clearPeople())
     dispatch(clearHistoryOfInvolvement())
     dispatch(clearRelationships())
+    dispatch(clearSearch())
+    dispatch(setSearchTerm(''))
   },
   unmount: () => {
     dispatch(clearPeople())

--- a/spec/javascripts/components/SnapshotPageSpec.jsx
+++ b/spec/javascripts/components/SnapshotPageSpec.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
-import {SnapshotPage} from 'snapshots/SnapshotPage'
+import {SnapshotPage, mapDispatchToProps} from 'snapshots/SnapshotPage'
+import {clear, setSearchTerm} from 'actions/peopleSearchActions'
 import {shallow} from 'enzyme'
 
 describe('SnapshotPage', () => {
@@ -39,5 +40,19 @@ describe('SnapshotPage', () => {
     const snapshotPage = renderSnapshotPage({unmount})
     snapshotPage.unmount()
     expect(unmount).toHaveBeenCalled()
+  })
+
+  describe('mapDispatchToProps', () => {
+    describe('starting over', () => {
+      it('clears search results', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const props = mapDispatchToProps(dispatch)
+
+        props.startOver()
+
+        expect(dispatch).toHaveBeenCalledWith(clear())
+        expect(dispatch).toHaveBeenCalledWith(setSearchTerm(''))
+      })
+    })
   })
 })


### PR DESCRIPTION

### Jira Story

- [Partial last name stayed in search box after clicking on Start Over search results cleared SNAP-52](https://osi-cwds.atlassian.net/browse/SNAP-52)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This adds two new actions to the many that are fired when resetting
a Snapshot. Clearing the search results prevents any lingering info
the user entered into the search from carrying over into the next
Snapshot.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

This workflow is not currently covered by feature tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

