### PR TITLE
Fixed header for all browsers

### DIFF
--- a/app/assets/stylesheets/page-error.scss
+++ b/app/assets/stylesheets/page-error.scss
@@ -27,6 +27,15 @@
   }
 }
 
+
+
+.sticky-pageheader {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  z-index: 3;
+}
+
 .error-panel {
   align-items: center;
   -webkit-box-align: center;

--- a/app/assets/stylesheets/page-error.scss
+++ b/app/assets/stylesheets/page-error.scss
@@ -27,8 +27,6 @@
   }
 }
 
-
-
 .sticky-pageheader {
   position: fixed;
   top: 0;

--- a/app/javascript/common/App.jsx
+++ b/app/javascript/common/App.jsx
@@ -6,6 +6,7 @@ import {fetch as fetchUserInfoAction} from 'actions/userInfoActions'
 import {fetch as fetchSystemCodesAction} from 'actions/systemCodesActions'
 import {checkStaffPermission} from 'actions/staffActions'
 import {bindActionCreators} from 'redux'
+import {handleScroll} from '../utils/stickyHeader'
 import {GlobalHeader} from 'react-wood-duck'
 import Footer from '../views/Footer'
 import userNameFormatter from 'utils/userNameFormatter'
@@ -18,8 +19,11 @@ export class App extends React.Component {
     fetchSystemCodesAction()
     checkStaffPermission('add_sensitive_people')
     checkStaffPermission('has_state_override')
+    window.addEventListener('scroll', handleScroll)
   }
-
+  componentWillUnmount() {
+    window.removeEventListener('scroll', handleScroll)
+  }
   render() {
     const logoutUrl = `${config().base_path.replace(/\/$/, '')}/logout`
     return (

--- a/app/javascript/common/App.jsx
+++ b/app/javascript/common/App.jsx
@@ -6,7 +6,6 @@ import {fetch as fetchUserInfoAction} from 'actions/userInfoActions'
 import {fetch as fetchSystemCodesAction} from 'actions/systemCodesActions'
 import {checkStaffPermission} from 'actions/staffActions'
 import {bindActionCreators} from 'redux'
-import {handleScroll} from '../utils/stickyHeader'
 import {GlobalHeader} from 'react-wood-duck'
 import Footer from '../views/Footer'
 import userNameFormatter from 'utils/userNameFormatter'
@@ -19,10 +18,6 @@ export class App extends React.Component {
     fetchSystemCodesAction()
     checkStaffPermission('add_sensitive_people')
     checkStaffPermission('has_state_override')
-    window.addEventListener('scroll', handleScroll)
-  }
-  componentWillUnmount() {
-    window.removeEventListener('scroll', handleScroll)
   }
   render() {
     const logoutUrl = `${config().base_path.replace(/\/$/, '')}/logout`

--- a/app/javascript/common/PageError.jsx
+++ b/app/javascript/common/PageError.jsx
@@ -1,19 +1,16 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import Affix from 'react-overlays/lib/AutoAffix'
 
 const PageError = ({pageErrorMessage}) => (
-  <Affix>
-    <div className='page-error'>
-      <div className='container'>
-        <div className='row'>
-          <p className='text-center'>
-            {pageErrorMessage || 'Something went wrong, sorry! Please try your last action again.'}
-          </p>
-        </div>
+  <div className='page-error'>
+    <div className='container'>
+      <div className='row'>
+        <p className='text-center'>
+          {pageErrorMessage || 'Something went wrong, sorry! Please try your last action again.'}
+        </p>
       </div>
     </div>
-  </Affix>
+  </div>
 
 )
 

--- a/app/javascript/common/PageHeader.jsx
+++ b/app/javascript/common/PageHeader.jsx
@@ -9,9 +9,11 @@ import {
 } from 'selectors/errorsSelectors'
 
 export const PageHeader = ({button, errorMessage, hasError, pageTitle}) => (
-  <WoodDuckPageHeader pageTitle={pageTitle} button={button}>
-    {hasError && <PageError pageErrorMessage={errorMessage} />}
-  </WoodDuckPageHeader>
+  <div id='page-sticky-header'>
+    <WoodDuckPageHeader pageTitle={pageTitle} button={button}>
+      {hasError && <PageError pageErrorMessage={errorMessage} />}
+    </WoodDuckPageHeader>
+  </div>
 )
 
 PageHeader.propTypes = {

--- a/app/javascript/common/PageHeader.jsx
+++ b/app/javascript/common/PageHeader.jsx
@@ -8,14 +8,39 @@ import {
   getPageErrorMessageValueSelector,
 } from 'selectors/errorsSelectors'
 
-export const PageHeader = ({button, errorMessage, hasError, pageTitle}) => (
-  <div id='page-sticky-header'>
-    <WoodDuckPageHeader pageTitle={pageTitle} button={button}>
-      {hasError && <PageError pageErrorMessage={errorMessage} />}
-    </WoodDuckPageHeader>
-  </div>
-)
+export class PageHeader extends React.Component {
+  constructor(props) {
+    super(props)
+    this.handleScroll = this.handleScroll.bind(this)
+  }
+  componentDidMount() {
+    window.addEventListener('scroll', this.handleScroll)
+  }
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this.handleScroll)
+  }
 
+  handleScroll() {
+    let header
+    var headerSticky = header || document.getElementById('page-stickyHeader')
+    var sticky = headerSticky.offsetTop
+    if (window.pageYOffset > sticky) {
+      headerSticky.classList.add('sticky-pageheader')
+    } else {
+      headerSticky.classList.remove('sticky-pageheader')
+    }
+  }
+  render() {
+    const {button, errorMessage, hasError, pageTitle} = this.props
+    return (
+      <div id='page-stickyHeader'>
+        <WoodDuckPageHeader pageTitle={pageTitle} button={button}>
+          {hasError && <PageError pageErrorMessage={errorMessage} />}
+        </WoodDuckPageHeader>
+      </div>
+    )
+  }
+}
 PageHeader.propTypes = {
   button: PropTypes.object,
   errorMessage: PropTypes.string,

--- a/app/javascript/utils/stickyHeader.js
+++ b/app/javascript/utils/stickyHeader.js
@@ -1,0 +1,9 @@
+export const handleScroll = () => {
+  var header = document.getElementById('page-sticky-header')
+  var sticky = header.offsetTop
+  if (window.pageYOffset > sticky) {
+    header.classList.add('sticky-pageheader')
+  } else {
+    header.classList.remove('sticky-pageheader')
+  }
+}

--- a/app/javascript/utils/stickyHeader.js
+++ b/app/javascript/utils/stickyHeader.js
@@ -1,9 +1,0 @@
-export const handleScroll = () => {
-  var header = document.getElementById('page-sticky-header')
-  var sticky = header.offsetTop
-  if (window.pageYOffset > sticky) {
-    header.classList.add('sticky-pageheader')
-  } else {
-    header.classList.remove('sticky-pageheader')
-  }
-}

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "react-clipboard.js": "^1.1.3",
     "react-dom": "16.3.2",
     "react-maskedinput": "^4.0.0",
-    "react-overlays": "^0.8.3",
     "react-redux": "5.0.5",
     "react-router": "3.2.0",
     "react-router-redux": "^4.0.8",

--- a/spec/features/screening/allegations/edit_allegations_spec.rb
+++ b/spec/features/screening/allegations/edit_allegations_spec.rb
@@ -130,7 +130,9 @@ feature 'edit allegations' do
       .and_return(json_body(screening.to_json, status: 200))
 
     within edit_participant_card_selector(marge.id) do
+      visit current_url + '#search-card'
       remove_react_select_option('Role', 'Perpetrator')
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
     end
 
@@ -142,6 +144,7 @@ feature 'edit allegations' do
     end
 
     within show_participant_card_selector(marge.id) do
+      visit current_url
       click_link 'Edit person'
     end
 
@@ -156,6 +159,7 @@ feature 'edit allegations' do
 
     within edit_participant_card_selector(marge.id) do
       fill_in_react_select('Role', with: 'Perpetrator')
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
     end
 
@@ -164,9 +168,9 @@ feature 'edit allegations' do
         expect(page).to_not have_content('Marge')
         expect(page).to_not have_content('Lisa')
       end
-
-      click_link 'Edit allegations'
     end
+    click_link('Allegations')
+    click_link 'Edit allegations'
 
     within '.card.edit', text: 'Allegations' do
       within 'tbody tr' do
@@ -209,6 +213,7 @@ feature 'edit allegations' do
       stub_request(:put,
         ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], marge.id)))
         .and_return(json_body(marge.to_json, status: 200))
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
     end
 
@@ -228,6 +233,8 @@ feature 'edit allegations' do
 
     within edit_participant_card_selector(lisa.id) do
       fill_in_react_select('Role', with: 'Victim')
+      visit current_url + '#search-card'
+      page.execute_script 'window.scrollBy(0,1500)'
       click_button 'Save'
     end
 
@@ -506,7 +513,7 @@ feature 'edit allegations' do
       stub_request(:delete,
         ferb_api_url(FerbRoutes.delete_screening_participant_path(screening[:id], marge.id)))
         .and_return(json_body(nil, status: 204))
-
+      visit current_url + '#search-card'
       click_button 'Remove person'
     end
 
@@ -572,14 +579,16 @@ feature 'edit allegations' do
       .and_return(json_body(screening.to_json, status: 200))
 
     within edit_participant_card_selector(lisa.id) do
+      visit current_url
       remove_react_select_option('Role', 'Victim')
+      page.execute_script 'window.scrollBy(0,700)'
       click_button 'Save'
     end
 
     within show_participant_card_selector(lisa.id) do
+      visit current_url + "#participant-card-#{marge.id}"
       click_link 'Edit person'
     end
-
     within '.card.show', text: 'Allegations' do
       expect(page).to have_no_content('Lisa')
       expect(page).to have_no_content('Marge')
@@ -667,11 +676,14 @@ feature 'edit allegations' do
       .and_return(json_body(screening.to_json, status: 200))
 
     within edit_participant_card_selector(marge.id) do
+      visit current_url + '#search-card'
       remove_react_select_option('Role', 'Perpetrator')
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
     end
 
     within show_participant_card_selector(marge.id) do
+      visit current_url
       click_link 'Edit person'
     end
 
@@ -679,8 +691,9 @@ feature 'edit allegations' do
       expect(page).to have_no_content('Lisa')
       expect(page).to have_no_content('Marge')
       expect(page).to have_no_content('General neglect')
-      click_link 'Edit allegations'
     end
+    click_link('Allegations')
+    click_link 'Edit allegations'
 
     within '.card.edit', text: 'Allegations' do
       expect(page).to have_content('Lisa')
@@ -697,9 +710,9 @@ feature 'edit allegations' do
 
     within edit_participant_card_selector(marge.id) do
       fill_in_react_select('Role', with: 'Perpetrator')
+      page.execute_script 'window.scrollBy(0,800)'
       click_button 'Save'
     end
-
     within '.card.edit', text: 'Allegations' do
       expect(page).to have_content('Lisa')
       expect(page).to have_content('Marge')

--- a/spec/features/screening/allegations/show_allegations_spec.rb
+++ b/spec/features/screening/allegations/show_allegations_spec.rb
@@ -169,6 +169,7 @@ feature 'show allegations' do
       .and_return(json_body(screening.to_json, status: 200))
 
     within show_participant_card_selector(marge.id) do
+      visit current_url + '#search-card'
       click_button 'Remove person'
     end
 
@@ -178,9 +179,9 @@ feature 'show allegations' do
         expect(page).to_not have_content('Lisa')
         expect(page).to_not have_content('General neglect')
       end
-
-      click_link 'Edit allegations'
     end
+    click_link('Allegations')
+    click_link 'Edit allegations'
 
     within '.card.edit', text: 'Allegations' do
       within 'tbody' do
@@ -243,9 +244,11 @@ feature 'show allegations' do
     screening[:participants] = [lisa.as_json.symbolize_keys, marge.as_json.symbolize_keys]
     stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
       .and_return(json_body(screening.to_json, status: 200))
-
+    url = current_url
     within edit_participant_card_selector(marge.id) do
       remove_react_select_option('Role', 'Perpetrator')
+      visit url + '#search-card'
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
     end
 
@@ -258,6 +261,7 @@ feature 'show allegations' do
     end
 
     within show_participant_card_selector(marge.id) do
+      visit url
       click_link 'Edit person'
     end
 
@@ -272,6 +276,8 @@ feature 'show allegations' do
 
     within edit_participant_card_selector(marge.id) do
       fill_in_react_select('Role', with: 'Perpetrator')
+      visit url + '#search-card'
+      page.execute_script 'window.scrollBy(0,1500)'
       click_button 'Save'
     end
 
@@ -281,9 +287,9 @@ feature 'show allegations' do
         expect(page).to_not have_content('Lisa')
         expect(page).to_not have_content('General neglect')
       end
-
-      click_link 'Edit allegations'
     end
+    click_link('Allegations')
+    click_link 'Edit allegations'
 
     within '.card.edit', text: 'Allegations' do
       within 'tbody tr' do
@@ -326,8 +332,9 @@ feature 'show allegations' do
     end
 
     within '#screening-information-card.card.show' do
-      click_link 'Edit screening information'
     end
+    click_link('Screening Information')
+    click_link 'Edit screening information'
 
     within '#screening-information-card.card.edit' do
       fill_in 'Title/Name of Screening', with: 'Hello'

--- a/spec/features/screening/allegations_cross_reports_spec.rb
+++ b/spec/features/screening/allegations_cross_reports_spec.rb
@@ -161,9 +161,11 @@ feature 'show cross reports' do
     within '#cross-report-card.edit' do
       expect(page).to have_content('must be cross-reported to law enforcement')
       select 'State of California', from: 'County'
+      visit current_url + '#cross-report-card'
       find('label', text: /\ADistrict Attorney\z/).click
       expect(page).to have_content('must be cross-reported to law enforcement')
       select 'LA District Attorney - Criminal Division', from: 'District Attorney Agency Name'
+      visit current_url
       find('label', text: /\ALaw Enforcement\z/).click
       expect(page).to_not have_content('must be cross-reported to law enforcement')
       select 'The Sheriff', from: 'Law Enforcement Agency Name'

--- a/spec/features/screening/cross_reports_spec.rb
+++ b/spec/features/screening/cross_reports_spec.rb
@@ -34,23 +34,24 @@ feature 'cross reports' do
 
     reported_on = DateTime.strptime('5/11/2018 11:10 AM', '%m/%d/%Y %l:%M %p')
     communication_method = 'Electronic Report'
-
+    expect(page).to_not have_content 'Communication Time and Method'
+    expect(page).to have_content 'County'
+    select 'Sacramento', from: 'County'
+    click_link('Cross Report')
+    find('label', text: /\ACounty Licensing\z/).click
+    select 'Hoverment Agency', from: 'County Licensing Agency Name'
+    find('label', text: /\ALaw Enforcement\z/).click
+    select 'The Sheriff', from: 'Law Enforcement Agency Name'
+    expect(page).to have_content 'Communication Time and Method'
+    fill_in_datepicker 'Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p')
+    expect(find_field('Cross Reported on Date').value).to \
+      eq(reported_on.strftime('%m/%d/%Y %l:%M %p'))
     within '#cross-report-card' do
-      expect(page).to_not have_content 'Communication Time and Method'
-      expect(page).to have_content 'County'
-      select 'Sacramento', from: 'County'
-      find('label', text: /\ACounty Licensing\z/).click
-      select 'Hoverment Agency', from: 'County Licensing Agency Name'
-      find('label', text: /\ALaw Enforcement\z/).click
-      select 'The Sheriff', from: 'Law Enforcement Agency Name'
-      expect(page).to have_content 'Communication Time and Method'
-      fill_in_datepicker 'Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p')
-      expect(find_field('Cross Reported on Date').value).to \
-        eq(reported_on.strftime('%m/%d/%Y %l:%M %p'))
       select communication_method, from: 'Communication Method'
-      click_button 'Save'
     end
-
+    click_link 'Cross Report'
+    page.execute_script 'window.scrollBy(0,500)'
+    page.find(:xpath, '//*[@id="cross-report-card"]/div[2]/div[5]/div/div/button[2]').click
     expect(
       a_request(
         :put, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
@@ -95,25 +96,29 @@ feature 'cross reports' do
     stub_empty_history_for_screening(existing_screening)
     visit edit_screening_path(id: existing_screening[:id])
 
+    expect(page).to have_select('County', selected: 'Sacramento')
+    select 'San Francisco', from: 'County'
+    expect(page).to have_select('County', selected: 'San Francisco')
+
+    expect(find(:checkbox, 'County Licensing')).to_not be_checked
+
+    click_link('Cross Report')
+
+    find('label', text: /\ALaw Enforcement\z/).click
+    expect(find(:checkbox, 'Law Enforcement')).to be_checked
+
+    select 'The Sheriff', from: 'Law Enforcement Agency Name'
+    find('label', text: /\ADistrict Attorney\z/).click
+    page.execute_script 'window.scrollBy(0,100)'
+    fill_in_datepicker 'Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p')
+    expect(find_field('Cross Reported on Date').value).to \
+      eq(reported_on.strftime('%m/%d/%Y %l:%M %p'))
     within '#cross-report-card' do
-      expect(page).to have_select('County', selected: 'Sacramento')
-      select 'San Francisco', from: 'County'
-      expect(page).to have_select('County', selected: 'San Francisco')
-
-      expect(find(:checkbox, 'County Licensing')).to_not be_checked
-
-      find('label', text: /\ALaw Enforcement\z/).click
-      expect(find(:checkbox, 'Law Enforcement')).to be_checked
-
-      select 'The Sheriff', from: 'Law Enforcement Agency Name'
-      find('label', text: /\ADistrict Attorney\z/).click
-      fill_in_datepicker 'Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p')
-      expect(find_field('Cross Reported on Date').value).to \
-        eq(reported_on.strftime('%m/%d/%Y %l:%M %p'))
       select communication_method, from: 'Communication Method'
-      click_button 'Save'
     end
-
+    click_link 'Cross Report'
+    page.execute_script 'window.scrollBy(0,500)'
+    page.find(:xpath, '//*[@id="cross-report-card"]/div[2]/div[5]/div/div/button[2]').click
     expect(
       a_request(
         :put, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
@@ -212,19 +217,22 @@ feature 'cross reports' do
     reported_on = DateTime.strptime('5/11/2018 11:10 AM', '%m/%d/%Y %l:%M %p')
     communication_method = 'Child Abuse Form'
 
+    select 'State of California', from: 'County'
+    click_link('Cross Report')
+    find('label', text: /\ACounty Licensing\z/).click
+    fill_in_datepicker 'Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p')
     within '#cross-report-card' do
-      select 'State of California', from: 'County'
-      find('label', text: /\ACounty Licensing\z/).click
-      fill_in_datepicker 'Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p')
       select communication_method, from: 'Communication Method'
-      find('label', text: /\ACounty Licensing\z/).click
-      find('label', text: /\ALaw Enforcement\z/).click
-      expect(page).to \
-        have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p'))
-      expect(page).to have_field('Communication Method', with: communication_method)
-
-      click_button 'Save'
     end
+    click_link('Cross Report')
+    find('label', text: /\ACounty Licensing\z/).click
+    find('label', text: /\ALaw Enforcement\z/).click
+    expect(page).to \
+      have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p'))
+    expect(page).to have_field('Communication Method', with: communication_method)
+    click_link 'Cross Report'
+    page.execute_script 'window.scrollBy(0,500)'
+    page.find(:xpath, '//*[@id="cross-report-card"]/div[2]/div[5]/div/div/button[2]').click
 
     expect(
       a_request(
@@ -259,24 +267,28 @@ feature 'cross reports' do
     reported_on = DateTime.strptime('5/11/2018 11:10 AM', '%m/%d/%Y %l:%M %p')
     communication_method = 'Child Abuse Form'
 
+    select 'San Francisco', from: 'County'
+    click_link('Cross Report')
+    find('label', text: /\ACounty Licensing\z/).click
+    fill_in_datepicker 'Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p')
     within '#cross-report-card' do
-      select 'San Francisco', from: 'County'
-      find('label', text: /\ACounty Licensing\z/).click
-      fill_in_datepicker 'Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p')
       select communication_method, from: 'Communication Method'
-      find('label', text: /\ACounty Licensing\z/).click
-      find('label', text: /\ALaw Enforcement\z/).click
-      expect(page).to \
-        have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p'))
-      expect(page).to have_field('Communication Method', with: communication_method)
-      select 'State of California', from: 'County'
-      find('label', text: /\ALaw Enforcement\z/).click
-      expect(page).to_not \
-        have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p'))
-      expect(page).to_not have_field('Communication Method', with: communication_method)
-
-      click_button 'Save'
     end
+    click_link('Cross Report')
+    find('label', text: /\ACounty Licensing\z/).click
+    find('label', text: /\ALaw Enforcement\z/).click
+    expect(page).to \
+      have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p'))
+    expect(page).to have_field('Communication Method', with: communication_method)
+    select 'State of California', from: 'County'
+    click_link('Cross Report')
+    find('label', text: /\ALaw Enforcement\z/).click
+    expect(page).to_not \
+      have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p'))
+    expect(page).to_not have_field('Communication Method', with: communication_method)
+    click_link 'Cross Report'
+    page.execute_script 'window.scrollBy(0,500)'
+    page.find(:xpath, '//*[@id="cross-report-card"]/div[2]/div[5]/div/div/button[2]').click
 
     expect(
       a_request(
@@ -311,22 +323,23 @@ feature 'cross reports' do
     reported_on = Date.today
     communication_method = 'Child Abuse Form'
 
+    select 'State of California', from: 'County'
+    click_link('Cross Report')
+    find('label', text: /\ACounty Licensing\z/).click
+    fill_in_datepicker 'Cross Reported on Date', with: reported_on
     within '#cross-report-card' do
-      select 'State of California', from: 'County'
-      find('label', text: /\ACounty Licensing\z/).click
-      fill_in_datepicker 'Cross Reported on Date', with: reported_on
       select communication_method, from: 'Communication Method'
-      find('label', text: /\ACounty Licensing\z/).click
-      click_button 'Save'
     end
-
+    click_link 'Cross Report'
+    page.execute_script 'window.scrollBy(0,500)'
+    page.find(:xpath, '//*[@id="cross-report-card"]/div[2]/div[5]/div/div/button[2]').click
+    click_link 'Cross Report'
     click_link 'Edit cross report'
 
-    within '#cross-report-card' do
-      select 'State of California', from: 'County'
-      find('label', text: /\ACounty Licensing\z/).click
-      expect(page).to have_field('Cross Reported on Date', with: '')
-      expect(page).to have_field('Communication Method', with: '')
-    end
+    select 'Sacramento', from: 'County'
+    click_link 'Cross Report'
+    find('label', text: /\ACounty Licensing\z/).click
+    expect(page).to have_field('Cross Reported on Date', with: '')
+    expect(page).to have_field('Communication Method', with: '')
   end
 end

--- a/spec/features/screening/edit_screening_spec.rb
+++ b/spec/features/screening/edit_screening_spec.rb
@@ -140,6 +140,7 @@ feature 'Edit Screening' do
           'Worker Safety Alerts',
           with: ['Dangerous Animal on Premises', 'Firearms in Home', 'Hostile Aggressive Client']
         )
+        visit current_url + '#worker-safety-card'
         click_button 'Cancel'
         expect(page).to have_content('Dangerous Animal on Premises')
         expect(page).to have_content('Firearms in Home')
@@ -178,6 +179,8 @@ feature 'Edit Screening' do
           with: ['Dangerous Animal on Premises', 'Firearms in Home',
                  'Hostile Aggressive Client', 'Severe Mental Health Status']
         )
+        visit current_url + '#screening-information-card'
+        page.execute_script 'window.scrollTo(0,0)'
         click_button 'Save'
       end
       expect(
@@ -344,7 +347,9 @@ feature 'individual card save' do
       ).and_return(json_body(updated_screening.to_json))
       stub_empty_relationships
       stub_empty_history_for_screening(existing_screening)
+      visit current_url.split('#')[0] + '#narrative-card'
       fill_in_datepicker 'Incident Date', with: '02/12/1996'
+      page.execute_script 'window.scrollBy(0,500)'
       click_button 'Save'
       expect(
         a_request(
@@ -397,6 +402,7 @@ feature 'individual card save' do
 
     within '#cross-report-card' do
       select 'State of California', from: 'County'
+      visit current_url + '#cross-report-card'
       find('label', text: 'District Attorney').click
       select 'LA District Attorney - Criminal Division', from: 'District Attorney Agency Name'
       click_button 'Save'
@@ -407,7 +413,7 @@ feature 'individual card save' do
         :put, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
       )
     ).to have_been_made
-
+    click_link('Cross Report')
     within '#cross-report-card' do
       click_link 'Edit cross report'
       expect(page).to have_select(
@@ -461,6 +467,7 @@ feature 'individual card save' do
     within '#worker-safety-card' do
       fill_in_react_select 'Worker Safety Alerts', with: 'Dangerous Animal on Premises'
       fill_in 'safety_information', with: 'Important information!'
+      visit current_url + '#worker-safety-card'
       click_button 'Save'
     end
     expect(
@@ -487,7 +494,7 @@ feature 'individual card save' do
       ).and_return(json_body(existing_screening.to_json))
       stub_empty_relationships
       stub_empty_history_for_screening(existing_screening)
-
+      visit current_url.split('#')[0] + '#narrative-card'
       fill_in_datepicker 'Incident Date', with: '02-12-1996'
       fill_in 'Address', with: '33 Whatever Rd'
       fill_in 'City', with: 'Modesto'

--- a/spec/features/screening/incident_information_spec.rb
+++ b/spec/features/screening/incident_information_spec.rb
@@ -36,6 +36,7 @@ feature 'screening incident information card' do
 
   scenario 'screening<->address edit merging should not override unchanged values' do
     existing_screening[:incident_address][:street_address] = '33 Whatever'
+    click_link('Incident Information')
     stub_request(
       :put, ferb_api_url(FerbRoutes.intake_screening_path(existing_screening[:id]))
     ).and_return(json_body(existing_screening.to_json))
@@ -61,6 +62,8 @@ feature 'screening incident information card' do
   end
 
   scenario 'user edits incident card from screening edit page and saves' do
+    click_link('Narrative')
+    page.execute_script 'window.scrollBy(0,100)'
     within '#incident-information-card.edit' do
       expect(page).to have_field('Incident Date', with: '08/11/2016')
       expect(page).to have_select('Incident County', selected: 'Colusa', disabled: true)
@@ -85,6 +88,7 @@ feature 'screening incident information card' do
     stub_empty_history_for_screening(existing_screening)
 
     within '#incident-information-card.edit' do
+      page.execute_script 'window.scrollBy(0,500)'
       click_button 'Save'
     end
 

--- a/spec/features/screening/narrative_spec.rb
+++ b/spec/features/screening/narrative_spec.rb
@@ -34,7 +34,7 @@ feature 'screening narrative card' do
     within '#narrative-card.show' do
       expect(page).to have_content 'This is my report narrative'
     end
-
+    visit current_url + '#search-card'
     click_link 'Edit narrative'
 
     within '#narrative-card.edit' do

--- a/spec/features/screening/participant/address_spec.rb
+++ b/spec/features/screening/participant/address_spec.rb
@@ -59,7 +59,8 @@ feature 'Participant Address' do
         fill_in 'Zip', with: '55555'
         select 'Home', from: 'Address Type'
       end
-
+      visit current_url + '#search-card'
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
     end
 
@@ -78,8 +79,8 @@ feature 'Participant Address' do
                    )
                  )
                ))).to have_been_made
-
     within show_participant_card_selector(marge.id) do
+      visit current_url
       click_link 'Edit'
       expect(page).to_not have_field('Address', with: marge.addresses.first.street_address)
       expect(page).to have_field('Address', with: '1234 Some Lane')

--- a/spec/features/screening/participant/editing_participant_spec.rb
+++ b/spec/features/screening/participant/editing_participant_spec.rb
@@ -95,9 +95,11 @@ feature 'Edit Person' do
           fill_in 'Social security number', with: 111_111_111
           select 'Sr', from: 'Suffix'
         end
-        click_button 'Save'
       end
-
+      click_link("#{marge.first_name} #{marge.last_name}")
+      page.execute_script 'window.scrollBy(0,1000)'
+      page.find(:xpath, '//*[@id=' +
+       %("participants-card-#{marge.id}") + ']/div[2]/div[2]/div/div/button[2]').click
       expect(
         a_request(:put,
           ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], marge.id)))
@@ -185,9 +187,11 @@ feature 'Edit Person' do
             select 'Home', from: 'Address Type'
           end
         end
-        click_button 'Save'
       end
-
+      click_link("#{marge.first_name} #{marge.last_name}")
+      page.execute_script 'window.scrollBy(0,1000)'
+      page.find(:xpath, '//*[@id=' +
+      %("participants-card-#{marge.id}") + ']/div[2]/div[2]/div/div/button[2]').click
       expect(
         a_request(:put,
           ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], homer.id)))
@@ -417,10 +421,13 @@ feature 'Edit Person' do
       ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], marge.id)))
       .and_return(json_body(marge.to_json, status: 200))
 
-    within edit_participant_card_selector(marge.id) do
-      click_button 'Save'
-    end
-
+    # within edit_participant_card_selector(marge.id) do
+    # click_button 'Save'
+    # end
+    click_link("#{marge.first_name} #{marge.last_name}")
+    page.execute_script 'window.scrollBy(0,1000)'
+    page.find(:xpath, '//*[@id=' +
+    %("participants-card-#{marge.id}") + ']/div[2]/div[2]/div/div/button[2]').click
     expect(
       a_request(:put,
         ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], marge.id)))
@@ -443,8 +450,9 @@ feature 'Edit Person' do
       stub_request(:put,
         ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], marge.id)))
         .and_return(json_body(marge.to_json, status: 200))
-
-      click_button 'Save'
+      page.execute_script 'window.scrollBy(0,1000)'
+      page.find(:xpath, '//*[@id=' +
+      %("participants-card-#{marge.id}") + ']/div[2]/div[2]/div/div/button[2]').click
       expect(a_request(:put,
         ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], marge.id)))
         .with(body: hash_including(
@@ -471,6 +479,7 @@ feature 'Edit Person' do
         expect(page).to have_field('Social security number', with: old_ssn)
         fill_in 'Social security number', with: new_ssn
         expect(page).to have_field('Social security number', with: new_ssn)
+        page.execute_script 'window.scrollBy(0,1550)'
         click_button 'Cancel'
       end
     end
@@ -493,8 +502,10 @@ feature 'Edit Person' do
 
     within edit_participant_card_selector(marge.id) do
       fill_in 'Social security number', with: new_ssn
-      click_button 'Cancel'
     end
+    page.execute_script 'window.scrollBy(0,1500)'
+    page.find(:xpath, '//*[@id=' +
+    %("participants-card-#{marge.id}") + ']/div[2]/div[2]/div/div/button[1]').click
 
     expect(page).to have_content marge_formatted_name
     expect(page).to have_link 'Edit person'
@@ -512,12 +523,10 @@ feature 'Edit Person' do
       stub_request(:put,
         ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], marge.id)))
         .and_return(json_body(marge.to_json, status: 200))
-
-      within '.card-body' do
-        click_button 'Save'
-      end
     end
-
+    page.execute_script 'window.scrollBy(0,1000)'
+    page.find(:xpath, '//*[@id=' +
+    %("participants-card-#{marge.id}") + ']/div[2]/div[2]/div/div/button[2]').click
     expect(
       a_request(:put,
         ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], marge.id)))
@@ -594,6 +603,8 @@ feature 'Edit Person' do
     within edit_participant_card_selector(marge.id) do
       expect(page).to have_field('Approximate Age', disabled: true)
       expect(page).to have_field('Approximate Age Units', disabled: true)
+      visit current_url.split('#')[0] + "#participant-card-#{marge.id}"
+      page.execute_script 'window.scrollBy(0,1200)'
       fill_in_datepicker 'Date of birth', with: ''
       expect(page).to have_field('Approximate Age', disabled: false)
       expect(page).to have_field('Approximate Age Units', disabled: false)
@@ -671,6 +682,7 @@ feature 'Edit Person' do
           fill_in_react_select 'Parent/Guardian Provided Medical Questionaire', with: 'Declined'
           fill_in_datepicker 'Medical Questionaire Return Date', with: '01-01-2011'
         end
+        page.execute_script 'window.scrollBy(0,200)'
         click_button 'Save'
       end
 

--- a/spec/features/screening/participant/phone_number_spec.rb
+++ b/spec/features/screening/participant/phone_number_spec.rb
@@ -37,7 +37,8 @@ feature 'Participant Phone Number' do
         fill_in 'Phone Number', with: '7894561245'
         select 'Home', from: 'Phone Number Type'
       end
-
+      visit current_url + "#participants-card-#{marge.id}"
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
     end
 
@@ -60,7 +61,8 @@ feature 'Participant Phone Number' do
       expect(page).to have_field('Phone Number', with: '(917)555-5555')
       expect(page).to have_field('Phone Number Type', with: 'Work')
       fill_in 'Phone Number', with: '7894561245'
-
+      visit current_url + "#participants-card-#{marge.id}"
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
     end
 
@@ -85,9 +87,12 @@ feature 'Participant Phone Number' do
     marge.phone_numbers = []
 
     within edit_participant_card_selector(marge.id) do
+      visit current_url + "#participants-card-#{marge.id}"
+      page.execute_script 'window.scrollBy(0,1000)'
       click_link 'Delete phone number'
       expect(page).to_not have_content('(917) 555-5555')
-
+      visit current_url
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
     end
 
@@ -104,6 +109,8 @@ feature 'Participant Phone Number' do
         fill_in 'Phone Number', with: 'as(343ld81103kjs809u38'
         expect(page).to have_field('Phone Number', with: '(343)811-0380')
       end
+      visit current_url + "#participants-card-#{marge.id}"
+      page.execute_script 'window.scrollBy(0,1000)'
       click_button 'Save'
 
       marge.phone_numbers.first.number = '3438110380'

--- a/spec/features/screening/participant/race_ethnicity_spec.rb
+++ b/spec/features/screening/participant/race_ethnicity_spec.rb
@@ -104,6 +104,8 @@ feature 'Race & Ethnicity' do
         within '#race' do
           expect(find('input[value="Unknown"]')).to be_checked
           expect(find('input[value="Asian"]')).to be_disabled
+          visit current_url + '#search-card'
+          page.execute_script 'window.scrollBy(0,1800)'
           find('label', text: 'Unknown').click
           find('label', text: 'Asian').click
           select 'Hmong', from: "participant-#{homer.id}-Asian-race-detail"

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -422,7 +422,7 @@ feature 'searching a participant in autocompleter' do
         a_request(:post, search_path)
         .with(body: hash_including('search_after' => %w[result_24_score result_24_uuid]))
       ).to have_been_made
-
+      click_link 'Screening Information'
       within '#search-card', text: 'Search' do
         click_button 'Show more results'
       end

--- a/spec/features/screening/relationships_card_spec.rb
+++ b/spec/features/screening/relationships_card_spec.rb
@@ -374,6 +374,7 @@ feature 'Relationship card' do
           describe '.attached-person' do
             scenario 'does not show "Attach" link' do
               assign_relationship(tag: 'td', element_text: 'Jake Campbell', link_text: 'Attach')
+              click_link('Relationship')
               find('td', text: 'Jake Campbell').find(:xpath, '..').find('div.dropdown').click
               expect(page).to have_no_content('Attach')
             end

--- a/spec/features/screening/screening_information_spec.rb
+++ b/spec/features/screening/screening_information_spec.rb
@@ -54,6 +54,7 @@ feature 'screening information card' do
       fill_in 'Assigned Social Worker', with: 'Mariko'
       select 'Safely Surrendered Baby', from: 'Report Type'
       select 'Phone', from: 'Communication Method'
+      page.execute_script 'window.scrollTo(0,0)'
       click_button 'Save'
     end
 
@@ -89,6 +90,7 @@ feature 'screening information card' do
       fill_in 'Assigned Social Worker', with: 'George Michael'
       select 'Commercially Sexually Exploited Children (CSEC)', from: 'Report Type'
       select 'In Person', from: 'Communication Method'
+      page.execute_script 'window.scrollTo(0,0)'
       fill_in_datepicker 'Screening Start Date/Time', with: '08/19/2016 3:00 AM'
       fill_in_datepicker 'Screening End Date/Time', with: '08/24/2016 3:00 AM'
       click_button 'Cancel'

--- a/spec/features/screening/screening_information_spec.rb
+++ b/spec/features/screening/screening_information_spec.rb
@@ -54,7 +54,6 @@ feature 'screening information card' do
       fill_in 'Assigned Social Worker', with: 'Mariko'
       select 'Safely Surrendered Baby', from: 'Report Type'
       select 'Phone', from: 'Communication Method'
-      byebug
       click_button 'Save'
     end
 

--- a/spec/features/screening/screening_information_spec.rb
+++ b/spec/features/screening/screening_information_spec.rb
@@ -54,6 +54,7 @@ feature 'screening information card' do
       fill_in 'Assigned Social Worker', with: 'Mariko'
       select 'Safely Surrendered Baby', from: 'Report Type'
       select 'Phone', from: 'Communication Method'
+      byebug
       click_button 'Save'
     end
 

--- a/spec/features/screening/submit_screening_spec.rb
+++ b/spec/features/screening/submit_screening_spec.rb
@@ -54,11 +54,18 @@ feature 'Submit Screening' do
         click_button 'Save'
       end
       expect(page).to have_css show_participant_card_selector(participant.id)
+      click_link('Narrative')
       within('.card', text: 'Narrative') { click_button 'Save' }
+      click_link('Incident Information')
+      page.execute_script 'window.scrollBy(0,100)'
       within('.card', text: 'Incident Information') { click_button 'Save' }
+      click_link('Allegations')
       within('.card', text: 'Allegations') { click_button 'Save' }
+      click_link('Worker Safety')
       within('.card', text: 'Worker Safety') { click_button 'Save' }
+      click_link('Cross Report')
       within('.card', text: 'Cross Report') { click_button 'Save' }
+      click_link('Decision')
       within('.card', text: 'Decision') { click_button 'Save' }
       expect(page).to have_button('Submit', disabled: false)
     end
@@ -67,13 +74,22 @@ feature 'Submit Screening' do
       visit edit_screening_path(existing_screening[:id])
       expect(page).to have_button('Submit', disabled: true)
       within('.card', text: 'Screening Information') { click_button 'Save' }
+      click_link('Narrative')
       within('.card', text: 'Narrative') { click_button 'Save' }
+      click_link('Incident Information')
+      page.execute_script 'window.scrollBy(0,100)'
       within('.card', text: 'Incident Information') { click_button 'Save' }
+      click_link('Allegations')
       within('.card', text: 'Allegations') { click_button 'Save' }
+      click_link('Worker Safety')
       within('.card', text: 'Worker Safety') { click_button 'Save' }
+      click_link('Cross Report')
       within('.card', text: 'Cross Report') { click_button 'Save' }
+      click_link('Decision')
       within('.card', text: 'Decision') { click_button 'Save' }
       expect(page).to have_button('Submit', disabled: true)
+      click_link("#{participant.first_name} #{participant.last_name}")
+      page.execute_script 'window.scrollBy(0,500)'
       within edit_participant_card_selector(participant.id) do
         click_button 'Save'
       end
@@ -89,12 +105,19 @@ feature 'Submit Screening' do
         click_button 'Save'
       end
       expect(page).to have_css show_participant_card_selector(participant.id)
+      click_link('Narrative')
       within('.card', text: 'Narrative') { click_button 'Save' }
+      click_link('Incident Information')
+      page.execute_script 'window.scrollBy(0,100)'
       within('.card', text: 'Incident Information') { click_button 'Save' }
+      click_link('Allegations')
       within('.card', text: 'Allegations') { click_button 'Save' }
+      click_link('Worker Safety')
       within('.card', text: 'Worker Safety') { click_button 'Save' }
+      click_link('Cross Report')
       within('.card', text: 'Cross Report') { click_button 'Save' }
       expect(page).to have_button('Submit', disabled: true)
+      click_link('Decision')
       within('.card', text: 'Decision') { click_button 'Save' }
       expect(page).to have_button('Submit', disabled: false)
     end
@@ -117,6 +140,7 @@ feature 'Submit Screening' do
       visit edit_screening_path(existing_screening[:id])
       save_all_cards
       expect(page).to have_button('Submit', disabled: true)
+      click_link('Screening Information')
       within('.card', text: 'Screening Information') { click_link 'Edit' }
 
       stub_screening_put_request_with_anything_and_return(
@@ -124,10 +148,9 @@ feature 'Submit Screening' do
         with_updated_attributes: { communication_method: 'fax' }
       )
 
-      within('.card', text: 'Screening Information') do
-        select 'Fax', from: 'Communication Method'
-        click_button 'Save'
-      end
+      select 'Fax', from: 'Communication Method'
+      click_link('Screening Information')
+      click_button 'Save'
 
       within('.card', text: 'Incident Information') { click_link 'Edit' }
 
@@ -168,8 +191,11 @@ feature 'Submit Screening' do
 
       visit edit_screening_path(existing_screening[:id])
       save_all_cards
+      click_link(person_name.to_s)
+      page.execute_script 'window.scrollBy(0,500)'
       within('.card', text: person_name) { click_button 'Save' }
       expect(page).to have_button('Submit', disabled: true)
+      click_link('People & Roles')
       within('.card', text: person_name) { click_link 'Edit' }
 
       person.ssn = '123-45-6789'
@@ -177,11 +203,10 @@ feature 'Submit Screening' do
         :put,
         ferb_api_url(FerbRoutes.screening_participant_path(existing_screening[:id], person.id))
       ).and_return(json_body(person.to_json))
-
-      within('.card', text: person_name) do
-        fill_in 'Social security number', with: '123-45-6789'
-        click_button 'Save'
-      end
+      click_link(person_name.to_s)
+      fill_in 'Social security number', with: '123-45-6789'
+      page.execute_script 'window.scrollBy(0,500)'
+      click_button 'Save'
 
       expect(page).to have_button('Submit', disabled: false)
     end

--- a/spec/features/screening/validations/allegations_sibling_at_risk_validations_spec.rb
+++ b/spec/features/screening/validations/allegations_sibling_at_risk_validations_spec.rb
@@ -88,15 +88,14 @@ feature 'Allegations Sibling At Risk Validations' do
         )
 
         blur_field # "allegations_#{victim.id}_#{perpetrator.id}"
-        visit current_url
+        visit current_url + '#allegations-card'
         click_button 'Save'
       end
-
       within '.card.show', text: 'Allegations' do
         expect(page).to have_content(sibling_at_risk_error)
-        visit current_url + '#allegations-card'
-        click_link 'Edit'
       end
+      click_link('Allegations')
+      click_link 'Edit'
     end
 
     scenario 'User can make the error go away' do
@@ -382,7 +381,7 @@ feature 'Allegations Sibling At Risk Validations' do
         )
 
         blur_field # "allegations_#{victim2.id}_#{perpetrator.id}"
-
+        visit current_url + '#allegations-card'
         click_button 'Save'
       end
 

--- a/spec/features/screening/validations/allegations_sibling_at_risk_validations_spec.rb
+++ b/spec/features/screening/validations/allegations_sibling_at_risk_validations_spec.rb
@@ -52,13 +52,15 @@ feature 'Allegations Sibling At Risk Validations' do
     scenario 'User sees no sibling error' do
       within '.card.edit', text: 'Allegations' do
         expect(page).not_to have_content(sibling_at_risk_error)
+        visit current_url
         click_button 'Cancel'
       end
 
       within '.card.show', text: 'Allegations' do
         expect(page).not_to have_content(sibling_at_risk_error)
-        click_link 'Edit'
       end
+      click_link('Allegations')
+      click_link 'Edit'
     end
 
     scenario 'User sees error when adding at risk allegation' do
@@ -86,12 +88,13 @@ feature 'Allegations Sibling At Risk Validations' do
         )
 
         blur_field # "allegations_#{victim.id}_#{perpetrator.id}"
-
+        visit current_url
         click_button 'Save'
       end
 
       within '.card.show', text: 'Allegations' do
         expect(page).to have_content(sibling_at_risk_error)
+        visit current_url + '#allegations-card'
         click_link 'Edit'
       end
     end
@@ -157,13 +160,15 @@ feature 'Allegations Sibling At Risk Validations' do
     scenario 'User sees warning about sibling at risk' do
       within '.card.edit', text: 'Allegations' do
         expect(page).to have_content(sibling_at_risk_error)
+        visit current_url
         click_button 'Cancel'
       end
 
       within '.card.show', text: 'Allegations' do
         expect(page).to have_content(sibling_at_risk_error)
-        click_link 'Edit'
       end
+      click_link('Allegations')
+      click_link 'Edit'
     end
 
     scenario 'User can fix warning about at risk' do

--- a/spec/features/screening/validations/allegations_validations_spec.rb
+++ b/spec/features/screening/validations/allegations_validations_spec.rb
@@ -32,8 +32,9 @@ feature 'Allegations Validations' do
 
     within '.card.show', text: 'Allegations' do
       expect(page).to have_content(error_message)
-      click_link 'Edit'
     end
+    click_link('Allegations')
+    click_link 'Edit'
 
     within '.card.edit', text: 'Allegations' do
       fill_in_react_select "allegations_#{victim.id}_#{perpetrator.id}", with: 'General neglect'
@@ -48,6 +49,7 @@ feature 'Allegations Validations' do
 
     within '.card.edit', text: 'Allegations' do
       expect(page).not_to have_content(error_message)
+      visit current_url
       click_button 'Cancel'
     end
 

--- a/spec/features/screening/validations/narrative_validations_spec.rb
+++ b/spec/features/screening/validations/narrative_validations_spec.rb
@@ -61,6 +61,7 @@ feature 'Narrative Card Validations' do
       end
       blur_field
       should_have_content error_message, inside: '#narrative-card.edit'
+      visit current_url + '#narrative-card'
       save_card('narrative')
       should_have_content error_message, inside: '#narrative-card .card-body'
     end

--- a/spec/features/screening/validations/person_age_validation_spec.rb
+++ b/spec/features/screening/validations/person_age_validation_spec.rb
@@ -56,6 +56,7 @@ feature 'Person Information Validations' do
 
           within('.card.show', text: person_name) do
             expect(page).not_to have_content(error_message)
+            visit current_url + '#search-card'
             click_link 'Edit'
           end
 
@@ -137,6 +138,8 @@ feature 'Person Information Validations' do
           person_updates: { date_of_birth: valid_date_of_birth }
         ) do
           within edit_participant_card_selector(person.id) do
+            visit current_url.split('#')[0] + "#participant-card-#{person.id}"
+            page.execute_script 'window.scrollBy(0,200)'
             fill_in_datepicker 'Date of birth', with: valid_date_of_birth
           end
         end
@@ -150,8 +153,11 @@ feature 'Person Information Validations' do
           person_updates: { date_of_birth: valid_date_of_birth }
         ) do
           within edit_participant_card_selector(person.id) do
+            visit current_url.split('#')[0] + "#participant-card-#{person.id}"
+            page.execute_script 'window.scrollBy(0,200)'
             fill_in_datepicker 'Date of birth', with: valid_date_of_birth
           end
+          click_link 'Screening Information'
           fill_in_datepicker 'Screening Start Date/Time', with: Time.new(2020, 1, 13)
         end
       end
@@ -170,6 +176,7 @@ feature 'Person Information Validations' do
 
           within('.card.show', text: person_name) do
             expect(page).not_to have_content(error_message)
+            visit current_url + '#search-card'
             click_link 'Edit'
           end
 
@@ -191,6 +198,8 @@ feature 'Person Information Validations' do
             person_updates: { date_of_birth: valid_date_of_birth }
           ) do
             within edit_participant_card_selector(person.id) do
+              visit current_url.split('#')[0] + "#participant-card-#{person.id}"
+              page.execute_script 'window.scrollBy(0,200)'
               fill_in_datepicker 'Date of birth', with: valid_date_of_birth
             end
           end

--- a/spec/features/screening/validations/person_csec_validation_spec.rb
+++ b/spec/features/screening/validations/person_csec_validation_spec.rb
@@ -36,10 +36,12 @@ feature 'CSEC validation' do
         expect(page).not_to have_content(csec_start_date_error_message)
         click_button 'Cancel'
         expect(page).to have_content(csec_start_date_error_message)
+        visit current_url + '#search-card'
         click_link 'Edit'
         fill_in_datepicker 'CSEC Start Date', with: '', blur: false
         expect(page).not_to have_content(csec_start_date_error_message)
         blur_field
+        page.execute_script 'window.scrollBy(0,100)'
         expect(page).to have_content(csec_start_date_error_message)
         fill_in_datepicker 'CSEC Start Date', with: '06-11-2018', blur: true
         expect(page).not_to have_content(csec_start_date_error_message)
@@ -55,7 +57,6 @@ feature 'CSEC validation' do
         stub_request(:put,
           ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], victim.id)))
           .and_return(json_body(updated_participant.to_json, status: 200))
-
         click_button 'Save'
         expect(page).to have_content('CSEC Start Date')
         expect(page).not_to have_content(csec_start_date_error_message)
@@ -74,7 +75,9 @@ feature 'CSEC validation' do
         expect(page).not_to have_content(csec_types_error_message)
         click_button 'Cancel'
         expect(page).to have_content(csec_types_error_message)
+        visit current_url + '#search-card'
         click_link 'Edit'
+        page.execute_script 'window.scrollBy(0,100)'
         expect(page).not_to have_content(csec_types_error_message)
         fill_in_react_select 'CSEC Types', with: ''
         blur_field

--- a/spec/features/screening/validations/person_ssn_validation_spec.rb
+++ b/spec/features/screening/validations/person_ssn_validation_spec.rb
@@ -240,13 +240,11 @@ feature 'Person Information Validations' do
       ).and_return(json_body(person.to_json))
 
       within('.card.edit', text: person_name) { click_button 'Save' }
-
-      within('.card.show', text: person_name) do
-        error_messages.each do |message|
-          expect(page).not_to have_content(message, count: 1)
-        end
-        click_link 'Edit'
+      error_messages.each do |message|
+        expect(page).not_to have_content(message, count: 1)
       end
+      click_link 'People & Roles'
+      click_link 'Edit'
 
       within('.card.edit', text: person_name) do
         error_messages.each do |message|

--- a/spec/features/screening/validations/screening_decision_validations_spec.rb
+++ b/spec/features/screening/validations/screening_decision_validations_spec.rb
@@ -55,6 +55,7 @@ feature 'Screening Decision Validations' do
   end
 
   context 'When page is opened in edit mode' do
+    Capybara.page.driver.browser.manage.window.maximize
     before do
       stub_and_visit_edit_screening(screening)
       stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))
@@ -67,7 +68,7 @@ feature 'Screening Decision Validations' do
         )
       ).and_return(json_body(involvements.to_json, status: 200))
       visit edit_screening_path(id: screening[:id])
-      page.driver.browser.navigate.refresh
+      # page.driver.browser.navigate.refresh
     end
 
     context 'Screening decision is set to nil on page load' do
@@ -100,7 +101,7 @@ feature 'Screening Decision Validations' do
           screening,
           with_updated_attributes: { screening_decision: 'promote_to_referral' }
         )
-
+        visit current_url + '#allegations-card'
         within '#decision-card.edit' do
           select 'Promote to referral', from: 'Screening Decision'
           blur_field
@@ -134,6 +135,7 @@ feature 'Screening Decision Validations' do
           expect(page).not_to have_content(allegation_error_message)
         end
 
+        visit current_url + '#allegations-card'
         within '.card.edit', text: 'Allegations' do
           fill_in_react_select "allegations_#{victim.id}_#{perpetrator.id}", with: 'General neglect'
         end
@@ -190,6 +192,7 @@ feature 'Screening Decision Validations' do
       end
 
       scenario 'Adding and removing allegations shows or hides error message' do
+        # visit current_url + '#allegations-card'
         within '#decision-card.edit' do
           select 'Promote to referral', from: 'Screening Decision'
           blur_field
@@ -200,6 +203,7 @@ feature 'Screening Decision Validations' do
           fill_in_react_select "allegations_#{victim.id}_#{perpetrator.id}", with: 'General neglect'
         end
 
+        click_link('Allegations')
         within '#decision-card.edit' do
           expect(page).not_to have_content(error_message)
         end
@@ -218,6 +222,7 @@ feature 'Screening Decision Validations' do
       let(:screening_decision) { 'promote_to_referral' }
 
       scenario 'Error message does not display until user has interacted with the field' do
+        visit current_url + '#allegations-card'
         within '#decision-card.edit' do
           expect(page).not_to have_content(error_message)
           find_field('Screening Decision').click
@@ -276,7 +281,6 @@ feature 'Screening Decision Validations' do
       scenario 'displays no error on initial load' do
         should_not_have_content error_message, inside: '#decision-card.edit'
       end
-
       scenario 'displays error on blur' do
         within '#decision-card.edit' do
           select 'Mark as Sensitive', from: 'Access Restrictions'
@@ -376,6 +380,7 @@ feature 'Screening Decision Validations' do
         end
 
         within '.card.show', text: 'Allegations' do
+          visit current_url + '#incident-information-card'
           click_link 'Edit'
         end
 

--- a/spec/features/screening/validations/screening_decision_validations_spec.rb
+++ b/spec/features/screening/validations/screening_decision_validations_spec.rb
@@ -55,7 +55,6 @@ feature 'Screening Decision Validations' do
   end
 
   context 'When page is opened in edit mode' do
-    Capybara.page.driver.browser.manage.window.maximize
     before do
       stub_and_visit_edit_screening(screening)
       stub_request(:get, ferb_api_url(FerbRoutes.intake_screening_path(screening[:id])))

--- a/spec/features/screening/worker_safety_spec.rb
+++ b/spec/features/screening/worker_safety_spec.rb
@@ -33,7 +33,7 @@ feature 'worker safety card' do
       expect(page).to have_content 'Dangerous Environment'
       expect(page).not_to have_content 'Firearms in Home'
     end
-
+    click_link('Worker Safety')
     click_link 'Edit worker safety'
 
     within '#worker-safety-card.edit' do

--- a/spec/support/helpers/screening_helpers.rb
+++ b/spec/support/helpers/screening_helpers.rb
@@ -81,8 +81,11 @@ module ScreeningHelpers
     within('.card', text: 'Narrative') { click_button 'Save' }
     within('.card', text: 'Incident Information') { click_button 'Save' }
     within('.card', text: 'Allegations') { click_button 'Save' }
+    click_link('Worker Safety')
     within('.card', text: 'Worker Safety') { click_button 'Save' }
+    click_link('Cross Report')
     within('.card', text: 'Cross Report') { click_button 'Save' }
+    click_link('Decision')
     within('.card', text: 'Decision') { click_button 'Save' }
   end
 

--- a/spec/support/helpers/validation_helpers.rb
+++ b/spec/support/helpers/validation_helpers.rb
@@ -42,12 +42,11 @@ module ValidationHelpers
 
     within('.card.edit.participant', text: person_name) { click_button 'Save' }
 
-    within('.card.show', text: person_name) do
-      error_messages.each do |message|
-        expect(page).to have_content(message, count: 1)
-      end
-      click_link 'Edit'
+    error_messages.each do |message|
+      expect(page).to have_content(message, count: 1)
     end
+    click_link('People & Roles')
+    click_link 'Edit'
 
     within('.card.edit.participant', text: person_name) do
       error_messages.each do |message|
@@ -67,12 +66,13 @@ module ValidationHelpers
       ferb_api_url(FerbRoutes.screening_participant_path(screening_id, person.id))
     ).and_return(json_body(person.to_json))
 
-    within('.card.edit.participant', text: person_name) do
-      error_messages.each do |message|
-        expect(page).not_to have_content(message)
-      end
-      click_button 'Save'
+    error_messages.each do |message|
+      expect(page).not_to have_content(message)
     end
+    click_link(person_name.to_s)
+    page.execute_script 'window.scrollBy(0,500)'
+    page.find(:xpath, '//*[@id=' +
+    %("participants-card-#{person.id}") + ']/div[2]/div[2]/div/div/button[2]').click
 
     within('.card.show', text: person_name) do
       error_messages.each do |message|


### PR DESCRIPTION
fixed stcky issue scrolling accross all browsers
### Jira Story

- [Error Message to Stay Sticky HOT-2068](https://osi-cwds.atlassian.net/browse/HOT-2068)

## Description
Removed the affix library from the intake code as that seems to break in Mozilla Firefox. As earlier we were using page header from react wooduck but for some reason, the scrolling functionality of react wood duck does not seems to be consistent in internet explorer 11. Created an own helper function that handles the scrolling events across all browsers. 

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

