### PR TITLE
SNAP-251 - Log analytics event for search result index metric

### DIFF
--- a/app/javascript/common/Autocompleter.jsx
+++ b/app/javascript/common/Autocompleter.jsx
@@ -4,6 +4,7 @@ import React, {Component} from 'react'
 import Autocomplete from 'react-autocomplete'
 import SuggestionHeader from 'common/SuggestionHeader'
 import AutocompleterFooter from 'common/AutocompleterFooter'
+import {logEvent} from 'utils/analytics'
 
 const menuStyle = {
   backgroundColor: '#fff',
@@ -52,6 +53,9 @@ export class Autocompleter extends Component {
   onItemSelect(_value, item) {
     const {isSelectable, onClear, onChange, onSelect} = this.props
     if (isSelectable(item)) {
+      logEvent('searchResultClick', {
+        searchIndex: this.props.results.indexOf(item),
+      })
       onClear()
       onChange('')
       onSelect(item)

--- a/app/javascript/utils/analytics.js
+++ b/app/javascript/utils/analytics.js
@@ -1,0 +1,5 @@
+// console.log(newrelic)
+//
+// newrelic.addPageAction('randomEventNameHere', {key1: 'value1'})
+export const logEvent = (event, attributes) =>
+  window.newrelic.addPageAction(event, attributes)

--- a/app/javascript/utils/analytics.js
+++ b/app/javascript/utils/analytics.js
@@ -1,5 +1,5 @@
-// console.log(newrelic)
-//
-// newrelic.addPageAction('randomEventNameHere', {key1: 'value1'})
+import {isFeatureActive} from 'common/config'
+
 export const logEvent = (event, attributes) =>
-  window.newrelic.addPageAction(event, attributes)
+  isFeatureActive('enable_newrelic_analytics') &&
+    window.newrelic.addPageAction(event, attributes)

--- a/app/javascript/utils/analytics.js
+++ b/app/javascript/utils/analytics.js
@@ -1,5 +1,15 @@
-import {isFeatureActive} from 'common/config'
+import {isFeatureInactive} from 'common/config'
 
-export const logEvent = (event, attributes) =>
-  isFeatureActive('enable_newrelic_analytics') &&
+export const logEvent = (event, attributes) => {
+  if (
+    isFeatureInactive('enable_newrelic_analytics') ||
+    !window.newrelic ||
+    !event
+  ) { return }
+
+  if (attributes) {
     window.newrelic.addPageAction(event, attributes)
+  } else {
+    window.newrelic.addPageAction(event)
+  }
+}

--- a/config/feature.yml
+++ b/config/feature.yml
@@ -7,6 +7,7 @@ development:
     hoi_from_intake_api: false
     snapshot: true
     screenings: true
+    enable_newrelic_analytics: true
 
 test:
   features:
@@ -16,6 +17,7 @@ test:
     hoi_from_intake_api: false
     snapshot: true
     screenings: true
+    enable_newrelic_analytics: true
 
 production:
   features:
@@ -25,3 +27,4 @@ production:
     hoi_from_intake_api: <%= ENV.fetch('HOI_FROM_INTAKE_API', false) %>
     snapshot: <%= ENV.fetch('SNAPSHOT', true) %>
     screenings: <%= ENV.fetch('SCREENINGS', true) %>
+    enable_newrelic_analytics: <%= ENV.fetch('ENABLE_NEWRELIC_ANALYTICS', true) %>

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -58,12 +58,20 @@ describe('<Autocompleter />', () => {
     )
   }
 
+  beforeEach(() => {
+    window.newrelic = jasmine.createSpyObj('newrelic', ['addPageAction'])
+  })
+
   describe('#onItemSelect', () => {
     let onClear
     let onChange
     let onSelect
-    const item = {legacyDescriptor: {legacy_id: 1}}
-    const results = [item]
+    const results = [
+      {legacyDescriptor: {legacy_id: 1}},
+      {legacyDescriptor: {legacy_id: 2}},
+      {legacyDescriptor: {legacy_id: 3}},
+    ]
+    const item = results[0]
     beforeEach(() => {
       onClear = jasmine.createSpy('onClear')
       onChange = jasmine.createSpy('onChange')
@@ -98,6 +106,28 @@ describe('<Autocompleter />', () => {
         const header = autocompleter.find('SuggestionHeader')
         expect(header.length).toBe(0)
       })
+
+      it('logs a search result event', () => {
+        expect(window.newrelic.addPageAction)
+          .toHaveBeenCalledWith('searchResultClick', {
+            searchIndex: 0,
+          })
+      })
+    })
+
+    it('logs a search result event when a deeper item is clicked', () => {
+      const autocompleter = mountAutocompleter({
+        results, onClear, onChange, onSelect,
+      })
+      autocompleter.find('input').simulate('change', {target: {value: 'te'}})
+      autocompleter.find('div[id="search-result-3"]')
+        .first()
+        .simulate('click', null)
+
+      expect(window.newrelic.addPageAction)
+        .toHaveBeenCalledWith('searchResultClick', {
+          searchIndex: 2,
+        })
     })
 
     describe('when an item is not selectable', () => {

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -1,6 +1,7 @@
 import Autocompleter from 'common/Autocompleter'
 import React from 'react'
 import {shallow, mount} from 'enzyme'
+import * as Analytics from 'utils/analytics'
 
 describe('<Autocompleter />', () => {
   function mountAutocompleter({
@@ -59,7 +60,7 @@ describe('<Autocompleter />', () => {
   }
 
   beforeEach(() => {
-    window.newrelic = jasmine.createSpyObj('newrelic', ['addPageAction'])
+    spyOn(Analytics, 'logEvent')
   })
 
   describe('#onItemSelect', () => {
@@ -108,7 +109,7 @@ describe('<Autocompleter />', () => {
       })
 
       it('logs a search result event', () => {
-        expect(window.newrelic.addPageAction)
+        expect(Analytics.logEvent)
           .toHaveBeenCalledWith('searchResultClick', {
             searchIndex: 0,
           })
@@ -124,7 +125,7 @@ describe('<Autocompleter />', () => {
         .first()
         .simulate('click', null)
 
-      expect(window.newrelic.addPageAction)
+      expect(Analytics.logEvent)
         .toHaveBeenCalledWith('searchResultClick', {
           searchIndex: 2,
         })

--- a/spec/javascripts/utils/analyticsSpec.js
+++ b/spec/javascripts/utils/analyticsSpec.js
@@ -1,0 +1,18 @@
+import {logEvent} from 'utils/analytics'
+
+describe('Analytics', () => {
+  let newrelic
+  beforeEach(() => {
+    newrelic = jasmine.createSpyObj('newrelic', ['addPageAction'])
+    window.newrelic = newrelic
+  })
+
+  describe('logEvent', () => {
+    it('logs an event to newrelic', () => {
+      logEvent('randomPageAction', {key1: 'value1'})
+
+      expect(window.newrelic.addPageAction)
+        .toHaveBeenCalledWith('randomPageAction', {key1: 'value1'})
+    })
+  })
+})

--- a/spec/javascripts/utils/analyticsSpec.js
+++ b/spec/javascripts/utils/analyticsSpec.js
@@ -10,21 +10,42 @@ describe('Analytics', () => {
 
   describe('logEvent', () => {
     it('logs an event to newrelic', () => {
-      spyOn(IntakeConfig, 'isFeatureActive').and.returnValue(true)
+      spyOn(IntakeConfig, 'isFeatureInactive').and.returnValue(false)
 
-      logEvent('randomPageAction', {key1: 'value1'})
+      logEvent('someAction', {key1: 'value1'})
 
       expect(window.newrelic.addPageAction)
-        .toHaveBeenCalledWith('randomPageAction', {key1: 'value1'})
+        .toHaveBeenCalledWith('someAction', {key1: 'value1'})
     })
 
     it('noops when newrelic analytics are disabled', () => {
-      spyOn(IntakeConfig, 'isFeatureActive').and.returnValue(false)
+      spyOn(IntakeConfig, 'isFeatureInactive').and.returnValue(true)
 
-      logEvent('randomPageAction', {key1: 'value1'})
+      logEvent('someAction', {key1: 'value1'})
 
-      expect(window.newrelic.addPageAction)
-        .not.toHaveBeenCalled()
+      expect(window.newrelic.addPageAction).not.toHaveBeenCalled()
+    })
+
+    it('does not crash when newrelic is undefined', () => {
+      spyOn(IntakeConfig, 'isFeatureInactive').and.returnValue(false)
+      window.newrelic = undefined
+
+      expect(() =>
+        logEvent('someAction', {key1: 'value1'})
+      ).not.toThrow()
+    })
+
+    it('noops when there is no event name', () => {
+      spyOn(IntakeConfig, 'isFeatureInactive').and.returnValue(false)
+      logEvent(null, {key1: 'value1'})
+      logEvent(undefined, {key1: 'value1'})
+      expect(window.newrelic.addPageAction).not.toHaveBeenCalled()
+    })
+
+    it('logs an event with no custom attributes', () => {
+      spyOn(IntakeConfig, 'isFeatureInactive').and.returnValue(false)
+      logEvent('someAction')
+      expect(window.newrelic.addPageAction).toHaveBeenCalledWith('someAction')
     })
   })
 })

--- a/spec/javascripts/utils/analyticsSpec.js
+++ b/spec/javascripts/utils/analyticsSpec.js
@@ -1,3 +1,4 @@
+import * as IntakeConfig from 'common/config'
 import {logEvent} from 'utils/analytics'
 
 describe('Analytics', () => {
@@ -9,10 +10,21 @@ describe('Analytics', () => {
 
   describe('logEvent', () => {
     it('logs an event to newrelic', () => {
+      spyOn(IntakeConfig, 'isFeatureActive').and.returnValue(true)
+
       logEvent('randomPageAction', {key1: 'value1'})
 
       expect(window.newrelic.addPageAction)
         .toHaveBeenCalledWith('randomPageAction', {key1: 'value1'})
+    })
+
+    it('noops when newrelic analytics are disabled', () => {
+      spyOn(IntakeConfig, 'isFeatureActive').and.returnValue(false)
+
+      logEvent('randomPageAction', {key1: 'value1'})
+
+      expect(window.newrelic.addPageAction)
+        .not.toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
### Jira Story

- [Initial Search Performance Metrics SNAP-251](https://osi-cwds.atlassian.net/browse/SNAP-251)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This uses newrelic to log a UX analytics event. Whenever the user clicks on a search result, we log the index (0, 1, 2, etc) of the result clicked. This only includes the result's position in the list and no PII from the query or result.

I abstracted this into a logEvent function that can be used for other future events. This searchResultClick event could be separated out into separate Hotline and Snapshot events in the future, but for now keeping them together seems OK.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

