### PR TITLE
Fix copy button issue with bind on IE -- use a fallback function instead

### DIFF
--- a/app/javascript/containers/snapshot/HistoryTableContainer.js
+++ b/app/javascript/containers/snapshot/HistoryTableContainer.js
@@ -34,14 +34,13 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => {
     ...stateProps,
     ...dispatchProps,
     ...ownProps,
-    onCopy: (e) => {
+    onCopy: (e, fallback) => {
       const copyData = formatTable(e.target.cloneNode(true))
       try {
         e.clipboardData.setData('text/html', copyData.outerHTML)
         e.preventDefault()
       } catch (error) {
-        this.originalTable = e.target.cloneNode(true) // eslint-disable-line no-invalid-this
-        formatTable(e.target)
+        fallback()
       }
     },
   }

--- a/app/javascript/views/history/HistoryTable.jsx
+++ b/app/javascript/views/history/HistoryTable.jsx
@@ -57,10 +57,7 @@ export default class HistoryTable extends React.Component {
     const {cases, referrals, screenings, onCopy, formatTable} = this.props
     return (<div className='card-body no-pad-top'>
       <div className='table-responsive' id='history'
-        ref={(history) => {
-          this.historyTable = history
-        }
-        }
+        ref={(history) => { this.historyTable = history }}
         onCopy={(e) => {
           onCopy(e, () => {
             this.originalTable = e.target.cloneNode(true)

--- a/app/javascript/views/history/HistoryTable.jsx
+++ b/app/javascript/views/history/HistoryTable.jsx
@@ -54,14 +54,19 @@ export default class HistoryTable extends React.Component {
   }
 
   render() {
-    const {cases, referrals, screenings, onCopy} = this.props
+    const {cases, referrals, screenings, onCopy, formatTable} = this.props
     return (<div className='card-body no-pad-top'>
       <div className='table-responsive' id='history'
         ref={(history) => {
           this.historyTable = history
         }
         }
-        onCopy={onCopy.bind(this)}
+        onCopy={(e) => {
+          onCopy(e, () => {
+            this.originalTable = e.target.cloneNode(true)
+            formatTable(e.target)
+          })
+        }}
       >
         <table className='table history-table ordered-table'>
           {this.renderColGroup()}
@@ -81,6 +86,7 @@ export default class HistoryTable extends React.Component {
 
 HistoryTable.propTypes = {
   cases: PropTypes.array,
+  formatTable: PropTypes.func,
   onCopy: PropTypes.func,
   referrals: PropTypes.array,
   replace: PropTypes.func,


### PR DESCRIPTION
### Jira Story

- [Copy Button Still copies Reporter Information in Internet Explorer 11 SNAP-310](https://osi-cwds.atlassian.net/browse/SNAP-310)

## Description
For some reason IE does not work well with `bind(this)` -- at least in the compiled javascript. This caused the copy button to still copy the reporter information in IE 11.

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
We don't test our containers currently.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

