### PR TITLE
Snap 237 hide reporter information from copy paste

### DIFF
--- a/app/assets/stylesheets/shame_overrides.scss
+++ b/app/assets/stylesheets/shame_overrides.scss
@@ -131,3 +131,11 @@
     }
   }
 }
+
+.reporter,
+.un-selectable {
+  -moz-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  user-select: none;
+}

--- a/app/javascript/containers/screenings/HistoryTableContainer.jsx
+++ b/app/javascript/containers/screenings/HistoryTableContainer.jsx
@@ -14,6 +14,7 @@ const resetCopyStyling = (copyContent) => {
     document.body.removeAttribute('style')
   }
   Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.removeAttribute('style')))
+  Array.from(copyContent.querySelectorAll('.reporter')).forEach((reporter) => reporter.removeAttribute('style'))
 }
 
 const mapStateToProps = (state) => ({
@@ -35,6 +36,7 @@ const mapStateToProps = (state) => ({
       el.style.borderCollapse = 'collapse'
       el.style.fontSize = '12px'
     })
+    Array.from(copyContent.querySelectorAll('.reporter')).forEach((reporter) => (reporter.style.display = 'none'))
     return copyContent
   },
   onSuccess: (copyContent) => {

--- a/app/javascript/containers/snapshot/HistoryTableContainer.js
+++ b/app/javascript/containers/snapshot/HistoryTableContainer.js
@@ -13,6 +13,7 @@ const resetCopyStyling = (copyContent) => {
     document.body.removeAttribute('style')
   }
   Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.removeAttribute('style')))
+  Array.from(copyContent.querySelectorAll('.reporter')).forEach((reporter) => reporter.removeAttribute('style'))
 }
 
 const mapStateToProps = (state) => ({
@@ -34,6 +35,7 @@ const mapStateToProps = (state) => ({
       el.style.borderCollapse = 'collapse'
       el.style.fontSize = '12px'
     })
+    Array.from(copyContent.querySelectorAll('.reporter')).forEach((reporter) => (reporter.style.display = 'none'))
     return copyContent
   },
   onSuccess: (copyContent) => {

--- a/app/javascript/containers/snapshot/HistoryTableContainer.js
+++ b/app/javascript/containers/snapshot/HistoryTableContainer.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state) => ({
   referrals: getFormattedReferralsSelector(state).toJS(),
   screenings: [],
   // To make the copied table fit in MS Word, we have to temporarily restyle it.
-  onCopy: (copyContent) => {
+  formatTable: (copyContent) => {
     Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.style.border = '1px solid black'))
     Array.from(copyContent.querySelectorAll('table')).forEach((el) => {
       el.style.borderCollapse = 'collapse'
@@ -21,6 +21,30 @@ const mapStateToProps = (state) => ({
     Array.from(copyContent.querySelectorAll('.reporter')).forEach((reporter) => (reporter.parentNode.removeChild(reporter)))
     return copyContent
   },
+  replace: (target, value) => {
+    if (value && target.parentNode) {
+      target.parentNode.replaceChild(value, target)
+    }
+  },
 })
 
-export default connect(mapStateToProps)(HistoryTable)
+const mergeProps = (stateProps, dispatchProps, ownProps) => {
+  const {formatTable} = stateProps
+  return {
+    ...stateProps,
+    ...dispatchProps,
+    ...ownProps,
+    onCopy: (e) => {
+      const copyData = formatTable(e.target.cloneNode(true))
+      try {
+        e.clipboardData.setData('text/html', copyData.outerHTML)
+        e.preventDefault()
+      } catch (error) {
+        this.originalTable = e.target.cloneNode(true) // eslint-disable-line no-invalid-this
+        formatTable(e.target)
+      }
+    },
+  }
+}
+
+export default connect(mapStateToProps, null, mergeProps)(HistoryTable)

--- a/app/javascript/containers/snapshot/HistoryTableContainer.js
+++ b/app/javascript/containers/snapshot/HistoryTableContainer.js
@@ -6,16 +6,6 @@ import {
 } from 'selectors/screening/historyOfInvolvementSelectors'
 import * as IntakeConfig from 'common/config'
 
-const resetCopyStyling = (copyContent) => {
-  if (window.clipboardData === undefined) {
-    Array.from(document.querySelectorAll('link[rel="stylesheet"]')).forEach((el) => (el.removeAttribute('disabled')))
-    copyContent.removeAttribute('style')
-    document.body.removeAttribute('style')
-  }
-  Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.removeAttribute('style')))
-  Array.from(copyContent.querySelectorAll('.reporter')).forEach((reporter) => reporter.removeAttribute('style'))
-}
-
 const mapStateToProps = (state) => ({
   showCopyButton: IntakeConfig.jsClipboardSupported(),
   cases: getFormattedCasesSelector(state).toJS(),
@@ -23,26 +13,13 @@ const mapStateToProps = (state) => ({
   screenings: [],
   // To make the copied table fit in MS Word, we have to temporarily restyle it.
   onCopy: (copyContent) => {
-    // >= IE11 does not need this hack
-    if (window.clipboardData === undefined) {
-      // hack to prevent scrolling when styles disappear
-      document.body.style.height = `${document.body.clientHeight}px`
-      Array.from(document.querySelectorAll('link[rel="stylesheet"]')).forEach((el) => (el.setAttribute('disabled', 'disabled')))
-      copyContent.style.width = '1%'
-    }
     Array.from(copyContent.querySelectorAll('table, th, td')).forEach((el) => (el.style.border = '1px solid black'))
     Array.from(copyContent.querySelectorAll('table')).forEach((el) => {
       el.style.borderCollapse = 'collapse'
       el.style.fontSize = '12px'
     })
-    Array.from(copyContent.querySelectorAll('.reporter')).forEach((reporter) => (reporter.style.display = 'none'))
+    Array.from(copyContent.querySelectorAll('.reporter')).forEach((reporter) => (reporter.parentNode.removeChild(reporter)))
     return copyContent
-  },
-  onSuccess: (copyContent) => {
-    resetCopyStyling(copyContent)
-  },
-  onError: (copyContent) => {
-    resetCopyStyling(copyContent)
   },
 })
 

--- a/app/javascript/views/history/HistoryTable.jsx
+++ b/app/javascript/views/history/HistoryTable.jsx
@@ -36,12 +36,15 @@ export default class HistoryTable extends React.Component {
   }
 
   renderButtonRow() {
+    const {replace} = this.props
     return (
       <div className='row'>
         <div className='centered'>
           <Clipboard
             className='btn btn-primary'
             data-clipboard-target='#history'
+            onSuccess={() => replace(this.historyTable, this.originalTable)}
+            onError={() => replace(this.historyTable, this.originalTable)}
           >
             Copy
           </Clipboard>
@@ -53,12 +56,12 @@ export default class HistoryTable extends React.Component {
   render() {
     const {cases, referrals, screenings, onCopy} = this.props
     return (<div className='card-body no-pad-top'>
-      <div className='table-responsive' id='history' onCopy={
-        (e) => {
-          e.clipboardData.setData('text/html', onCopy(e.target.cloneNode(true)).outerHTML)
-          e.preventDefault()
+      <div className='table-responsive' id='history'
+        ref={(history) => {
+          this.historyTable = history
         }
-      }
+        }
+        onCopy={onCopy.bind(this)}
       >
         <table className='table history-table ordered-table'>
           {this.renderColGroup()}
@@ -79,8 +82,7 @@ export default class HistoryTable extends React.Component {
 HistoryTable.propTypes = {
   cases: PropTypes.array,
   onCopy: PropTypes.func,
-  onError: PropTypes.func,
-  onSuccess: PropTypes.func,
   referrals: PropTypes.array,
+  replace: PropTypes.func,
   screenings: PropTypes.array,
 }

--- a/app/javascript/views/history/HistoryTable.jsx
+++ b/app/javascript/views/history/HistoryTable.jsx
@@ -36,15 +36,12 @@ export default class HistoryTable extends React.Component {
   }
 
   renderButtonRow() {
-    const {onCopy, onError, onSuccess} = this.props
     return (
       <div className='row'>
         <div className='centered'>
           <Clipboard
             className='btn btn-primary'
-            onSuccess={() => onSuccess(this.historyTable)}
-            onError={() => onError(this.historyTable)}
-            option-target={() => (onCopy(this.historyTable))}
+            data-clipboard-target='#history'
           >
             Copy
           </Clipboard>
@@ -54,9 +51,15 @@ export default class HistoryTable extends React.Component {
   }
 
   render() {
-    const {cases, referrals, screenings} = this.props
+    const {cases, referrals, screenings, onCopy} = this.props
     return (<div className='card-body no-pad-top'>
-      <div className='table-responsive' ref={(history) => { this.historyTable = history }}>
+      <div className='table-responsive' id='history' onCopy={
+        (e) => {
+          e.clipboardData.setData('text/html', onCopy(e.target.cloneNode(true)).outerHTML)
+          e.preventDefault()
+        }
+      }
+      >
         <table className='table history-table ordered-table'>
           {this.renderColGroup()}
           {this.renderTHead()}

--- a/app/javascript/views/history/ReferralView.jsx
+++ b/app/javascript/views/history/ReferralView.jsx
@@ -47,7 +47,7 @@ const ReferralView = ({
             ))
           }
           <tr>
-            <td colSpan='2'>
+            <td colSpan='2' className='un-selectable'>
               <span className='semibold reporter'>Reporter: </span><span className='reporter'>{reporter}</span>
             </td>
             <td>

--- a/app/javascript/views/history/ReferralView.jsx
+++ b/app/javascript/views/history/ReferralView.jsx
@@ -48,7 +48,7 @@ const ReferralView = ({
           }
           <tr>
             <td colSpan='2'>
-              <span className='semibold'>Reporter: </span>{reporter}
+              <span className='semibold reporter'>Reporter: </span><span className='reporter'>{reporter}</span>
             </td>
             <td>
               <span className='semibold'>Worker: </span>{worker}

--- a/spec/features/screening/history_of_involvement_spec.rb
+++ b/spec/features/screening/history_of_involvement_spec.rb
@@ -284,7 +284,9 @@ feature 'History card' do
         'label.setAttribute("for", "spec_meta")',
         'spec_meta.setAttribute("id", "spec_meta")',
         'document.getElementById("history-card").appendChild(spec_meta)',
-        'document.getElementById("spec_meta").appendChild(label)'
+        'document.getElementById("spec_meta").appendChild(label)',
+        'document.getElementById("spec_meta").addEventListener("paste",'\
+        ' function(e) { e.target.value = e.clipboardData.getData("text/html") })'
       ].join(';')
       page.execute_script js
       find('#spec_meta').send_keys [:control, 'v']

--- a/spec/features/screening/history_of_involvement_spec.rb
+++ b/spec/features/screening/history_of_involvement_spec.rb
@@ -269,7 +269,7 @@ feature 'History card' do
       stub_empty_relationships
     end
 
-    scenario 'copy button' do
+    scenario 'copying with the copy button copies the table without reporter information' do
       visit screening_path(id: existing_screening[:id])
       within '#history-card.card.show', text: 'History' do
         click_button 'Copy'
@@ -289,6 +289,10 @@ feature 'History card' do
       page.execute_script js
       find('#spec_meta').send_keys [:control, 'v']
       expect(find('#spec_meta').value).not_to be_empty
+      expect(find('#spec_meta').value).not_to have_text('Reporter1')
+      expect(find('#spec_meta').value).not_to have_text('r1LastName')
+      expect(find('#spec_meta').value).not_to have_text('Reporter2')
+      expect(find('#spec_meta').value).not_to have_text('r2LastName')
     end
 
     scenario 'viewing a screening' do

--- a/spec/features/snapshot/history_of_involvement_spec.rb
+++ b/spec/features/snapshot/history_of_involvement_spec.rb
@@ -231,7 +231,7 @@ feature 'Snapshot History of Involvement' do
       end
     end
 
-    scenario 'copy button' do
+    scenario 'copying with the copy button copies the table without reporter information' do
       within '#history-card.card.show', text: 'History' do
         click_button 'Copy'
       end
@@ -250,6 +250,10 @@ feature 'Snapshot History of Involvement' do
       page.execute_script js
       find('#spec_meta').send_keys [:control, 'v']
       expect(find('#spec_meta').value).not_to be_empty
+      expect(find('#spec_meta').value).not_to have_text('Reporter1')
+      expect(find('#spec_meta').value).not_to have_text('r1LastName')
+      expect(find('#spec_meta').value).not_to have_text('Reporter2')
+      expect(find('#spec_meta').value).not_to have_text('r2LastName')
     end
 
     scenario 'viewing a snapshot displays HOI without screenings' do

--- a/spec/features/snapshot/history_of_involvement_spec.rb
+++ b/spec/features/snapshot/history_of_involvement_spec.rb
@@ -232,7 +232,7 @@ feature 'Snapshot History of Involvement' do
     end
 
     scenario 'copying with the copy button copies the table without reporter information' do
-      within '#history-card.card.show', text: 'History' do
+      within '#history-card.card.show' do
         click_button 'Copy'
       end
       #
@@ -245,7 +245,9 @@ feature 'Snapshot History of Involvement' do
         'label.setAttribute("for", "spec_meta")',
         'spec_meta.setAttribute("id", "spec_meta")',
         'document.getElementById("history-card").appendChild(spec_meta)',
-        'document.getElementById("spec_meta").appendChild(label)'
+        'document.getElementById("spec_meta").appendChild(label)',
+        'document.getElementById("spec_meta").addEventListener("paste",'\
+        'function(e) { e.target.value = e.clipboardData.getData("text/html") })'
       ].join(';')
       page.execute_script js
       find('#spec_meta').send_keys [:control, 'v']

--- a/spec/javascripts/views/history/HistoryTableSpec.jsx
+++ b/spec/javascripts/views/history/HistoryTableSpec.jsx
@@ -84,9 +84,7 @@ describe('HistoryTable', () => {
         const copyButton = component.find('ClipboardButton')
 
         expect(copyButton.exists()).toEqual(true)
-        expect(copyButton.props()['option-target']).toBeDefined()
-        expect(copyButton.props().onSuccess).toBeDefined()
-        expect(copyButton.props().onError).toBeDefined()
+        expect(copyButton.props()['data-clipboard-target']).toBeDefined()
       })
     })
   })

--- a/spec/javascripts/views/history/HistoryTableSpec.jsx
+++ b/spec/javascripts/views/history/HistoryTableSpec.jsx
@@ -7,8 +7,9 @@ describe('HistoryTable', () => {
     cases = [],
     referrals = [],
     screenings = [],
+    onCopy = () => true,
   }) {
-    const props = {cases, referrals, screenings}
+    const props = {cases, referrals, screenings, onCopy}
     return shallow(<HistoryTable {...props}/>, {disableLifecycleMethods: true})
   }
 


### PR DESCRIPTION
### Jira Story

- [Hidden Reporter information from copy and paste feature SNAP-237](https://osi-cwds.atlassian.net/browse/SNAP-237)

## Description
We need to hide the reporter information when using the copy button because its PII. It must still be displayed on the HOI card, just not copied.

There are some caveats that were mentioned in the story

## Tests
- [ ] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
We aren't unit testing our containers most of the time, so my changes to `onCopy` were not unit tested. However, the feature test should cover everything
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

