### PR TITLE
Refactor decision selectors

### DIFF
--- a/app/javascript/selectors/screening/decisionFormSelectors.js
+++ b/app/javascript/selectors/screening/decisionFormSelectors.js
@@ -14,7 +14,7 @@ import {
   validateScreeningContactReference,
   validateAllegations,
   validateScreeningDecisionDetail,
-} from './decisionSelectors'
+} from 'selectors/screening/decisionSelectors'
 
 const selectOptionsFormatter = (options) => (
   Object.entries(options).map(([key, value]) => ({value: key, label: value}))

--- a/app/javascript/selectors/screening/decisionFormSelectors.js
+++ b/app/javascript/selectors/screening/decisionFormSelectors.js
@@ -2,30 +2,27 @@ import {createSelector} from 'reselect'
 import {Map, List, fromJS} from 'immutable'
 import {getScreeningSelector} from 'selectors/screeningSelectors'
 import {isRequiredIfCreate, isRequiredCreate, combineCompact} from 'utils/validator'
+import {selectParticipants} from 'selectors/participantSelectors'
 import SCREENING_DECISION from 'enums/ScreeningDecision'
 import ACCESS_RESTRICTIONS from 'enums/AccessRestrictions'
 import SCREENING_DECISION_OPTIONS from 'enums/ScreeningDecisionOptions'
-import {selectParticipants} from 'selectors/participantSelectors'
 import {getAllegationsWithTypesSelector} from 'selectors/screening/allegationsTypeFormSelectors'
-import {ROLE_TYPE_REPORTER} from 'enums/RoleType'
+import {
+  selectParticipantsRoles,
+  isReporterRequired,
+  selectCasesAndReferrals,
+  validateScreeningContactReference,
+  validateAllegations,
+  validateScreeningDecisionDetail,
+} from './decisionSelectors'
 
 const selectOptionsFormatter = (options) => (
   Object.entries(options).map(([key, value]) => ({value: key, label: value}))
 )
 
-export const getDecisionRolesSelector = (state) => (
-  selectParticipants(state).map((participant) => participant.get('roles', List())).flatten()
-)
-
 export const getDecisionFormSelector = (state) => state.get('screeningDecisionForm', Map())
 
 export const getDecisionOptionListSelector = () => fromJS(selectOptionsFormatter(SCREENING_DECISION))
-
-export const selectCasesAndReferrals = createSelector(
-  (state) => state.getIn(['involvements', 'cases'], List()),
-  (state) => state.getIn(['involvements', 'referrals'], List()),
-  (cases, referrals) => (cases.merge(referrals))
-)
 
 export const getDecisionOptionsSelector = createSelector(
   selectCasesAndReferrals,
@@ -60,36 +57,12 @@ export const getDecisionDetailOptionsSelector = createSelector(
   }
 )
 
-export const isReporterRequired = (decision, roles) => (
-  (decision === 'information_to_child_welfare_services' &&
-    !roles.some((role) => ROLE_TYPE_REPORTER.includes(role))) ?
-    'A reporter is required to submit a screening Contact' : undefined
-)
-
-export const validateAllegations = (decision, allegations) => (
-  (decision === 'promote_to_referral' &&
-          allegations.every((allegation) => allegation.get('allegationTypes').isEmpty())) ?
-    'Please enter at least one allegation to promote to referral.' : undefined
-)
-
-export const validateScreenerContactReference = (casesAndReferrals, contactReference, decision) => (
-  (decision === 'information_to_child_welfare_services' &&
-    !casesAndReferrals.find((hoiItem) => !hoiItem.get('end_date') &&
-      hoiItem.getIn(['legacy_descriptor', 'legacy_ui_id']) === contactReference
-    )) ? 'Please enter a valid Case or Referral Id' : undefined
-)
-
-export const validateScreeningDecisionDetail = (decision, decisionDetail) => (
-  (decision === 'promote_to_referral' && !decisionDetail) ?
-    'Please enter a response time' : undefined
-)
-
 export const getErrorsSelector = createSelector(
   getDecisionValueSelector,
   getDecisionDetailValueSelector,
   (state) => state.getIn(['screeningDecisionForm', 'restrictions_rationale', 'value']) || '',
   (state) => state.get('allegationsForm', List()),
-  getDecisionRolesSelector,
+  selectParticipantsRoles,
   (state) => state.getIn(['screeningDecisionForm', 'additional_information', 'value']) || '',
   selectContactReferenceValue,
   selectCasesAndReferrals,
@@ -100,7 +73,7 @@ export const getErrorsSelector = createSelector(
       () => isReporterRequired(decision, roles)
     ),
     screening_contact_reference: combineCompact(
-      () => validateScreenerContactReference(casesAndReferrals, contactReference, decision)
+      () => validateScreeningContactReference(casesAndReferrals, contactReference, decision)
     ),
     screening_decision_detail: combineCompact(
       () => validateScreeningDecisionDetail(decision, decisionDetail)

--- a/app/javascript/selectors/screening/decisionSelectors.js
+++ b/app/javascript/selectors/screening/decisionSelectors.js
@@ -21,9 +21,9 @@ export const selectCasesAndReferrals = createSelector(
 
 export const validateScreeningContactReference = (casesAndReferrals, contactReference, decision) => (
   (decision === 'information_to_child_welfare_services' &&
-    !casesAndReferrals.find((hoiItem) => !hoiItem.get('end_date') &&
-      hoiItem.getIn(['legacy_descriptor', 'legacy_ui_id']) === contactReference
-    )) ? 'Please enter a valid Case or Referral Id' : undefined
+    casesAndReferrals.every((hoiItem) => hoiItem.get('end_date') ||
+      hoiItem.getIn(['legacy_descriptor', 'legacy_ui_id']) !== contactReference)) ?
+    'Please enter a valid Case or Referral Id' : undefined
 )
 
 export const validateScreeningDecisionDetail = (decision, decisionDetail) => (

--- a/app/javascript/selectors/screening/decisionSelectors.js
+++ b/app/javascript/selectors/screening/decisionSelectors.js
@@ -1,0 +1,38 @@
+import {createSelector} from 'reselect'
+import {List} from 'immutable'
+import {selectParticipants} from 'selectors/participantSelectors'
+import {ROLE_TYPE_REPORTER} from 'enums/RoleType'
+
+export const selectParticipantsRoles = (state) => (
+  selectParticipants(state).map((participant) => participant.get('roles', List())).flatten()
+)
+
+export const isReporterRequired = (decision, roles) => (
+  (decision === 'information_to_child_welfare_services' &&
+    !roles.some((role) => ROLE_TYPE_REPORTER.includes(role))) ?
+    'A reporter is required to submit a screening Contact' : undefined
+)
+
+export const selectCasesAndReferrals = createSelector(
+  (state) => state.getIn(['involvements', 'cases'], List()),
+  (state) => state.getIn(['involvements', 'referrals'], List()),
+  (cases, referrals) => (cases.concat(referrals))
+)
+
+export const validateScreeningContactReference = (casesAndReferrals, contactReference, decision) => (
+  (decision === 'information_to_child_welfare_services' &&
+    !casesAndReferrals.find((hoiItem) => !hoiItem.get('end_date') &&
+      hoiItem.getIn(['legacy_descriptor', 'legacy_ui_id']) === contactReference
+    )) ? 'Please enter a valid Case or Referral Id' : undefined
+)
+
+export const validateScreeningDecisionDetail = (decision, decisionDetail) => (
+  (decision === 'promote_to_referral' && !decisionDetail) ?
+    'Please enter a response time' : undefined
+)
+
+export const validateAllegations = (decision, allegations) => (
+  (decision === 'promote_to_referral' &&
+          allegations.every((allegation) => allegation.get('allegationTypes').isEmpty())) ?
+    'Please enter at least one allegation to promote to referral.' : undefined
+)

--- a/app/javascript/selectors/screening/decisionShowSelectors.js
+++ b/app/javascript/selectors/screening/decisionShowSelectors.js
@@ -5,13 +5,13 @@ import SCREENING_DECISION from 'enums/ScreeningDecision'
 import SCREENING_DECISION_OPTIONS from 'enums/ScreeningDecisionOptions'
 import {isRequiredCreate, isRequiredIfCreate, combineCompact} from 'utils/validator'
 import {
-  getDecisionRolesSelector,
+  selectParticipantsRoles,
   isReporterRequired,
   selectCasesAndReferrals,
-  validateScreenerContactReference,
+  validateScreeningContactReference,
   validateAllegations,
   validateScreeningDecisionDetail,
-} from './decisionFormSelectors'
+} from './decisionSelectors'
 
 export const getErrorsSelector = createSelector(
   (state) => state.getIn(['screening', 'screening_decision']),
@@ -20,7 +20,7 @@ export const getErrorsSelector = createSelector(
   (state) => state.getIn(['screening', 'access_restrictions']) || '',
   (state) => state.getIn(['screening', 'restrictions_rationale']) || '',
   (state) => state.get('allegationsForm', List()),
-  getDecisionRolesSelector,
+  selectParticipantsRoles,
   selectCasesAndReferrals,
   (state) => state.getIn(['screening', 'additional_information']) || '',
   (decision, decisionDetail, contactReference, accessRestrictions, restrictionsRationale, allegations, roles, casesAndReferrals, additionalInformation) => (
@@ -39,7 +39,7 @@ export const getErrorsSelector = createSelector(
         ))
       ),
       screening_contact_reference: combineCompact(
-        () => validateScreenerContactReference(casesAndReferrals, contactReference, decision)
+        () => validateScreeningContactReference(casesAndReferrals, contactReference, decision)
       ),
       restrictions_rationale: combineCompact(
         isRequiredIfCreate(restrictionsRationale, 'Please enter an access restriction reason', () => (accessRestrictions))

--- a/app/javascript/selectors/screening/decisionShowSelectors.js
+++ b/app/javascript/selectors/screening/decisionShowSelectors.js
@@ -11,7 +11,7 @@ import {
   validateScreeningContactReference,
   validateAllegations,
   validateScreeningDecisionDetail,
-} from './decisionSelectors'
+} from 'selectors/screening/decisionSelectors'
 
 export const getErrorsSelector = createSelector(
   (state) => state.getIn(['screening', 'screening_decision']),

--- a/spec/javascripts/selectors/screening/decisionFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/decisionFormSelectorsSpec.js
@@ -1,6 +1,5 @@
 import {List, Map, fromJS} from 'immutable'
 import {
-  getDecisionRolesSelector,
   getAccessRestrictionOptionsSelector,
   getDecisionAlertErrorMessageSelector,
   getDecisionDetailOptionsSelector,
@@ -24,34 +23,6 @@ import * as matchers from 'jasmine-immutable-matchers'
 
 describe('screeningDecisionFormSelectors', () => {
   beforeEach(() => jasmine.addMatchers(matchers))
-
-  describe('getDecisionRolesSelector', () => {
-    const state = fromJS({
-      participants: [
-        {
-          screening_id: '3',
-          roles: [
-            'Perpetrator',
-          ],
-        },
-        {
-          screening_id: '3',
-          roles: [
-            'Victim',
-          ],
-        },
-        {
-          screening_id: '3',
-          roles: [
-            'Mandated Reporter',
-          ],
-        }],
-    })
-
-    it('returns all the roles', () => {
-      expect(getDecisionRolesSelector(state)).toEqualImmutable(fromJS(['Perpetrator', 'Victim', 'Mandated Reporter']))
-    })
-  })
 
   describe('getDecisionOptionsSelector', () => {
     it('returns information to child welfare services when HOI contains at least 1 open cases/referrals', () => {

--- a/spec/javascripts/selectors/screening/decisionSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/decisionSelectorsSpec.js
@@ -41,14 +41,17 @@ describe('decisionSelectors', () => {
   })
 
   describe('isReporterRequired', () => {
-    it('returns false if the decision is "info to cws" and there is a reporter', () => {
-      expect(isReporterRequired('information_to_child_welfare_services', ['Mandated Reporter']))
+    it('returns undefined if the decision is "info to cws" and there is a reporter', () => {
+      expect(isReporterRequired('information_to_child_welfare_services', ['Mandated Reporter'])).toEqual(undefined)
     })
-    it('returns true if the decision is not "info to cws" and there is a reporter', () => {
-      expect(isReporterRequired('promote_to_referral', ['Mandated Reporter']))
+    it('returns undefined if the decision is not "info to cws" and there is a reporter', () => {
+      expect(isReporterRequired('promote_to_referral', ['Mandated Reporter'])).toEqual(undefined)
     })
-    it('returns true if the decision is "info to cws" and there are no reporters', () => {
-      expect(isReporterRequired('promote_to_referral', ['Victim']))
+    it('returns an error if the decision is "info to cws" and there are no reporters', () => {
+      expect(isReporterRequired('information_to_child_welfare_services', ['Victim'])).toEqual('A reporter is required to submit a screening Contact')
+    })
+    it('returns an error if the decision is "info to cws" and there are no roles at all', () => {
+      expect(isReporterRequired('information_to_child_welfare_services', [])).toEqual('A reporter is required to submit a screening Contact')
     })
   })
 

--- a/spec/javascripts/selectors/screening/decisionSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/decisionSelectorsSpec.js
@@ -1,0 +1,153 @@
+import {List, fromJS} from 'immutable'
+import * as matchers from 'jasmine-immutable-matchers'
+import {
+  selectParticipantsRoles,
+  isReporterRequired,
+  selectCasesAndReferrals,
+  validateScreeningContactReference,
+  validateScreeningDecisionDetail,
+  validateAllegations,
+} from 'selectors/screening/decisionSelectors'
+
+describe('decisionSelectors', () => {
+  beforeEach(() => jasmine.addMatchers(matchers))
+
+  describe('selectParticipantsRoles', () => {
+    const state = fromJS({
+      participants: [
+        {
+          screening_id: '3',
+          roles: [
+            'Perpetrator',
+          ],
+        },
+        {
+          screening_id: '3',
+          roles: [
+            'Victim',
+          ],
+        },
+        {
+          screening_id: '3',
+          roles: [
+            'Mandated Reporter',
+          ],
+        }],
+    })
+
+    it('returns all the roles', () => {
+      expect(selectParticipantsRoles(state)).toEqualImmutable(fromJS(['Perpetrator', 'Victim', 'Mandated Reporter']))
+    })
+  })
+
+  describe('isReporterRequired', () => {
+    it('returns false if the decision is "info to cws" and there is a reporter', () => {
+      expect(isReporterRequired('information_to_child_welfare_services', ['Mandated Reporter']))
+    })
+    it('returns true if the decision is not "info to cws" and there is a reporter', () => {
+      expect(isReporterRequired('promote_to_referral', ['Mandated Reporter']))
+    })
+    it('returns true if the decision is "info to cws" and there are no reporters', () => {
+      expect(isReporterRequired('promote_to_referral', ['Victim']))
+    })
+  })
+
+  describe('selectCasesAndReferrals', () => {
+    const state = fromJS({
+      involvements: {
+        cases: [
+          {
+            legacy_descriptor: {legacy_id: 'adfe2ese'},
+            start_date: '2007-11-11',
+            id: 'dfsa',
+          },
+          {
+            legacy_descriptor: {legacy_id: 'd232321'},
+            start_date: '2008-11-11',
+            id: 'dd121',
+            focus_child: {},
+          },
+          {
+            legacy_descriptor: {legacy_id: 'd232321'},
+            start_date: '2008-11-11',
+            id: 'ddda',
+            focus_child: {},
+          },
+        ],
+        referrals: [
+          {
+            legacy_descriptor: {legacy_id: 'kjfds'},
+            start_date: '2009-11-11',
+            end_date: '2011-09-09',
+            reporter: {},
+            county: {}},
+        ],
+      },
+    })
+
+    it('returns a single list of cases and referrals', () => {
+      expect(selectCasesAndReferrals(state).size).toEqual(4)
+    })
+  })
+
+  describe('validateScreeningContactReference', () => {
+    const decision = 'information_to_child_welfare_services'
+    const casesAndReferrals = fromJS([
+      {
+        start_date: '01/01/2014',
+        end_date: '01/01/2015',
+        legacy_descriptor: {
+          legacy_ui_id: 'closedcaseid',
+        },
+      },
+      {
+        start_date: '01/01/2014',
+        legacy_descriptor: {
+          legacy_ui_id: 'opencaseid',
+        },
+      },
+      {
+        start_date: '01/01/2014',
+        legacy_descriptor: {
+          legacy_ui_id: '22312321',
+        },
+      },
+    ])
+
+    it('does not return an error if the id references an open item and "info to cws" is the decision', () => {
+      expect(validateScreeningContactReference(casesAndReferrals, 'opencaseid', decision)).toEqual(undefined)
+    })
+    it('returns an error if the id provided is from a closed case', () => {
+      expect(validateScreeningContactReference(casesAndReferrals, 'closedcaseid', decision)).toEqual('Please enter a valid Case or Referral Id')
+    })
+    it('does not return an error if the decision is not "info to cws"', () => {
+      expect(validateScreeningContactReference(casesAndReferrals, 'closedcaseid', 'promote_to_something')).toEqual(undefined)
+    })
+    it('returns an error when the list of cases/referrals is empty', () => {
+      expect(validateScreeningContactReference(List(), 'closedcaseid', decision)).toEqual('Please enter a valid Case or Referral Id')
+    })
+  })
+
+  describe('validateScreeningDecisionDetail', () => {
+    it('returns an error when the decision detail is not provided', () => {
+      expect(validateScreeningDecisionDetail('promote_to_referral', '')).toEqual('Please enter a response time')
+    })
+    it('returns undefined when the decision detail is provided', () => {
+      expect(validateScreeningDecisionDetail('promote_to_referral', '3 days')).toEqual(undefined)
+    })
+    it('returns undefined when the decision is not promote to referral', () => {
+      expect(validateScreeningDecisionDetail('', '3 days')).toEqual(undefined)
+    })
+  })
+
+  describe('validateAllegations', () => {
+    it('returns an error when allegationtypes are empty', () => {
+      const allegations = fromJS([{allegationTypes: []}, {allegationTypes: []}])
+      expect(validateAllegations('promote_to_referral', allegations)).toEqual('Please enter at least one allegation to promote to referral.')
+    })
+    it('returns undefined when the allegations have types', () => {
+      const allegations = fromJS([{allegationTypes: ['General neglect']}, {allegationTypes: []}])
+      expect(validateAllegations('promote_to_referral', allegations)).toEqual(undefined)
+    })
+  })
+})


### PR DESCRIPTION
### Jira Story

No story

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
Piggybacking on my previous story, @wmitchell-cambria mentioned it would be nice to have a general location to import selectors instead of grabbing from each other.

This is a refactor to do exactly that for decisions selectors.

As an interesting side note this would fix what can be a potential bug with my story.
Writing the tests for `selectCasesAndReferrals` I noticed that immutable `merge` and `concat` are different. [see](https://stackoverflow.com/a/30128393) 

It also renames some selectors to start to adapt to the new convention.

# Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue) (possibly)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

