### PR TITLE
Add primary tag to race in person card show view

### DIFF
--- a/app/javascript/selectors/screening/personShowSelectors.js
+++ b/app/javascript/selectors/screening/personShowSelectors.js
@@ -108,12 +108,15 @@ export const getErrorsSelector = (state, personId) => {
   })
 }
 
-const getRaces = (person) => person.get('races') && person.get('races').map((raceInformation) => {
-  const race = raceInformation.get('race')
-  const raceDetail = raceInformation.get('race_detail')
-  const raceDetailText = raceDetail ? ` - ${raceDetail}` : ''
-  return `${race}${raceDetailText}`
-}).join(', ')
+const getRaces = (person) => (
+  person.get('races') && person.get('races').map((raceInformation, index) => {
+    const race = raceInformation.get('race')
+    const raceDetail = raceInformation.get('race_detail')
+    const racePrimary = index === 0 ? ' (primary)' : ''
+    const raceDetailText = raceDetail ? ` - ${raceDetail}` : ''
+    return `${race}${raceDetailText}${racePrimary}`
+  }).join(', ')
+)
 
 const getEthnicity = (person) => {
   const {hispanic_latino_origin: hispanicLatinoOrigin, ethnicity_detail} = person.toJS().ethnicity || {}

--- a/spec/features/screening/participant/show_participant_spec.rb
+++ b/spec/features/screening/participant/show_participant_spec.rb
@@ -91,7 +91,8 @@ feature 'Show Screening' do
         expect(page).to have_content(address.type)
         expect(page).to have_content('Hispanic/Latino Origin')
         expect(page).to have_content('Mexican - Yes')
-        expect(page).to have_content('Asian - Korean, Native Hawaiian or Other Pacific Islander')
+        expect(page).to have_content('Asian - Korean (primary), '\
+                                     'Native Hawaiian or Other Pacific Islander')
       end
     end
   end

--- a/spec/javascripts/containers/screenings/PersonShowContainerSpec.jsx
+++ b/spec/javascripts/containers/screenings/PersonShowContainerSpec.jsx
@@ -38,7 +38,7 @@ describe('PersonShowContainer', () => {
       languages: 'Javascript (Primary), Ruby',
       legacySource: 'Client ID 1-4 in CWS-CMS',
       personId: '1',
-      races: 'White - Romanian, Asian - Chinese',
+      races: 'White - Romanian (primary), Asian - Chinese',
       roles: {
         value: ['super-hero', 'anti-hero'],
         errors: [],

--- a/spec/javascripts/selectors/screening/personShowSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/personShowSelectorsSpec.js
@@ -119,7 +119,27 @@ describe('personShowSelectors', () => {
       ]
       const state = fromJS({participants})
       expect(getFormattedPersonInformationSelector(state, '1').get('races'))
-        .toEqual('White - Romanian, Asian - Chinese, Black or African American')
+        .toEqual('White - Romanian (primary), Asian - Chinese, Black or African American')
+    })
+
+    it('shows primary race when there is one race', () => {
+      const participants = [
+        {id: '1', races: [
+          {race: 'White', race_detail: 'Romanian'},
+        ]},
+      ]
+      const state = fromJS({participants})
+      expect(getFormattedPersonInformationSelector(state, '1').get('races'))
+        .toEqual('White - Romanian (primary)')
+    })
+
+    it('shows nothing when there is no race', () => {
+      const participants = [
+        {id: '1', races: []},
+      ]
+      const state = fromJS({participants})
+      expect(getFormattedPersonInformationSelector(state, '1').get('races'))
+        .toEqual('')
     })
 
     it('includes the formatted ethnicity for a person of hispanic/latino origin who has ethnicity details', () => {


### PR DESCRIPTION
### Jira Story

- [Order of Primary Race displayed in Legacy HOT-1474](https://osi-cwds.atlassian.net/browse/HOT-1474)

## Description
Basically, this is to add a primary indicator on the race / ethnicity in Intake's person card show mode.
## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

