### PR TITLE
HOT-1472 Unique ID for Screening should be triggered by a save command.

### DIFF
--- a/app/controllers/api/v1/screenings_controller.rb
+++ b/app/controllers/api/v1/screenings_controller.rb
@@ -5,6 +5,10 @@
 module Api
   module V1
     class ScreeningsController < ApiController # :nodoc:
+      def new
+        render json: new_screening
+      end
+
       def create
         screening = ScreeningRepository.create(session[:security_token], new_screening)
         render json: screening

--- a/app/controllers/api/v1/screenings_controller.rb
+++ b/app/controllers/api/v1/screenings_controller.rb
@@ -10,9 +10,9 @@ module Api
       end
 
       def create
-        screening = params.require(:screening).as_json.symbolize_keys
-        created_screening = ScreeningRepository.create(session[:security_token], screening)
-        render json: created_screening
+        has_params = params['screening'].blank?
+        screening = has_params ? new_screening : params.require(:screening).as_json.symbolize_keys
+        render json: ScreeningRepository.create(session[:security_token], screening)
       end
 
       def update

--- a/app/controllers/api/v1/screenings_controller.rb
+++ b/app/controllers/api/v1/screenings_controller.rb
@@ -10,8 +10,9 @@ module Api
       end
 
       def create
-        screening = ScreeningRepository.create(session[:security_token], new_screening)
-        render json: screening
+        screening = params.require(:screening).as_json.symbolize_keys
+        created_screening = ScreeningRepository.create(session[:security_token], screening)
+        render json: created_screening
       end
 
       def update

--- a/app/javascript/common/routes.jsx
+++ b/app/javascript/common/routes.jsx
@@ -26,6 +26,7 @@ export default (
     <Router history={history} >
       <Route path='/' component={App}>
         <IndexRoute component={HomePageContainer} />
+        {screeningActive && <Route path='screenings/new' component={ScreeningPage}/>}
         {screeningActive && <Route path='screenings/:id' component={ScreeningPage}/>}
         {screeningActive && <Route path='screenings/:id/:mode' component={ScreeningPage} />}
         {snapshotActive && <Route path='snapshot' component={SnapshotPage}/>}

--- a/app/javascript/sagas/createParticipantSaga.js
+++ b/app/javascript/sagas/createParticipantSaga.js
@@ -1,5 +1,5 @@
 import {takeLatest, put, call, select} from 'redux-saga/effects'
-import {STATUS_CODES, post, get} from 'utils/http'
+import {STATUS_CODES, post} from 'utils/http'
 import {
   CREATE_PERSON,
   createPersonSuccess,
@@ -19,8 +19,7 @@ export function* sendPersonPayload(person) {
   const {legacy_id, legacy_source_table} = legacy_descriptor || {}
   let id
   if (screening_id === undefined) {
-    const newScreening = yield call(get, '/api/v1/screenings/new')
-    const screeningResponse = yield call(post, '/api/v1/screenings', {screening: newScreening})
+    const screeningResponse = yield call(post, '/api/v1/screenings')
     id = screeningResponse.id
     yield put(createScreeningSuccess(screeningResponse))
     const screeningEditPath = `/screenings/${id}/edit`

--- a/app/javascript/sagas/createParticipantSaga.js
+++ b/app/javascript/sagas/createParticipantSaga.js
@@ -9,13 +9,25 @@ import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
 import {fetchRelationships} from 'actions/relationshipsActions'
 import {selectClientIds} from 'selectors/participantSelectors'
 import {getScreeningIdValueSelector} from 'selectors/screeningSelectors'
+import {push} from 'react-router-redux'
+import {
+  createScreeningSuccess,
+} from 'actions/screeningActions'
 
 export function* sendPersonPayload(person) {
   const {screening_id, legacy_descriptor, sealed, sensitive} = person
   const {legacy_id, legacy_source_table} = legacy_descriptor || {}
+  let id
+  if (screening_id === undefined) {
+    const screeningResponse = yield call(post, '/api/v1/screenings')
+    id = screeningResponse.id
+    yield put(createScreeningSuccess(screeningResponse))
+    const screeningEditPath = `/screenings/${id}/edit`
+    yield put(push(screeningEditPath))
+  }
   const participantPayload = {
     participant: {
-      screening_id,
+      screening_id: screening_id || id,
       legacy_descriptor: {
         legacy_id,
         legacy_table_name: legacy_source_table,

--- a/app/javascript/sagas/createParticipantSaga.js
+++ b/app/javascript/sagas/createParticipantSaga.js
@@ -9,7 +9,7 @@ import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
 import {fetchRelationships} from 'actions/relationshipsActions'
 import {selectClientIds} from 'selectors/participantSelectors'
 import {getScreeningIdValueSelector} from 'selectors/screeningSelectors'
-import {push} from 'react-router-redux'
+import {replace} from 'react-router-redux'
 import {
   createScreeningSuccess,
 } from 'actions/screeningActions'
@@ -23,7 +23,7 @@ export function* sendPersonPayload(person) {
     id = screeningResponse.id
     yield put(createScreeningSuccess(screeningResponse))
     const screeningEditPath = `/screenings/${id}/edit`
-    yield put(push(screeningEditPath))
+    yield put(replace(screeningEditPath))
   }
   const participantPayload = {
     participant: {

--- a/app/javascript/sagas/createParticipantSaga.js
+++ b/app/javascript/sagas/createParticipantSaga.js
@@ -1,5 +1,5 @@
 import {takeLatest, put, call, select} from 'redux-saga/effects'
-import {STATUS_CODES, post} from 'utils/http'
+import {STATUS_CODES, post, get} from 'utils/http'
 import {
   CREATE_PERSON,
   createPersonSuccess,
@@ -19,7 +19,8 @@ export function* sendPersonPayload(person) {
   const {legacy_id, legacy_source_table} = legacy_descriptor || {}
   let id
   if (screening_id === undefined) {
-    const screeningResponse = yield call(post, '/api/v1/screenings')
+    const newScreening = yield call(get, '/api/v1/screenings/new')
+    const screeningResponse = yield call(post, '/api/v1/screenings', {screening: newScreening})
     id = screeningResponse.id
     yield put(createScreeningSuccess(screeningResponse))
     const screeningEditPath = `/screenings/${id}/edit`

--- a/app/javascript/sagas/createScreeningSaga.js
+++ b/app/javascript/sagas/createScreeningSaga.js
@@ -1,22 +1,10 @@
-import {takeEvery, put, call} from 'redux-saga/effects'
-import {post} from 'utils/http'
-import {
-  createScreeningSuccess,
-  createScreeningFailure,
-} from 'actions/screeningActions'
+import {takeEvery, put} from 'redux-saga/effects'
 import {CREATE_SCREENING} from 'actions/actionTypes'
 import {push} from 'react-router-redux'
 
 export function* createScreening() {
-  try {
-    const response = yield call(post, '/api/v1/screenings')
-    const {id} = response
-    const screeningEditPath = `/screenings/${id}/edit`
-    yield put(createScreeningSuccess(response))
-    yield put(push(screeningEditPath))
-  } catch (error) {
-    yield put(createScreeningFailure(error))
-  }
+  const screeningNewPath = '/screenings/new'
+  yield put(push(screeningNewPath))
 }
 export function* createScreeningSaga() {
   yield takeEvery(CREATE_SCREENING, createScreening)

--- a/app/javascript/sagas/fetchScreeningSaga.js
+++ b/app/javascript/sagas/fetchScreeningSaga.js
@@ -19,9 +19,14 @@ function* fetchCrossReports(cross_reports) {
 }
 
 function* tryToFetchScreening(id) {
-  const response = yield call(get, `/api/v1/screenings/${id}`)
-  const {cross_reports} = response
-  yield* fetchCrossReports(cross_reports)
+  let response
+  if (id) {
+    response = yield call(get, `/api/v1/screenings/${id}`)
+    const {cross_reports} = response
+    yield* fetchCrossReports(cross_reports)
+  } else {
+    response = yield call(get, '/api/v1/screenings/new')
+  }
   yield put(fetchScreeningSuccess(response))
   const clientIds = response.participants && response.participants.map(
     (p) => (p.legacy_id || p.legacy_descriptor && p.legacy_descriptor.legacy_id)

--- a/app/javascript/sagas/saveScreeningCardSaga.js
+++ b/app/javascript/sagas/saveScreeningCardSaga.js
@@ -29,9 +29,9 @@ import {cardName as workerSafetyCardName} from 'containers/screenings/WorkerSafe
 import {cardName as crossReportsCardName} from 'containers/screenings/CrossReportFormContainer'
 import {push} from 'react-router-redux'
 
-export function* createScreeningBase() {
+export function* createScreeningBase(screening) {
   try {
-    const response = yield call(api.post, '/api/v1/screenings')
+    const response = yield call(api.post, '/api/v1/screenings', {screening: screening.toJS()})
     const {id} = response
     const screeningEditPath = `/screenings/${id}/edit`
     yield put(createScreeningSuccess(response))
@@ -85,7 +85,7 @@ export function* saveScreeningCard({payload: {card}}) {
       const response = yield call(api.put, path, {screening: screening.toJS()})
       yield put(saveSuccess(response))
     } else {
-      yield createScreeningBase()
+      yield createScreeningBase(screening)
     }
   } catch (error) {
     yield put(saveFailure(error))

--- a/app/javascript/sagas/saveScreeningCardSaga.js
+++ b/app/javascript/sagas/saveScreeningCardSaga.js
@@ -85,7 +85,7 @@ export function* saveScreeningCard({payload: {card}}) {
       const response = yield call(api.put, path, {screening: screening.toJS()})
       yield put(saveSuccess(response))
     } else {
-      yield createScreeningBase(screening)
+      yield* createScreeningBase(screening)
     }
   } catch (error) {
     yield put(saveFailure(error))

--- a/app/javascript/sagas/saveScreeningCardSaga.js
+++ b/app/javascript/sagas/saveScreeningCardSaga.js
@@ -1,6 +1,6 @@
 import {takeEvery, put, call, select} from 'redux-saga/effects'
 import * as api from 'utils/http'
-import {saveSuccess, saveFailure, saveFailureFromNoParticipants, SAVE_SCREENING} from 'actions/screeningActions'
+import {saveSuccess, saveFailure, saveFailureFromNoParticipants, SAVE_SCREENING, createScreeningSuccess, createScreeningFailure} from 'actions/screeningActions'
 import {getScreeningWithAllegationsEditsSelector} from 'selectors/screening/allegationsFormSelectors'
 import {
   getScreeningWithEditsSelector as getScreeningWithScreeningInformationEditsSelector,
@@ -27,6 +27,19 @@ import {cardName as narrativeCardName} from 'containers/screenings/NarrativeForm
 import {cardName as decisionCardName} from 'containers/screenings/DecisionFormContainer'
 import {cardName as workerSafetyCardName} from 'containers/screenings/WorkerSafetyFormContainer'
 import {cardName as crossReportsCardName} from 'containers/screenings/CrossReportFormContainer'
+import {push} from 'react-router-redux'
+
+export function* createScreeningBase() {
+  try {
+    const response = yield call(api.post, '/api/v1/screenings')
+    const {id} = response
+    const screeningEditPath = `/screenings/${id}/edit`
+    yield put(createScreeningSuccess(response))
+    yield put(push(screeningEditPath))
+  } catch (error) {
+    yield put(createScreeningFailure(error))
+  }
+}
 
 export function* saveScreeningCard({payload: {card}}) {
   try {
@@ -67,9 +80,13 @@ export function* saveScreeningCard({payload: {card}}) {
       return
     }
     const id = screening.get('id')
-    const path = `/api/v1/screenings/${id}`
-    const response = yield call(api.put, path, {screening: screening.toJS()})
-    yield put(saveSuccess(response))
+    if (id) {
+      const path = `/api/v1/screenings/${id}`
+      const response = yield call(api.put, path, {screening: screening.toJS()})
+      yield put(saveSuccess(response))
+    } else {
+      yield createScreeningBase()
+    }
   } catch (error) {
     yield put(saveFailure(error))
   }

--- a/app/javascript/sagas/saveScreeningCardSaga.js
+++ b/app/javascript/sagas/saveScreeningCardSaga.js
@@ -27,7 +27,7 @@ import {cardName as narrativeCardName} from 'containers/screenings/NarrativeForm
 import {cardName as decisionCardName} from 'containers/screenings/DecisionFormContainer'
 import {cardName as workerSafetyCardName} from 'containers/screenings/WorkerSafetyFormContainer'
 import {cardName as crossReportsCardName} from 'containers/screenings/CrossReportFormContainer'
-import {push} from 'react-router-redux'
+import {replace} from 'react-router-redux'
 
 export function* createScreeningBase(screening) {
   try {
@@ -35,7 +35,7 @@ export function* createScreeningBase(screening) {
     const {id} = response
     const screeningEditPath = `/screenings/${id}/edit`
     yield put(createScreeningSuccess(response))
-    yield put(push(screeningEditPath))
+    yield put(replace(screeningEditPath))
   } catch (error) {
     yield put(createScreeningFailure(error))
   }

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -1,10 +1,7 @@
 import * as screeningActions from 'actions/screeningActions'
 import * as personCardActions from 'actions/personCardActions'
 import {setPageMode} from 'actions/screeningPageActions'
-import {
-  fetchHistoryOfInvolvements,
-  clearHistoryOfInvolvement,
-} from 'actions/historyOfInvolvementActions'
+import {fetchHistoryOfInvolvements, clearHistoryOfInvolvement,} from 'actions/historyOfInvolvementActions'
 import {clearRelationships} from 'actions/relationshipsActions'
 import PersonCardView from 'screenings/PersonCardView'
 import PropTypes from 'prop-types'

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -64,9 +64,11 @@ export class ScreeningPage extends React.Component {
       },
       params: {mode, id},
     } = this.props
-    setPageMode(mode || 'show')
-    fetchScreening(id)
-    fetchHistoryOfInvolvements('screenings', id)
+    if (id) {
+      setPageMode(mode || 'show')
+      fetchScreening(id)
+      fetchHistoryOfInvolvements('screenings', id)
+    } else { fetchScreening(null) }
   }
 
   componentWillUnmount() {

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -1,7 +1,7 @@
 import * as screeningActions from 'actions/screeningActions'
 import * as personCardActions from 'actions/personCardActions'
 import {setPageMode} from 'actions/screeningPageActions'
-import {fetchHistoryOfInvolvements, clearHistoryOfInvolvement,} from 'actions/historyOfInvolvementActions'
+import {fetchHistoryOfInvolvements, clearHistoryOfInvolvement} from 'actions/historyOfInvolvementActions'
 import {clearRelationships} from 'actions/relationshipsActions'
 import PersonCardView from 'screenings/PersonCardView'
 import PropTypes from 'prop-types'

--- a/app/javascript/selectors/screening/workerSafetyShowSelectors.js
+++ b/app/javascript/selectors/screening/workerSafetyShowSelectors.js
@@ -1,9 +1,10 @@
 import {createSelector} from 'reselect'
 import {getScreeningSelector} from 'selectors/screeningSelectors'
+import {List} from 'immutable'
 
 export const getAlertValuesSelector = createSelector(
   getScreeningSelector,
-  (screening) => screening.get('safety_alerts')
+  (screening) => screening.get('safety_alerts', List())
 )
 
 export const getInformationValueSelector = createSelector(

--- a/app/javascript/selectors/screeningSelectors.js
+++ b/app/javascript/selectors/screeningSelectors.js
@@ -21,5 +21,5 @@ export const getScreeningNameValueSelector = createSelector(
 export const getScreeningTitleSelector = createSelector(
   getScreeningIdValueSelector,
   getScreeningNameValueSelector,
-  (id, name) => name || (id ? `Screening ${id}` : 'New Screening')
+  (id, name) => name || (id ? `Edit Screening ${id}` : 'New Screening')
 )

--- a/app/javascript/selectors/screeningSelectors.js
+++ b/app/javascript/selectors/screeningSelectors.js
@@ -21,5 +21,5 @@ export const getScreeningNameValueSelector = createSelector(
 export const getScreeningTitleSelector = createSelector(
   getScreeningIdValueSelector,
   getScreeningNameValueSelector,
-  (id, name) => name || `Screening ${id}`
+  (id, name) => name || (id ? `Screening ${id}` : 'New Screening')
 )

--- a/app/javascript/views/CardView.jsx
+++ b/app/javascript/views/CardView.jsx
@@ -6,7 +6,7 @@ import EditLink from 'common/EditLink'
 const CardView = ({edit, editable, id, mode, onEdit, show, title}) => (
   <div>
     <a className='anchor' id={`${id}-anchor`}/>
-    <div className={ClassNames('card', mode, 'double-gap-bottom', 'position-relative')} id={id}>
+    <div className={ClassNames('card', mode || 'edit', 'double-gap-bottom', 'position-relative')} id={id}>
       <div className='card-header'>
         <span>{title}</span>
         {(editable && mode === 'show') &&

--- a/app/javascript/views/CardView.jsx
+++ b/app/javascript/views/CardView.jsx
@@ -19,7 +19,7 @@ const CardView = ({edit, editable, id, mode, onEdit, show, title}) => (
           />
         }
       </div>
-      {mode === 'edit' && edit}
+      {(mode === 'edit' || mode === undefined) && edit}
       {mode === 'show' && show}
     </div>
   </div>

--- a/app/javascript/views/CardView.jsx
+++ b/app/javascript/views/CardView.jsx
@@ -9,7 +9,7 @@ const CardView = ({edit, editable, id, mode, onEdit, show, title}) => (
     <div className={ClassNames('card', mode, 'double-gap-bottom', 'position-relative')} id={id}>
       <div className='card-header'>
         <span>{title}</span>
-        {editable &&
+        {(editable && mode === 'show') &&
           <EditLink
             ariaLabel={`Edit ${title && title.toLowerCase()}`}
             onClick={(event) => {

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,7 @@ Rails.application.routes.draw do
       get '/user_info' => 'user#user_info'
 
       resources :screenings,
-        only: %i[index update show create],
+        only: %i[new index update show create],
         constraints: Routes::ActiveScreeningsConstraint do
         member do
           get 'history_of_involvements'

--- a/spec/controllers/api/v1/screenings_controller_spec.rb
+++ b/spec/controllers/api/v1/screenings_controller_spec.rb
@@ -75,7 +75,13 @@ describe Api::V1::ScreeningsController do
         .and_return(created_screening)
     end
 
-    it 'creates and renders screening as json' do
+    it 'creates and renders screening as json without params' do
+      process :create, method: :post, session: session
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)).to eq(created_screening.as_json)
+    end
+
+    it 'creates and renders screening as json with params' do
       process :create, method: :post, params: { screening: created_screening }, session: session
       expect(response).to be_successful
       expect(JSON.parse(response.body)).to eq(created_screening.as_json)

--- a/spec/controllers/api/v1/screenings_controller_spec.rb
+++ b/spec/controllers/api/v1/screenings_controller_spec.rb
@@ -25,6 +25,33 @@ describe Api::V1::ScreeningsController do
     end
   end
 
+  describe '#new' do
+    let(:new_screening) do
+      {
+        reference: 'F3RBKY',
+        assignee: nil,
+        assignee_staff_id: nil,
+        incident_county: nil,
+        indexable: true,
+        addresses: [],
+        cross_reports: [],
+        participants: [],
+        allegations: [],
+        incident_address: {}
+      }
+    end
+
+    before do
+      allow(LUID).to receive(:generate).and_return(['F3RBKY'])
+    end
+
+    it 'renders new screening as json' do
+      process :new, method: :get
+      expect(response).to be_successful
+      expect(JSON.parse(response.body)).to eq(new_screening.as_json)
+    end
+  end
+
   describe '#create' do
     let(:created_screening) do
       {

--- a/spec/controllers/api/v1/screenings_controller_spec.rb
+++ b/spec/controllers/api/v1/screenings_controller_spec.rb
@@ -71,12 +71,12 @@ describe Api::V1::ScreeningsController do
     before do
       allow(LUID).to receive(:generate).and_return(['123ABC'])
       expect(ScreeningRepository).to receive(:create)
-        .with(security_token, created_screening)
+        .with(security_token, anything)
         .and_return(created_screening)
     end
 
     it 'creates and renders screening as json' do
-      process :create, method: :post, session: session
+      process :create, method: :post, params: { screening: created_screening }, session: session
       expect(response).to be_successful
       expect(JSON.parse(response.body)).to eq(created_screening.as_json)
     end
@@ -99,7 +99,7 @@ describe Api::V1::ScreeningsController do
 
       it 'leaves assignee and assignee_staff_id as nil' do
         session = { 'security_token' => security_token }
-        process :create, method: :post, session: session
+        process :create, method: :post, params: { screening: created_screening }, session: session
         expect(response).to be_successful
         expect(JSON.parse(response.body)).to eq(created_screening.as_json)
       end
@@ -124,7 +124,7 @@ describe Api::V1::ScreeningsController do
       it 'is blank if user_details is empty' do
         staff = FactoryBot.build(:staff, first_name: nil, last_name: nil, county: nil)
         session = { 'security_token' => security_token, 'user_details' => staff }
-        process :create, method: :post, session: session
+        process :create, method: :post, params: { screening: created_screening }, session: session
         expect(response).to be_successful
         expect(JSON.parse(response.body)).to eq(created_screening.as_json)
       end
@@ -168,7 +168,7 @@ describe Api::V1::ScreeningsController do
             'security_token' => security_token,
             'user_details' => staff
           }
-          process :create, method: :post, session: session
+          process :create, method: :post, params: { screening: created_screening }, session: session
           expect(response).to be_successful
           expect(JSON.parse(response.body)).to eq(created_screening.as_json)
         end
@@ -196,7 +196,7 @@ describe Api::V1::ScreeningsController do
             'security_token' => security_token,
             'user_details' => staff
           }
-          process :create, method: :post, session: session
+          process :create, method: :post, params: { screening: created_screening }, session: session
           expect(response).to be_successful
           expect(JSON.parse(response.body)).to eq(created_screening.as_json)
         end
@@ -204,14 +204,14 @@ describe Api::V1::ScreeningsController do
         it 'returns the same name if run more than once' do
           # Added second expectation as in the before so both create calls are properly expected
           expect(ScreeningRepository).to receive(:create)
-            .with(security_token, created_screening)
+            .with(security_token, anything)
             .and_return(created_screening)
           session = {
             'security_token' => security_token,
             'user_details' => staff
           }
-          process :create, method: :post, session: session
-          process :create, method: :post, session: session
+          process :create, method: :post, params: { screening: created_screening }, session: session
+          process :create, method: :post, params: { screening: created_screening }, session: session
         end
       end
     end
@@ -237,7 +237,7 @@ describe Api::V1::ScreeningsController do
         end
 
         it 'leaves incident county as nil if user_details is not set' do
-          process :create, method: :post, session: session
+          process :create, method: :post, params: { screening: created_screening }, session: session
           expect(response).to be_successful
           expect(JSON.parse(response.body)).to eq(created_screening.as_json)
         end
@@ -268,7 +268,7 @@ describe Api::V1::ScreeningsController do
           }
         end
         it 'is blank if user_details is empty' do
-          process :create, method: :post, session: session
+          process :create, method: :post, params: { screening: created_screening }, session: session
           expect(response).to be_successful
           expect(JSON.parse(response.body)).to eq(created_screening.as_json)
         end
@@ -294,7 +294,7 @@ describe Api::V1::ScreeningsController do
         end
 
         it 'default to have user info county' do
-          process :create, method: :post, session: session
+          process :create, method: :post, params: { screening: created_screening }, session: session
           expect(response).to be_successful
           expect(JSON.parse(response.body)).to eq(created_screening.as_json)
         end

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -21,7 +21,6 @@ feature 'Create Screening' do
           user_name_display = 'Joe B. Cool - Mendocino'
           allow(LUID).to receive(:generate).and_return(['DQJIYK'])
           new_screening = {
-            id: '1',
             reference: 'DQJIYK',
             assignee: user_name_display,
             assignee_staff_id: '1234',
@@ -34,27 +33,17 @@ feature 'Create Screening' do
             allegations: []
           }
 
-          stub_empty_history_for_screening(new_screening)
-          stub_empty_relationships
-          stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
-            .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
-            .and_return(json_body(new_screening.to_json, status: 201))
+          stub_request(
+            :get, new_api_v1_screening_path
+          ).and_return(json_body(new_screening.to_json, status: 200))
 
           stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
             .and_return(json_body([].to_json, status: 200))
-
-          stub_request(
-            :get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id]))
-          ).and_return(json_body(new_screening.to_json, status: 200))
-
-          stub_request(:get, ferb_api_url(FerbRoutes.staff_path('1234')))
-            .and_return(json_body(staff_info.to_json, status: 200))
-
           visit root_path(accessCode: access_code)
           click_button 'Start Screening'
 
           within '.page-header-mast' do
-            expect(page).to have_content("Screening #{new_screening[:id]}")
+            expect(page).to have_content('New Screening')
           end
 
           expect(page).to have_field(
@@ -81,7 +70,6 @@ feature 'Create Screening' do
           user_name_display = 'Joe B. Cool - Mendocino'
           allow(LUID).to receive(:generate).and_return(['DQJIYK'])
           new_screening = {
-            id: '1',
             reference: 'DQJIYK',
             assignee: user_name_display,
             assignee_staff_id: '1234',
@@ -94,17 +82,11 @@ feature 'Create Screening' do
             allegations: []
           }
 
-          stub_empty_history_for_screening(new_screening)
-          stub_empty_relationships
-          stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
-            .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
-            .and_return(json_body(new_screening.to_json, status: 201))
-
           stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
             .and_return(json_body([].to_json, status: 200))
 
           stub_request(
-            :get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id]))
+            :get, new_api_v1_screening_path
           ).and_return(json_body(new_screening.to_json, status: 200))
 
           stub_request(:get, ferb_api_url(FerbRoutes.staff_path('1234')))
@@ -114,7 +96,7 @@ feature 'Create Screening' do
           click_button 'Start Screening'
 
           within '.page-header-mast' do
-            expect(page).to have_content("Screening #{new_screening[:id]}")
+            expect(page).to have_content('New Screening')
           end
 
           expect(page).to have_select('Incident County', selected: 'Mendocino', disabled: true)
@@ -140,7 +122,6 @@ feature 'Create Screening' do
           user_name_display = 'Joe Cool - Mendocino'
           allow(LUID).to receive(:generate).and_return(['DQJIYK'])
           new_screening = {
-            id: '1',
             reference: 'DQJIYK',
             assignee: user_name_display,
             assignee_staff_id: '1234',
@@ -152,24 +133,19 @@ feature 'Create Screening' do
             participants: [],
             allegations: []
           }
-          stub_empty_history_for_screening(new_screening)
-          stub_empty_relationships
-          stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
-            .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
-            .and_return(json_body(new_screening.to_json, status: 201))
 
           stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
             .and_return(json_body([].to_json, status: 200))
 
           stub_request(
-            :get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id]))
+            :get, new_api_v1_screening_path
           ).and_return(json_body(new_screening.to_json, status: 200))
 
           visit root_path(accessCode: access_code)
           click_button 'Start Screening'
 
           within '.page-header-mast' do
-            expect(page).to have_content("Screening #{new_screening[:id]}")
+            expect(page).to have_content('New Screening')
           end
 
           expect(page).to have_field(
@@ -185,7 +161,6 @@ feature 'Create Screening' do
         scenario 'via start screening link' do
           allow(LUID).to receive(:generate).and_return(['DQJIYK'])
           new_screening = {
-            id: '1',
             reference: 'DQJIYK',
             assignee: '',
             assignee_staff_id: nil,
@@ -197,24 +172,19 @@ feature 'Create Screening' do
             participants: [],
             allegations: []
           }
-          stub_empty_history_for_screening(new_screening)
-          stub_empty_relationships
-          stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
-            .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
-            .and_return(json_body(new_screening.to_json, status: 201))
 
           stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
             .and_return(json_body([].to_json, status: 200))
 
           stub_request(
-            :get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id]))
+            :get, new_api_v1_screening_path
           ).and_return(json_body(new_screening.to_json, status: 200))
 
           visit root_path(accessCode: access_code)
           click_button 'Start Screening'
 
           within '.page-header-mast' do
-            expect(page).to have_content("Screening #{new_screening[:id]}")
+            expect(page).to have_content('New Screening')
           end
 
           expect(page).to have_field('Assigned Social Worker', with: '', disabled: false)
@@ -225,7 +195,6 @@ feature 'Create Screening' do
     scenario 'via start screening link' do
       allow(LUID).to receive(:generate).and_return(['DQJIYK'])
       new_screening = {
-        id: '1',
         reference: 'DQJIYK',
         assignee: 'Joe Cool',
         assignee_staff_id: nil,
@@ -238,29 +207,17 @@ feature 'Create Screening' do
         allegations: []
       }
 
-      stub_empty_history_for_screening(new_screening)
-      stub_empty_relationships
-      stub_request(:post, ferb_api_url(FerbRoutes.intake_screenings_path))
-        .with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
-        .and_return(json_body(new_screening.to_json, status: 201))
-
       stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
         .and_return(json_body([].to_json, status: 200))
 
-      stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(new_screening[:id])))
+      stub_request(:get, new_api_v1_screening_path)
         .and_return(json_body(new_screening.to_json, status: 200))
 
       visit root_path(accessCode: access_code)
       click_button 'Start Screening'
 
-      expect(
-        a_request(
-          :post, ferb_api_url(FerbRoutes.intake_screenings_path)
-        ).with(body: new_screening.merge(incident_address: {}).as_json(except: :id))
-      ).to have_been_made
-
       within '.page-header-mast' do
-        expect(page).to have_content("Screening #{new_screening[:id]}")
+        expect(page).to have_content('New Screening')
       end
     end
   end

--- a/spec/features/screening/create_screening_spec.rb
+++ b/spec/features/screening/create_screening_spec.rb
@@ -20,22 +20,6 @@ feature 'Create Screening' do
         scenario 'via start screening link' do
           user_name_display = 'Joe B. Cool - Mendocino'
           allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-          new_screening = {
-            reference: 'DQJIYK',
-            assignee: user_name_display,
-            assignee_staff_id: '1234',
-            incident_county: nil,
-            indexable: true,
-            incident_address: {},
-            addresses: [],
-            cross_reports: [],
-            participants: [],
-            allegations: []
-          }
-
-          stub_request(
-            :get, new_api_v1_screening_path
-          ).and_return(json_body(new_screening.to_json, status: 200))
 
           stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
             .and_return(json_body([].to_json, status: 200))
@@ -67,27 +51,10 @@ feature 'Create Screening' do
         end
 
         scenario 'via start screening link' do
-          user_name_display = 'Joe B. Cool - Mendocino'
           allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-          new_screening = {
-            reference: 'DQJIYK',
-            assignee: user_name_display,
-            assignee_staff_id: '1234',
-            incident_county: '23',
-            indexable: true,
-            incident_address: {},
-            addresses: [],
-            cross_reports: [],
-            participants: [],
-            allegations: []
-          }
 
           stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
             .and_return(json_body([].to_json, status: 200))
-
-          stub_request(
-            :get, new_api_v1_screening_path
-          ).and_return(json_body(new_screening.to_json, status: 200))
 
           stub_request(:get, ferb_api_url(FerbRoutes.staff_path('1234')))
             .and_return(json_body(staff_info.to_json, status: 200))
@@ -121,25 +88,9 @@ feature 'Create Screening' do
         scenario 'via start screening link' do
           user_name_display = 'Joe Cool - Mendocino'
           allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-          new_screening = {
-            reference: 'DQJIYK',
-            assignee: user_name_display,
-            assignee_staff_id: '1234',
-            incident_county: nil,
-            indexable: true,
-            incident_address: {},
-            addresses: [],
-            cross_reports: [],
-            participants: [],
-            allegations: []
-          }
 
           stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
             .and_return(json_body([].to_json, status: 200))
-
-          stub_request(
-            :get, new_api_v1_screening_path
-          ).and_return(json_body(new_screening.to_json, status: 200))
 
           visit root_path(accessCode: access_code)
           click_button 'Start Screening'
@@ -160,25 +111,9 @@ feature 'Create Screening' do
         let(:staff_info) { {} }
         scenario 'via start screening link' do
           allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-          new_screening = {
-            reference: 'DQJIYK',
-            assignee: '',
-            assignee_staff_id: nil,
-            incident_county: nil,
-            indexable: true,
-            incident_address: {},
-            addresses: [],
-            cross_reports: [],
-            participants: [],
-            allegations: []
-          }
 
           stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
             .and_return(json_body([].to_json, status: 200))
-
-          stub_request(
-            :get, new_api_v1_screening_path
-          ).and_return(json_body(new_screening.to_json, status: 200))
 
           visit root_path(accessCode: access_code)
           click_button 'Start Screening'
@@ -194,24 +129,9 @@ feature 'Create Screening' do
 
     scenario 'via start screening link' do
       allow(LUID).to receive(:generate).and_return(['DQJIYK'])
-      new_screening = {
-        reference: 'DQJIYK',
-        assignee: 'Joe Cool',
-        assignee_staff_id: nil,
-        incident_county: nil,
-        indexable: true,
-        incident_address: {},
-        addresses: [],
-        cross_reports: [],
-        participants: [],
-        allegations: []
-      }
 
       stub_request(:get, ferb_api_url(FerbRoutes.screenings_path))
         .and_return(json_body([].to_json, status: 200))
-
-      stub_request(:get, new_api_v1_screening_path)
-        .and_return(json_body(new_screening.to_json, status: 200))
 
       visit root_path(accessCode: access_code)
       click_button 'Start Screening'

--- a/spec/features/screening/new_screening_title_to_edit.rb
+++ b/spec/features/screening/new_screening_title_to_edit.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Title changed from New screening to Edit Screening' do
+  let(:screening) do
+    {
+      id: '1',
+      name: nil,
+      assignee: 'Lisa',
+      report_type: '',
+      started_at: '2016-08-13T10:00:00.000Z',
+      ended_at: '2016-08-15T11:00:00.000Z',
+      communication_method: 'mail',
+      incident_address: {},
+      addresses: [],
+      cross_reports: [],
+      participants: [],
+      allegations: [],
+      safety_alerts: []
+    }
+  end
+
+  before(:each) do
+    stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
+      .and_return(json_body(screening.to_json, status: 200))
+    stub_request(:put, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
+      .and_return(json_body(screening.to_json, status: 200))
+    stub_empty_relationships
+    stub_empty_history_for_screening(screening)
+    visit edit_screening_path(id: screening[:id])
+  end
+
+  scenario 'After saving the card title changed to edit screening' do
+    within '#screening-information-card' do
+      click_button 'Save'
+    end
+    expect(page).to have_content("Edit Screening #{screening[:id]}")
+  end
+end

--- a/spec/features/snapshot/create_snapshot_spec.rb
+++ b/spec/features/snapshot/create_snapshot_spec.rb
@@ -169,7 +169,6 @@ feature 'Create Snapshot' do
         end
 
         page.driver.go_back
-        page.driver.go_back
         click_button 'Start Snapshot'
 
         within '#snapshot-card' do

--- a/spec/features/snapshot/create_snapshot_spec.rb
+++ b/spec/features/snapshot/create_snapshot_spec.rb
@@ -169,7 +169,7 @@ feature 'Create Snapshot' do
         end
 
         page.driver.go_back
-
+        page.driver.go_back
         click_button 'Start Snapshot'
 
         within '#snapshot-card' do

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -62,21 +62,23 @@ describe('ScreeningPage', () => {
 
   describe('componentDidMount', () => {
     it("sets the page mode to 'edit' when url mode is 'edit' and editable is true", () => {
+      const id = '222'
       const setPageMode = jasmine.createSpy('setPageMode')
       renderScreeningPageWithLifecycle({
         editable: true,
         actions: {setPageMode},
-        params: {mode: 'edit'},
+        params: {mode: 'edit', id: id},
       })
       expect(setPageMode).toHaveBeenCalledWith('edit')
     })
 
     it("sets the page mode to 'show' when url mode is 'show' and editable is true", () => {
+      const id = '333'
       const setPageMode = jasmine.createSpy('setPageMode')
       renderScreeningPageWithLifecycle({
         editable: true,
         actions: {setPageMode},
-        params: {mode: 'show'},
+        params: {mode: 'show', id: id},
       })
       expect(setPageMode).toHaveBeenCalledWith('show')
     })

--- a/spec/javascripts/sagas/createParticipantSagaSpec.js
+++ b/spec/javascripts/sagas/createParticipantSagaSpec.js
@@ -11,6 +11,7 @@ import {getScreeningIdValueSelector} from 'selectors/screeningSelectors'
 import * as personCardActions from 'actions/personCardActions'
 import {fetchHistoryOfInvolvements} from 'actions/historyOfInvolvementActions'
 import {fetchRelationships} from 'actions/relationshipsActions'
+import {createScreeningSuccess} from 'actions/screeningActions'
 
 describe('createParticipantSaga', () => {
   it('creates participant on CREATE_PERSON', () => {
@@ -20,6 +21,16 @@ describe('createParticipantSaga', () => {
 })
 
 describe('createParticipant', () => {
+  it('triggers post if screening id is undefined', () => {
+    const screening = {id: undefined}
+    const action = personCardActions.createPerson(screening)
+    const gen = createParticipant(action)
+    expect(gen.next().value).toEqual(call(post, '/api/v1/screenings'))
+    expect(gen.next(screening).value).toEqual(
+      put(createScreeningSuccess(screening))
+    )
+  })
+
   const params = {screening_id: '1', legacy_descriptor: {legacy_id: '1', legacy_table_name: 'table'}, sealed: false, sensitive: false}
   const participant = {
     first_name: 'Michael',

--- a/spec/javascripts/sagas/createParticipantSagaSpec.js
+++ b/spec/javascripts/sagas/createParticipantSagaSpec.js
@@ -1,6 +1,6 @@
 import 'babel-polyfill'
 import {takeLatest, put, call, select} from 'redux-saga/effects'
-import {post, get} from 'utils/http'
+import {post} from 'utils/http'
 import {
   createParticipant,
   createParticipantSaga,
@@ -25,8 +25,7 @@ describe('createParticipant', () => {
     const screening = {id: undefined}
     const action = personCardActions.createPerson(screening)
     const gen = createParticipant(action)
-    expect(gen.next().value).toEqual(call(get, '/api/v1/screenings/new'))
-    expect(gen.next(screening).value).toEqual(call(post, '/api/v1/screenings', {screening}))
+    expect(gen.next(screening).value).toEqual(call(post, '/api/v1/screenings'))
     expect(gen.next(screening).value).toEqual(
       put(createScreeningSuccess(screening))
     )

--- a/spec/javascripts/sagas/createParticipantSagaSpec.js
+++ b/spec/javascripts/sagas/createParticipantSagaSpec.js
@@ -1,6 +1,6 @@
 import 'babel-polyfill'
 import {takeLatest, put, call, select} from 'redux-saga/effects'
-import {post} from 'utils/http'
+import {post, get} from 'utils/http'
 import {
   createParticipant,
   createParticipantSaga,
@@ -21,11 +21,12 @@ describe('createParticipantSaga', () => {
 })
 
 describe('createParticipant', () => {
-  it('triggers post if screening id is undefined', () => {
+  it('get new screening and post it if screening id is undefined', () => {
     const screening = {id: undefined}
     const action = personCardActions.createPerson(screening)
     const gen = createParticipant(action)
-    expect(gen.next().value).toEqual(call(post, '/api/v1/screenings'))
+    expect(gen.next().value).toEqual(call(get, '/api/v1/screenings/new'))
+    expect(gen.next(screening).value).toEqual(call(post, '/api/v1/screenings', {screening}))
     expect(gen.next(screening).value).toEqual(
       put(createScreeningSuccess(screening))
     )

--- a/spec/javascripts/sagas/createScreeningSagaSpec.js
+++ b/spec/javascripts/sagas/createScreeningSagaSpec.js
@@ -1,15 +1,10 @@
 import 'babel-polyfill'
-import {takeEvery, put, call} from 'redux-saga/effects'
-import {post} from 'utils/http'
+import {takeEvery, put} from 'redux-saga/effects'
 import {
   createScreeningSaga,
   createScreening,
 } from 'sagas/createScreeningSaga'
 import {CREATE_SCREENING} from 'actions/actionTypes'
-import {
-  createScreeningSuccess,
-  createScreeningFailure,
-} from 'actions/screeningActions'
 import {push} from 'react-router-redux'
 
 describe('createScreeningSaga', () => {
@@ -20,24 +15,10 @@ describe('createScreeningSaga', () => {
 })
 
 describe('createScreening', () => {
-  it('creates and puts screening', () => {
-    const screening = {id: '123'}
+  it('screening new', () => {
     const gen = createScreening()
-    expect(gen.next().value).toEqual(call(post, '/api/v1/screenings'))
-    expect(gen.next(screening).value).toEqual(
-      put(createScreeningSuccess(screening))
-    )
     expect(gen.next().value).toEqual(
-      put(push('/screenings/123/edit'))
-    )
-  })
-
-  it('puts errors when errors are thrown', () => {
-    const error = {responseJSON: 'some error'}
-    const gen = createScreening()
-    expect(gen.next().value).toEqual(call(post, '/api/v1/screenings'))
-    expect(gen.throw(error).value).toEqual(
-      put(createScreeningFailure(error))
+      put(push('/screenings/new'))
     )
   })
 })

--- a/spec/javascripts/sagas/fetchScreeningSagaSpec.js
+++ b/spec/javascripts/sagas/fetchScreeningSagaSpec.js
@@ -16,9 +16,21 @@ describe('fetchScreeningSaga', () => {
 })
 
 describe('fetchScreening', () => {
-  const id = '123'
-  const action = actions.fetchScreening(id)
+  describe('without id', () => {
+    it('fetch screening without id', () => {
+      const action = actions.fetchScreening(null)
+      const gen = fetchScreening(action)
+      const screening = {id: null, cross_reports: []}
+      expect(gen.next().value).toEqual(call(get, '/api/v1/screenings/new'))
+      expect(gen.next(screening).value).toEqual(
+        put(actions.fetchScreeningSuccess(screening))
+      )
+    })
+  })
+
   describe('when successful', () => {
+    const id = '123'
+    const action = actions.fetchScreening(id)
     it('fetches and puts screening with cross report data', () => {
       const gen = fetchScreening(action)
       expect(gen.next().value).toEqual(call(get, '/api/v1/screenings/123'))
@@ -65,6 +77,8 @@ describe('fetchScreening', () => {
     })
   })
   describe('when unsuccessful', () => {
+    const id = '123'
+    const action = actions.fetchScreening(id)
     it('returns the error', () => {
       const gen = fetchScreening(action)
       const error = {responseJSON: 'some error'}

--- a/spec/javascripts/sagas/saveScreeningCardSagaSpec.js
+++ b/spec/javascripts/sagas/saveScreeningCardSagaSpec.js
@@ -30,7 +30,7 @@ import {cardName as narrativeCardName} from 'containers/screenings/NarrativeForm
 import {cardName as decisionCardName} from 'containers/screenings/DecisionFormContainer'
 import {cardName as workerSafetyCardName} from 'containers/screenings/WorkerSafetyFormContainer'
 import {cardName as crossReportsCardName} from 'containers/screenings/CrossReportFormContainer'
-import {push} from 'react-router-redux'
+import {replace} from 'react-router-redux'
 
 describe('saveScreeningCardSaga', () => {
   it('saves screening on SAVE_SCREENING', () => {
@@ -51,7 +51,7 @@ describe('createScreeningBase', () => {
     )
     const screeningNew = fromJS({id: '123', allegations: [], participants: []})
     expect(gen.next().value).toEqual(
-      put(push(`/screenings/${screeningNew.id}/edit`))
+      put(replace(`/screenings/${screeningNew.id}/edit`))
     )
   })
 

--- a/spec/javascripts/selectors/screening/workerSafetyShowSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/workerSafetyShowSelectorsSpec.js
@@ -16,11 +16,11 @@ describe('workerSafetyShowSelectors', () => {
         toEqualImmutable(List(['ABC']))
     })
 
-    it('returns undefined when safety_alerts not present', () => {
+    it('returns empty list when safety_alerts not present', () => {
       const screening = {}
       const state = fromJS({screening})
       expect(getAlertValuesSelector(state)).
-        toEqual(List([]))
+        toEqualImmutable(List([]))
     })
   })
 

--- a/spec/javascripts/selectors/screening/workerSafetyShowSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/workerSafetyShowSelectorsSpec.js
@@ -20,7 +20,7 @@ describe('workerSafetyShowSelectors', () => {
       const screening = {}
       const state = fromJS({screening})
       expect(getAlertValuesSelector(state)).
-        toEqual(undefined)
+        toEqual(List([]))
     })
   })
 

--- a/spec/javascripts/selectors/screeningSelectorsSpec.js
+++ b/spec/javascripts/selectors/screeningSelectorsSpec.js
@@ -60,5 +60,10 @@ describe('screeningSelectors', () => {
       const state = fromJS({screening: {id: 1}})
       expect(getScreeningTitleSelector(state)).toEqual('Screening 1')
     })
+
+    it('returns the New screening if screening does not have a name or id', () => {
+      const state = fromJS({screening: {id: null}})
+      expect(getScreeningTitleSelector(state)).toEqual('New Screening')
+    })
   })
 })

--- a/spec/javascripts/selectors/screeningSelectorsSpec.js
+++ b/spec/javascripts/selectors/screeningSelectorsSpec.js
@@ -58,7 +58,7 @@ describe('screeningSelectors', () => {
 
     it('returns the screening id if screening does not have a name', () => {
       const state = fromJS({screening: {id: 1}})
-      expect(getScreeningTitleSelector(state)).toEqual('Screening 1')
+      expect(getScreeningTitleSelector(state)).toEqual('Edit Screening 1')
     })
 
     it('returns the New screening if screening does not have a name or id', () => {

--- a/spec/javascripts/views/CardViewSpec.jsx
+++ b/spec/javascripts/views/CardViewSpec.jsx
@@ -31,19 +31,19 @@ describe('Card View', () => {
 
   it('displays an edit button if editable is true', () => {
     const onEdit = jasmine.createSpy('onEdit')
-    const component = renderCardView({onEdit, editable: true})
+    const component = renderCardView({onEdit, editable: true, mode: 'show'})
     expect(component.find('EditLink').exists()).toEqual(true)
   })
 
   it('uses the card title for the edit link aria label', () => {
     const onEdit = jasmine.createSpy('onEdit')
-    const component = renderCardView({onEdit, title: 'My Title', editable: true})
+    const component = renderCardView({onEdit, title: 'My Title', editable: true, mode: 'show'})
     expect(component.find('EditLink').props().ariaLabel).toEqual('Edit my title')
   })
 
   it('calls onEdit when the edit button is clicked', () => {
     const onEdit = jasmine.createSpy('onEdit')
-    const component = renderCardView({onEdit, editable: true})
+    const component = renderCardView({onEdit, editable: true, mode: 'show'})
     component.find('EditLink').simulate('click', {preventDefault: () => {}})
     expect(onEdit).toHaveBeenCalled()
   })


### PR DESCRIPTION
### Jira Story

- [Unique ID for Screening should be triggered by a save command.](https://osi-cwds.atlassian.net/browse/HOT-1472)

## Description
As a Social Worker, I need the screening I create to generate a Unique Identifier at the point that I click on the "Save" button, so that if I press Start Screening by accident and then exit the application, no placeholder screening with Unique ID is permanently created in the database.

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

