### PR TITLE
Upgrade sprockets version to 3.7.2 to avoid information leak vulnerability

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,10 +14,10 @@ gem 'puma'
 gem 'rails', '~> 5.1'
 gem 'redis-rails', '~> 5.0.2'
 gem 'responders'
+gem 'sprockets', '~>3.7.2'
 gem 'virtus'
 gem 'webpacker'
 gem 'yard', '~> 0.9.11'
-gem 'sprockets', '~>3.7.2'
 
 group :development, :test do
   gem 'factory_bot_rails', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'responders'
 gem 'virtus'
 gem 'webpacker'
 gem 'yard', '~> 0.9.11'
+gem 'sprockets', '~>3.7.2'
 
 group :development, :test do
   gem 'factory_bot_rails', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,7 +230,7 @@ GEM
       coderay (~> 1.1)
     public_suffix (3.0.2)
     puma (3.11.3)
-    rack (2.0.4)
+    rack (2.0.5)
     rack-proxy (0.6.4)
       rack
     rack-test (0.8.3)
@@ -346,7 +346,7 @@ GEM
     slop (3.6.0)
     spring (2.0.2)
       activesupport (>= 4.2)
-    sprockets (3.7.1)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -439,6 +439,7 @@ DEPENDENCIES
   selenium-webdriver (= 3.8.0)
   simplecov-parallel
   spring
+  sprockets (~> 3.7.2)
   virtus
   web-console (~> 3.5)
   webmock


### PR DESCRIPTION

### Jira Story

- [No story)

## Description
There is an information leak vulnerability in Sprockets. This vulnerability has been assigned the CVE identifier CVE-2018-3760.
Impact
------
Specially crafted requests can be used to access files that exists on the filesystem that is outside an application's root directory, when the Sprockets server is used in production.

All users running an affected release should either upgrade or use one of the work arounds immediately.

Releases
--------
The 4.0.0.beta8, 3.7.2 and 2.12.5 releases are available at the normal locations.


## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
This is just a gem upgrade nothing to be tested.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

