### PR TITLE
Purify buildSelector

### DIFF
--- a/app/javascript/selectors/index.js
+++ b/app/javascript/selectors/index.js
@@ -3,9 +3,7 @@ export const findByCategory = (statusCodes = List(), selectedCategory) => (
   statusCodes.filter(({category}) => category === selectedCategory)
 )
 
-export const buildSelector = (...funcs) => (
-  (arg) => {
-    var selector = funcs.pop()
-    return selector(...(funcs.map((f) => (f(arg)))))
-  }
-)
+export const buildSelector = (...funcs) => {
+  const selector = funcs.pop()
+  return (arg) => selector(...(funcs.map((f) => (f(arg)))))
+}

--- a/spec/javascripts/selectors/indexSpec.js
+++ b/spec/javascripts/selectors/indexSpec.js
@@ -1,0 +1,34 @@
+import {buildSelector} from 'selectors'
+
+describe('buildSelector', () => {
+  it('accepts a single selector function which receives no args', () => {
+    const selector = jasmine.createSpy('selector').and.returnValue('goodbye')
+    const built = buildSelector(selector)
+
+    expect(built('hello')).toEqual('goodbye')
+
+    expect(selector).toHaveBeenCalled()
+    expect(selector).not.toHaveBeenCalledWith('hello')
+  })
+
+  it('calls intermediate selectors', () => {
+    const final = (a, b) => a + b
+    const getFirst = (s) => s[0]
+    const getLast = (s) => s[s.length - 1]
+    const built = buildSelector(getFirst, getLast, final)
+
+    expect(built('Hello, world!')).toEqual('H!')
+  })
+
+  it('can be called more than once', () => {
+    const final = (a, b) => a + b
+    const getFirst = (s) => s[0]
+    const getLast = (s) => s[s.length - 1]
+    const built = buildSelector(getFirst, getLast, final)
+
+    expect(built('1 For the Money!')).toEqual('1!')
+    expect(built('2 For The Show!')).toEqual('2!')
+    expect(built('3 To Make Ready!')).toEqual('3!')
+    expect(built('4 To Go!')).toEqual('4!')
+  })
+})


### PR DESCRIPTION
### Jira Story

No story. Came up when debugging SNAP-46 with Manish

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->

buildSelector was mutating its internal function state every time
it was called, which means that once built, you can only call a
selector once. We happen to be avoiding this by consistenly
building a new selector every time we call something using this,
which is likely horrendous for performance.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

While this is a bug fix, I also consider it refactoring, because the user will not see any difference. This simply allows us to structure our selectors a little more easily going forward.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

