### PR TITLE
HOT-1947 - Save Screening Info within generateBabyDoeSaga

### DIFF
--- a/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
+++ b/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
@@ -55,12 +55,13 @@ export const mergeProps = (stateProps, dispatchProps, ownProps) => ({
   ...dispatchProps,
   ...ownProps,
   onSave: () => {
-    dispatchProps.dispatch(saveCard(cardName))
-    dispatchProps.dispatch(touchAllFields())
-    dispatchProps.dispatch(setCardMode(cardName, SHOW_MODE))
     if (stateProps.reportType === 'ssb' && stateProps.persistedReportType !== 'ssb') {
       dispatchProps.dispatch(generateBabyDoe(stateProps.screeningId))
+    } else {
+      dispatchProps.dispatch(saveCard(cardName))
     }
+    dispatchProps.dispatch(touchAllFields())
+    dispatchProps.dispatch(setCardMode(cardName, SHOW_MODE))
   },
 })
 

--- a/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
@@ -34,9 +34,10 @@ describe('ScreeningInformationFormContainer', () => {
         onSave()
 
         expect(dispatch).toHaveBeenCalledWith(saveCard(cardName))
+        expect(dispatch).not.toHaveBeenCalledWith(generateBabyDoe('3'))
+
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
         expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
-        expect(dispatch).not.toHaveBeenCalledWith(generateBabyDoe('3'))
       })
 
       it('triggers SSB when report type changes to SSB', () => {
@@ -45,10 +46,11 @@ describe('ScreeningInformationFormContainer', () => {
 
         onSave()
 
-        expect(dispatch).toHaveBeenCalledWith(saveCard(cardName))
+        expect(dispatch).not.toHaveBeenCalledWith(saveCard(cardName))
+        expect(dispatch).toHaveBeenCalledWith(generateBabyDoe('3'))
+
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
         expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
-        expect(dispatch).toHaveBeenCalledWith(generateBabyDoe('3'))
       })
 
       it('does not trigger SSB when report type was already SSB', () => {
@@ -58,9 +60,10 @@ describe('ScreeningInformationFormContainer', () => {
         onSave()
 
         expect(dispatch).toHaveBeenCalledWith(saveCard(cardName))
+        expect(dispatch).not.toHaveBeenCalledWith(generateBabyDoe('3'))
+
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
         expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
-        expect(dispatch).not.toHaveBeenCalledWith(generateBabyDoe('3'))
       })
     })
   })

--- a/spec/javascripts/sagas/generateBabyDoeSagaSpec.js
+++ b/spec/javascripts/sagas/generateBabyDoeSagaSpec.js
@@ -1,18 +1,26 @@
-import {takeEvery, call, put} from 'redux-saga/effects'
+import {fromJS} from 'immutable'
+import {takeEvery, call, put, select} from 'redux-saga/effects'
 import {setAllegationTypes} from 'actions/allegationsFormActions'
 import {
   createPersonFailure,
   createPersonSuccess,
 } from 'actions/personCardActions'
 import {GENERATE_BABY_DOE} from 'actions/safelySurrenderedBabyActions'
-import {saveCard} from 'actions/screeningActions'
+import {
+  saveCard,
+  saveFailure,
+  saveSuccess,
+} from 'actions/screeningActions'
 import {cardName as allegationsCardName} from 'containers/screenings/AllegationsFormContainer'
 import {babyDoe, caretakerDoe} from 'data/participants'
 import {
   generateBabyDoe,
   generateBabyDoeSaga,
 } from 'sagas/generateBabyDoeSaga'
-import {post} from 'utils/http'
+import {
+  getScreeningWithEditsSelector as getScreeningWithScreeningInformationEditsSelector,
+} from 'selectors/screening/screeningInformationFormSelectors'
+import * as http from 'utils/http'
 
 describe('generateBabyDoeSaga', () => {
   it('triggers SSB info creation on GENERATE_BABY_DOE', () => {
@@ -24,9 +32,23 @@ describe('generateBabyDoeSaga', () => {
 describe('triggerSSB', () => {
   const screening_id = '1'
 
+  const screening = {
+    id: screening_id,
+    report_type: 'ssb',
+  }
+
+  const saveScreening = (gen) => {
+    gen.next()
+    gen.next(fromJS(screening))
+    gen.next(screening)
+  }
+
   it('adds Baby Doe and Caretaker Doe', () => {
     const gen = generateBabyDoe({payload: screening_id})
-    expect(gen.next().value).toEqual(call(post, '/api/v1/participants', {
+    expect(gen.next().value).toEqual(select(getScreeningWithScreeningInformationEditsSelector))
+    expect(gen.next(fromJS(screening)).value).toEqual(call(http.put, '/api/v1/screenings/1', {screening}))
+    expect(gen.next('response').value).toEqual(put(saveSuccess('response')))
+    expect(gen.next().value).toEqual(call(http.post, '/api/v1/participants', {
       participant: {
         screening_id,
         ...babyDoe,
@@ -38,7 +60,7 @@ describe('triggerSSB', () => {
 
     expect(putBaby.value).toEqual(put(createPersonSuccess(babyResponse)))
 
-    expect(gen.next().value).toEqual(call(post, '/api/v1/participants', {
+    expect(gen.next().value).toEqual(call(http.post, '/api/v1/participants', {
       participant: {
         screening_id,
         ...caretakerDoe,
@@ -60,6 +82,7 @@ describe('triggerSSB', () => {
 
   it('puts createPersonFailure when Baby Doe fails', () => {
     const gen = generateBabyDoe({payload: screening_id})
+    saveScreening(gen)
     gen.next()
 
     const error = {responseJSON: 'some error'}
@@ -68,11 +91,20 @@ describe('triggerSSB', () => {
 
   it('puts createPersonFailure when Caretaker Doe fails', () => {
     const gen = generateBabyDoe({payload: screening_id})
+    saveScreening(gen)
     gen.next()
     gen.next({id: '111'})
     gen.next()
 
     const error = {responseJSON: 'some error'}
     expect(gen.throw(error).value).toEqual(put(createPersonFailure('some error')))
+  })
+
+  it('puts saveFailure when saving the screening type fails', () => {
+    const gen = generateBabyDoe({payload: screening_id})
+    gen.next()
+    gen.next(fromJS(screening))
+    const error = {responseJSON: 'some error'}
+    expect(gen.throw(error).value).toEqual(put(saveFailure('some error')))
   })
 })


### PR DESCRIPTION
### Jira Story

- [Save triggers creation of unknown victim, perpetrator and allegation HOT-1947](https://osi-cwds.atlassian.net/browse/HOT-1947)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This incorporates the saving of the screening info (including the
report type) into the generateBabyDoeSaga. This resolves a race
condition, where creating the new participants sometimes happened
faster than this initial screening update. When that occurred, the
screening update response would contain an outdated list of
participants.

This PR duplicates some logic between the generateBabyDoeSaga and
the saveScreeningCardSaga. This is primarily because using yield*
to call sagas from each other results in painful unit tests. I am
asynchronously considering ways to improve this, but it is outside
the scope of this story.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

