### PR TITLE
HOT-1947 - Update allegationsForm on any screening update

### DIFF
--- a/app/javascript/reducers/allegationsFormReducer.js
+++ b/app/javascript/reducers/allegationsFormReducer.js
@@ -16,7 +16,7 @@ import {List, fromJS} from 'immutable'
 export const buildFerbAllegations = (allegations) => (
   fromJS(
     allegations.map((allegation) => ({
-      id: allegation.id.toString(),
+      id: allegation.id && allegation.id.toString(),
       victimId: allegation.victim_person_id.toString(),
       perpetratorId: allegation.perpetrator_person_id.toString(),
       allegationTypes: allegation.types,

--- a/app/javascript/reducers/allegationsFormReducer.js
+++ b/app/javascript/reducers/allegationsFormReducer.js
@@ -2,11 +2,14 @@ import {
   RESET_ALLEGATIONS_FORM,
   SET_ALLEGATION_TYPES,
 } from 'actions/allegationsFormActions'
-import {FETCH_SCREENING_COMPLETE} from 'actions/actionTypes'
+import {
+  FETCH_SCREENING_COMPLETE,
+} from 'actions/actionTypes'
 import {
   DELETE_PERSON_COMPLETE,
   UPDATE_PERSON_COMPLETE,
 } from 'actions/personCardActions'
+import {SAVE_SCREENING_COMPLETE} from 'actions/screeningActions'
 import {createReducer} from 'utils/createReducer'
 import {List, fromJS} from 'immutable'
 
@@ -21,15 +24,16 @@ export const buildFerbAllegations = (allegations) => (
   )
 )
 
+const reduceFromScreening = (state, {payload: {screening}, error}) => {
+  if (error) {
+    return state
+  }
+  return buildFerbAllegations(screening.allegations || [])
+}
+
 export default createReducer(List(), {
-  [FETCH_SCREENING_COMPLETE](state, {payload: {screening}, error}) {
-    if (error) {
-      return state
-    } else {
-      const {allegations} = screening
-      return buildFerbAllegations(allegations)
-    }
-  },
+  [FETCH_SCREENING_COMPLETE]: reduceFromScreening,
+  [SAVE_SCREENING_COMPLETE]: reduceFromScreening,
   [SET_ALLEGATION_TYPES](state, {payload: {victimId, perpetratorId, allegationTypes}}) {
     const notFound = -1
     const allegationIndex = state.findIndex((allegation) => (

--- a/spec/javascripts/reducers/allegationsFormReducerSpec.js
+++ b/spec/javascripts/reducers/allegationsFormReducerSpec.js
@@ -9,11 +9,16 @@ import {
   updatePersonSuccess,
   updatePersonFailure,
 } from 'actions/personCardActions'
-import {fetchScreeningSuccess, fetchScreeningFailure} from 'actions/screeningActions'
+import {
+  fetchScreeningFailure,
+  fetchScreeningSuccess,
+  saveFailure,
+  saveSuccess,
+} from 'actions/screeningActions'
 import * as matchers from 'jasmine-immutable-matchers'
 import allegationsFormReducer from 'reducers/allegationsFormReducer'
 
-describe('narrativeFormReducer', () => {
+describe('allegationsFormReducer', () => {
   beforeEach(() => jasmine.addMatchers(matchers))
 
   describe('on FETCH_SCREENING_COMPLETE', () => {
@@ -34,6 +39,29 @@ describe('narrativeFormReducer', () => {
 
     it('returns the last state on failure', () => {
       const action = fetchScreeningFailure()
+      expect(allegationsFormReducer(List(), action))
+        .toEqualImmutable(List())
+    })
+  })
+
+  describe('on SAVE_SCREENING_COMPLETE', () => {
+    it('returns the allegations form', () => {
+      const allegations = [{id: '123', victim_person_id: '1', perpetrator_person_id: '2', types: ['General neglect']}]
+      const action = saveSuccess({allegations})
+      expect(allegationsFormReducer(List(), action)).toEqualImmutable(
+        fromJS([
+          {
+            id: '123',
+            victimId: '1',
+            perpetratorId: '2',
+            allegationTypes: ['General neglect'],
+          },
+        ])
+      )
+    })
+
+    it('returns the last state on failure', () => {
+      const action = saveFailure()
       expect(allegationsFormReducer(List(), action))
         .toEqualImmutable(List())
     })


### PR DESCRIPTION
### Jira Story

- [Save triggers creation of unknown victim, perpetrator and allegation HOT-1947](https://osi-cwds.atlassian.net/browse/HOT-1947)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
Prior to this, we only updated the allegations form with new
allegations when fetching a screening. This is because we assumed
that if the allegations changed, it must have been due to the user
submitting the form. This was never true, but particularly now when
allegations can be saved by triggering a Baby Doe generation.

Practically speaking, this prevents a bug where submitting the
allegations form after setting report type to SSB causes a 500
error, because it attempts to create the same allegation twice.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

