### PR TITLE
SNAP-46 - Display last known phone number in search results

### DIFF
--- a/app/javascript/selectors/peopleSearchSelectors.js
+++ b/app/javascript/selectors/peopleSearchSelectors.js
@@ -10,6 +10,7 @@ import {
   mapRaces,
   mapEthnicities,
   mapAddress,
+  mapPhoneNumber,
 } from 'utils/peopleSearchHelper'
 import {isCommaSuffix, formatHighlightedSuffix} from 'utils/nameFormatter'
 import {phoneNumberFormatter} from 'utils/phoneNumberFormatter'
@@ -28,10 +29,10 @@ export const getLastResultsSortValueSelector = (state) => {
 
 const formatSSN = (ssn) => ssn && ssn.replace(/(\d{3})(\d{2})(\d{4})/, '$1-$2-$3')
 const formatDOB = (dob, highlight) => (highlight ? '<em>'.concat(dob, '</em>') : dob)
-const formatPhoneNumber = (phoneNumber) => phoneNumber && Map({
+const formatPhoneNumber = (phoneNumber) => (phoneNumber ? Map({
   number: phoneNumberFormatter(phoneNumber.get('number')),
   type: phoneNumber.get('type'),
-})
+}) : null)
 
 // Try to find a match from a list of highlights by stripping out <em> tags
 const highlightNameField = (exactName, highlights) => (highlights.find(
@@ -81,7 +82,7 @@ export const getPeopleResultsSelector = (state) => getPeopleSearchSelector(state
       ssn: formatSSN(highlight.getIn(['ssn', 0], result.get('ssn'))),
       clientCounty: systemCodeDisplayValue(result.getIn(['client_county', 'id']), state.get('counties')),
       address: mapAddress(state, result),
-      phoneNumber: formatPhoneNumber(result.getIn(['phone_numbers', 0], null)),
+      phoneNumber: formatPhoneNumber((mapPhoneNumber(result) || List()).first()),
       isSensitive: mapIsSensitive(result),
       isSealed: mapIsSealed(result),
     })

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -59,6 +59,7 @@ feature 'searching a participant in autocompleter' do
                     address.with_state_code('NY')
                     address.with_city('Springfield')
                     address.with_zip('11222')
+                    address.with_phone_number(number: '6035550123', type: 'Home')
                     address.with_type do
                       AddressTypeSearchResultBuilder.build('Home')
                     end
@@ -96,7 +97,7 @@ feature 'searching a participant in autocompleter' do
         expect(page).to have_content 'Hispanic/Latino'
         expect(page).to have_content 'Language'
         expect(page).to have_content 'French (Primary), Italian'
-        expect(page).to have_content 'Home(971) 287-6774'
+        expect(page).to have_content 'Home(603) 555-0123'
         expect(page).to have_content 'SSN'
         expect(page).to have_content '1234'
         expect(page).to have_content '123-23-1234'
@@ -213,7 +214,7 @@ feature 'searching a participant in autocompleter' do
       end
     end
 
-    scenario 'person without phone_numbers' do
+    scenario 'person without last known phone_numbers' do
       search_response = PersonSearchResponseBuilder.build do |response|
         response.with_total(1)
         response.with_hits do
@@ -223,7 +224,8 @@ feature 'searching a participant in autocompleter' do
               builder.with_middle_name('Jacqueline')
               builder.with_last_name('Simpson')
               builder.with_name_suffix('md')
-              builder.with_phone_number({})
+              # Phone numbers should be pulled from addresses, not here.
+              builder.with_phone_number(number: '6035550123', type: 'Home')
             end
           ]
         end

--- a/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
+++ b/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
@@ -94,6 +94,10 @@ describe('peopleSearchSelectors', () => {
               state_code: 'state',
               zip: '11344',
               type: {id: RESIDENCE_TYPE},
+              phone_numbers: [{
+                number: '2126666666',
+                type: 'Home',
+              }],
             }],
             phone_numbers: [{
               id: '2',
@@ -148,7 +152,7 @@ describe('peopleSearchSelectors', () => {
             streetAddress: '234 Fake Street',
           },
           phoneNumber: {
-            number: '(994) 907-6774',
+            number: '(212) 666-6666',
             type: 'Home',
           },
           isSensitive: true,
@@ -157,7 +161,7 @@ describe('peopleSearchSelectors', () => {
       )
     })
 
-    it('maps the first address and phone number result to address and phone number', () => {
+    it('maps the first address and its phone number result to address and phone number', () => {
       const peopleSearch = {
         results: [{
           _source: {
@@ -169,6 +173,10 @@ describe('peopleSearchSelectors', () => {
               state_code: 'state',
               zip: '11344',
               type: {id: RESIDENCE_TYPE},
+              phone_numbers: [{
+                number: '2125550123',
+                type: 'Home',
+              }],
             }, {
               id: '2',
               street_number: '2',
@@ -177,6 +185,10 @@ describe('peopleSearchSelectors', () => {
               state_code: 'state',
               zip: '11222',
               type: {id: RESIDENCE_TYPE},
+              phone_numbers: [{
+                number: '1231231234',
+                type: 'Home',
+              }],
             }],
             phone_numbers: [{
               number: '9949076774',
@@ -210,7 +222,7 @@ describe('peopleSearchSelectors', () => {
       )
       expect(peopleResults.getIn([0, 'phoneNumber'])).toEqualImmutable(
         Map({
-          number: '(994) 907-6774',
+          number: '(212) 555-0123',
           type: 'Home',
         })
       )


### PR DESCRIPTION
### Jira Story

- [Snapshot search should return last known phone number for people added SNAP-46](https://osi-cwds.atlassian.net/browse/SNAP-46)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->

We were previously only displaying the last known phone number in
the person information card. This unifies which phone number we
display, so it is always the same in both cases. Note that in most
of our test data, these happen to be the same anyways.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

