### PR TITLE
Add an empty plugins() function for PostCSS to recognize the options in sass.js

### DIFF
--- a/config/webpack/loaders/sass.js
+++ b/config/webpack/loaders/sass.js
@@ -7,7 +7,13 @@ module.exports = {
     fallback: 'style-loader',
     use: [
       { loader: 'css-loader', options: { minimize: env.NODE_ENV === 'production' } },
-      { loader: 'postcss-loader', options: { sourceMap: true } },
+      { 
+        loader: 'postcss-loader',
+        options: {
+          sourceMap: true,
+          plugins: function() { return []; }
+        }
+      },
       'resolve-url-loader',
       { loader: 'sass-loader', options: { sourceMap: true } }
     ]


### PR DESCRIPTION
### Jira Story

- [Name of Story INT-NNN](https://osi-cwds.atlassian.net/browse/INT-NNN)

## Description
Example error similar to the one we had in intake (Lost track of it after fixing).
``ERROR in ./~/css-loader!./~/postcss-loader!./~/resolve-url-loader!./~/sass-loader?sourceMap!./~/bootstrap-loader/lib/bootstrap.styles.loader.js!./~/bootstrap-loader/no-op.js
Module build failed: Error: No PostCSS Config found in: /app/jenkins/workspace/dashboard/node_modules/bootstrap-loader
at Error (native)
at /app/jenkins/workspace/Toolbox-web/node_modules/postcss-load-config/index.js:51:26
@ ./~/style-loader!./~/css-loader!./~/postcss-loader!./~/resolve-url-loader!./~/sass-loader?  sourceMap!./~/bootstrap-loader/lib/bootstrap.styles.loader.js!./~/bootstrap-loader/no-op.js 4:14-193
@ ./~/bootstrap-loader/lib/bootstrap.loader.js!./~/bootstrap-loader/no-op.js
 @ ./~/bootstrap-loader/loader.js
@ ./src/vendor.browser.ts``
While trying to work with any local NPM packages with intake we face a missing POSTCSS config error when webpack-dev-server builds the app.
To resolve this we can either add a empty config file for postCSS as stackoverFlow says or we ca add an empty plugins() function for PostCSS to recognize the options.

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
Config change that has no tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

