### PR TITLE
HOT-1671 include the screening status in screenings table based on the response

### DIFF
--- a/app/javascript/screenings/ScreeningRow.jsx
+++ b/app/javascript/screenings/ScreeningRow.jsx
@@ -15,10 +15,11 @@ const screeningStatus = (decision, decisionDetail) => {
 
 const linkName = (id, referralId, name) => (name || referralId || id)
 
-const ScreeningRow = ({id, name, decision, decisionDetail, assignee, startedAt, referralId}) => (
+const ScreeningRow = ({id, name, decision, decisionDetail, assignee, startedAt, referralId, screening_status}) => (
   <tr>
     <td><Link to={`/screenings/${id}`}>{linkName(id, referralId, name)}</Link></td>
     <td>{screeningStatus(decision, decisionDetail)}</td>
+    <td>{screening_status}</td>
     <td>&nbsp;</td>
     <td>{assignee}</td>
     <td>
@@ -35,6 +36,7 @@ ScreeningRow.propTypes = {
   id: PropTypes.string,
   name: PropTypes.string,
   referralId: PropTypes.string,
+  screening_status: PropTypes.string,
   startedAt: PropTypes.string,
 }
 export default ScreeningRow

--- a/app/javascript/screenings/ScreeningRow.jsx
+++ b/app/javascript/screenings/ScreeningRow.jsx
@@ -5,7 +5,7 @@ import SCREENING_DECISION_OPTIONS from '../enums/ScreeningDecisionOptions'
 import moment from 'moment'
 import {Link} from 'react-router'
 
-const screeningStatus = (decision, decisionDetail) => {
+const decisionType = (decision, decisionDetail) => {
   if (['promote_to_referral', 'screen_out'].includes(decision)) {
     const responseTimes = SCREENING_DECISION_OPTIONS[decision]
     return responseTimes.values[decisionDetail]
@@ -18,7 +18,7 @@ const linkName = (id, referralId, name) => (name || referralId || id)
 const ScreeningRow = ({id, name, decision, decisionDetail, assignee, startedAt, referralId, screening_status}) => (
   <tr>
     <td><Link to={`/screenings/${id}`}>{linkName(id, referralId, name)}</Link></td>
-    <td>{screeningStatus(decision, decisionDetail)}</td>
+    <td>{decisionType(decision, decisionDetail)}</td>
     <td>{screening_status}</td>
     <td>&nbsp;</td>
     <td>{assignee}</td>

--- a/app/javascript/screenings/ScreeningsTable.jsx
+++ b/app/javascript/screenings/ScreeningsTable.jsx
@@ -27,7 +27,7 @@ class ScreeningsTable extends React.Component {
           <thead>{this.renderTableHead()}</thead>
           <tbody>
             {
-              this.props.screenings.map(({id, name, screening_decision, screening_decision_detail, assignee, started_at, referral_id}) => (
+              this.props.screenings.map(({id, name, screening_decision, screening_decision_detail, assignee, started_at, referral_id, screening_status}) => (
                 <ScreeningRow
                   key={id}
                   id={id}
@@ -37,6 +37,7 @@ class ScreeningsTable extends React.Component {
                   assignee={assignee}
                   startedAt={started_at}
                   referralId={referral_id}
+                  screening_status={screening_status}
                 />
               )
               )

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -101,7 +101,8 @@ feature 'home page' do
             expect(page).to have_link(screening_one[:name],
               href: screening_path(id: screening_one[:id]))
             expect(page).to have_text(
-              'Little Shop of Horrors Differential response submitted Melody Pond 08/11/2016 11:24 AM'
+              'Little Shop of Horrors Differential response '\
+              'submitted Melody Pond 08/11/2016 11:24 AM'
             )
           end
           within rows[1] do
@@ -174,7 +175,9 @@ feature 'home page' do
         within 'tbody' do
           rows = all('tr')
           within rows[0] do
-            expect(page).to have_text("It's bigger on the inside open Clara Oswald 08/11/2016 5:00 PM")
+            expect(page).to have_text(
+              "It's bigger on the inside open Clara Oswald 08/11/2016 5:00 PM"
+            )
           end
           within rows[1] do
             expect(page).to have_content('Immediate submitted')
@@ -206,7 +209,7 @@ feature 'home page' do
             id: 2,
             screening_decision: 'screen_out',
             screening_decision_detail: 'evaluate_out',
-            screening_status: 'submitted',
+            screening_status: 'submitted'
           },
           {
             id: 3,
@@ -234,7 +237,9 @@ feature 'home page' do
         within 'tbody' do
           rows = all('tr')
           within rows[0] do
-            expect(page).to have_text("It's bigger on the inside submitted Clara Oswald 08/11/2016 5:00 PM")
+            expect(page).to have_text(
+              "It's bigger on the inside submitted Clara Oswald 08/11/2016 5:00 PM"
+            )
           end
           within rows[1] do
             expect(page).to have_content('Evaluate out submitted')

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -53,27 +53,31 @@ feature 'home page' do
           name: 'Little Shop of Horrors',
           assignee: 'Melody Pond',
           started_at: '2016-08-11T18:24:22.157Z',
-          screening_decision: 'differential_response'
+          screening_decision: 'differential_response',
+          screening_status: 'submitted'
         }
         screening_two = {
           id: 2,
           name: 'The Shining',
           assignee: 'Sarah Jane Smith',
           started_at: '2016-08-12T12:12:22.157Z',
-          screening_decision: 'information_to_child_welfare_services'
+          screening_decision: 'information_to_child_welfare_services',
+          screening_status: 'open'
         }
         screening_without_name = {
           id: 3,
           assignee: 'Rory Williams',
           started_at: '2016-08-17T01:24:22.157Z',
-          screening_decision: 'differential_response'
+          screening_decision: 'differential_response',
+          screening_status: 'open'
         }
         screening_without_decision = {
           id: 4,
           name: 'Elm Street',
           assignee: 'Freddy Krueger',
           started_at: '2017-10-13T00:24:22.157Z',
-          screening_decision: nil
+          screening_decision: nil,
+          screening_status: 'open'
         }
         screenings =
           [screening_one, screening_two, screening_without_name, screening_without_decision]
@@ -97,7 +101,7 @@ feature 'home page' do
             expect(page).to have_link(screening_one[:name],
               href: screening_path(id: screening_one[:id]))
             expect(page).to have_text(
-              'Little Shop of Horrors Differential response Melody Pond 08/11/2016 11:24 AM'
+              'Little Shop of Horrors Differential response submitted Melody Pond 08/11/2016 11:24 AM'
             )
           end
           within rows[1] do
@@ -105,7 +109,7 @@ feature 'home page' do
               href: screening_path(id: screening_two[:id]))
             expect(page).to have_text(
               'The Shining Information to child welfare '\
-              'services Sarah Jane Smith 08/12/2016 5:12 AM'
+              'services open Sarah Jane Smith 08/12/2016 5:12 AM'
             )
           end
           within rows[2] do
@@ -114,7 +118,7 @@ feature 'home page' do
               href: screening_path(id: screening_without_name[:id])
             )
             expect(page).to have_text(
-              'Differential response Rory Williams 08/16/2016 6:24 PM'
+              'Differential response open Rory Williams 08/16/2016 6:24 PM'
             )
           end
           within rows[3] do
@@ -122,7 +126,7 @@ feature 'home page' do
               screening_without_decision[:name],
               href: screening_path(id: screening_without_decision[:id])
             )
-            expect(page).to have_text('Elm Street Freddy Krueger 10/12/2017 5:24 PM')
+            expect(page).to have_text('Elm Street open Freddy Krueger 10/12/2017 5:24 PM')
           end
         end
       end
@@ -135,27 +139,32 @@ feature 'home page' do
             assignee: 'Clara Oswald',
             started_at: '2016-08-12T00:00:00.157Z',
             screening_decision: 'promote_to_referral',
-            screening_decision_detail: nil
+            screening_decision_detail: nil,
+            screening_status: 'open'
           },
           {
             id: 2,
             screening_decision: 'promote_to_referral',
-            screening_decision_detail: 'immediate'
+            screening_decision_detail: 'immediate',
+            screening_status: 'submitted'
           },
           {
             id: 3,
             screening_decision: 'promote_to_referral',
-            screening_decision_detail: '3_days'
+            screening_decision_detail: '3_days',
+            screening_status: 'submitted'
           },
           {
             id: 4,
             screening_decision: 'promote_to_referral',
-            screening_decision_detail: '5_days'
+            screening_decision_detail: '5_days',
+            screening_status: 'submitted'
           },
           {
             id: 5,
             screening_decision: 'promote_to_referral',
-            screening_decision_detail: '10_days'
+            screening_decision_detail: '10_days',
+            screening_status: 'submitted'
           }
         ]
         stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
@@ -165,19 +174,19 @@ feature 'home page' do
         within 'tbody' do
           rows = all('tr')
           within rows[0] do
-            expect(page).to have_text("It's bigger on the inside Clara Oswald 08/11/2016 5:00 PM")
+            expect(page).to have_text("It's bigger on the inside open Clara Oswald 08/11/2016 5:00 PM")
           end
           within rows[1] do
-            expect(page).to have_content('Immediate')
+            expect(page).to have_content('Immediate submitted')
           end
           within rows[2] do
-            expect(page).to have_content('3 days')
+            expect(page).to have_content('3 days submitted')
           end
           within rows[3] do
-            expect(page).to have_content('5 days')
+            expect(page).to have_content('5 days submitted')
           end
           within rows[4] do
-            expect(page).to have_content('10 days')
+            expect(page).to have_content('10 days submitted')
           end
         end
       end
@@ -190,27 +199,32 @@ feature 'home page' do
             assignee: 'Clara Oswald',
             started_at: '2016-08-12T00:00:00.157Z',
             screening_decision: 'screen_out',
-            screening_decision_detail: nil
+            screening_decision_detail: nil,
+            screening_status: 'submitted'
           },
           {
             id: 2,
             screening_decision: 'screen_out',
-            screening_decision_detail: 'evaluate_out'
+            screening_decision_detail: 'evaluate_out',
+            screening_status: 'submitted',
           },
           {
             id: 3,
             screening_decision: 'screen_out',
-            screening_decision_detail: 'information_request'
+            screening_decision_detail: 'information_request',
+            screening_status: 'submitted'
           },
           {
             id: 4,
             screening_decision: 'screen_out',
-            screening_decision_detail: 'consultation'
+            screening_decision_detail: 'consultation',
+            screening_status: 'submitted'
           },
           {
             id: 5,
             screening_decision: 'screen_out',
-            screening_decision_detail: 'other'
+            screening_decision_detail: 'other',
+            screening_status: 'submitted'
           }
         ]
         stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
@@ -220,19 +234,19 @@ feature 'home page' do
         within 'tbody' do
           rows = all('tr')
           within rows[0] do
-            expect(page).to have_text("It's bigger on the inside Clara Oswald 08/11/2016 5:00 PM")
+            expect(page).to have_text("It's bigger on the inside submitted Clara Oswald 08/11/2016 5:00 PM")
           end
           within rows[1] do
-            expect(page).to have_content('Evaluate out')
+            expect(page).to have_content('Evaluate out submitted')
           end
           within rows[2] do
-            expect(page).to have_content('Information request')
+            expect(page).to have_content('Information request submitted')
           end
           within rows[3] do
-            expect(page).to have_content('Consultation')
+            expect(page).to have_content('Consultation submitted')
           end
           within rows[4] do
-            expect(page).to have_content('Other')
+            expect(page).to have_content('Other submitted')
           end
         end
       end

--- a/spec/javascripts/components/screenings/ScreeningRowSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningRowSpec.jsx
@@ -19,5 +19,11 @@ describe('ScreeningRow', () => {
       expect(link.props().to).toEqual('/screenings/1')
       expect(link.html()).toEqual('<a>456</a>')
     })
+
+    it('renders screening status when available', () => {
+      const props = {id: '1', referralId: '456', name: null, screening_status: 'open'}
+      const view = shallow(<ScreeningRow {...props} />, {disableLifecycleMethods: true})
+      expect(view.html()).toContain('open')
+    })
   })
 })

--- a/spec/javascripts/components/screenings/ScreeningsTableSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningsTableSpec.jsx
@@ -22,6 +22,7 @@ describe('ScreeningsTable', () => {
       assignee: 'Robert Jones',
       started_at: '2016-09-21T14:26:58.042Z',
       referral_id: '456',
+      screening_status: 'open',
     }]
     const view = shallow(<ScreeningsTable screenings={screenings} />, {disableLifecycleMethods: true})
     const screeningRow = view.find('ScreeningRow')
@@ -33,6 +34,7 @@ describe('ScreeningsTable', () => {
       assignee: 'Robert Jones',
       startedAt: '2016-09-21T14:26:58.042Z',
       referralId: '456',
+      screening_status: 'open',
     })
   })
 })


### PR DESCRIPTION

### Jira Story

- [Screenings show as Open until they are submitted HOT-1671](https://osi-cwds.atlassian.net/browse/HOT-1671)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

