### PR TITLE
Rl 158  - Displaying suffixes

### DIFF
--- a/app/javascript/utils/nameFormatter.js
+++ b/app/javascript/utils/nameFormatter.js
@@ -22,12 +22,17 @@ export const formatHighlightedSuffix = (highlightedSuffix) => {
   return rehighlightedSuffix
 }
 
+export const removeLooseSuffix = (suffix) => (
+  (typeof suffix === 'string') && suffix.replace(/([^\w])/g, '')
+)
+
 export const addSuffix = (name, suffix) => {
-  const validSuffix = formatNameSuffix(suffix)
+  const filteredSuffix = removeLooseSuffix(suffix)
+  const validSuffix = formatNameSuffix(filteredSuffix)
 
   if (!validSuffix) { return name }
 
-  return `${name}${isCommaSuffix(suffix) ? ',' : ''} ${validSuffix}`
+  return `${name}${isCommaSuffix(filteredSuffix) ? ',' : ''} ${validSuffix}`
 }
 
 const nameFormatter = ({

--- a/spec/features/screening/relationships_card_spec.rb
+++ b/spec/features/screening/relationships_card_spec.rb
@@ -40,7 +40,7 @@ feature 'Relationship card' do
         id: participant.id.to_s,
         first_name: participant.first_name,
         last_name: participant.last_name,
-        relationships: [].push(jane, jake),
+        relationships: [].push(jane, jake, john),
         age: 20,
         age_unit: 'Y',
         legacy_id: 'jane_legacy_id'
@@ -90,13 +90,31 @@ feature 'Relationship card' do
       }
     }
   end
+  let(:john) do
+    {
+      related_person_first_name: 'John',
+      related_person_last_name: 'Florence',
+      related_person_name_suffix: 'phd.',
+      relationship: 'Sister/Brother (Half)',
+      related_person_relationship: '18',
+      indexed_person_relationship: '277',
+      relationship_context: 'Half',
+      related_person_id: '10',
+      related_person_date_of_birth: '1986-05-05',
+      related_person_age: 32,
+      related_person_age_unit: 'Y',
+      legacy_descriptor: {
+        legacy_id: 'jake_legacy_id'
+      }
+    }
+  end
   let(:new_relationships) do
     [
       {
         id: participant.id.to_s,
         first_name: participant.first_name,
         last_name: participant.last_name,
-        relationships: [].push(jane, jake)
+        relationships: [].push(jane, jake, john)
       },
       {
         id: new_participant.id.to_s,
@@ -180,6 +198,7 @@ feature 'Relationship card' do
         )
         expect(page).to have_content('Jane Campbell Sister (Half)')
         expect(page).to have_content('Jake Campbell Brother (Half)')
+        expect(page).to have_content('John Florence, PhD Brother (Half)')
       end
 
       expect(
@@ -202,6 +221,7 @@ feature 'Relationship card' do
 
           expect(page).to have_content('Jane Campbell Sister (Half)')
           expect(page).to have_content('Jake Campbell Brother (Half)')
+          expect(page).to have_content('John Florence, PhD Brother (Half)')
         end
 
         expect(
@@ -341,6 +361,8 @@ feature 'Relationship card' do
               expect(page).to have_content('Jane Campbell')
               expect(page).to have_content('Jake Campbell Brother (Half)')
               expect(page).to have_content('05/05/1990 (28 yrs)')
+              expect(page).to have_content('John Florence, PhD Brother (Half)')
+              expect(page).to have_content('05/05/1986 (32 yrs)')
             end
 
             scenario 'should display the name of the newly attached person in sidebar' do

--- a/spec/features/snapshot/relationships_snapshot_spec.rb
+++ b/spec/features/snapshot/relationships_snapshot_spec.rb
@@ -56,6 +56,16 @@ feature 'Snapshot relationship card' do
             related_person_relationship: '280',
             indexed_person_relationship: '280',
             relationship_context: 'Half'
+          }, {
+            related_person_id: nil,
+            related_person_legacy_id: '808',
+            related_person_first_name: 'John',
+            related_person_last_name: 'Florence',
+            related_person_name_suffix: 'phd.',
+            relationship: 'Sister/Brother (Half)',
+            related_person_relationship: '18',
+            indexed_person_relationship: '277',
+            relationship_context: 'Half'
           }]
         }
       ]
@@ -120,6 +130,7 @@ feature 'Snapshot relationship card' do
         )
         expect(page).to have_content('Sister (Half) of Jake Campbell')
         expect(page).to have_content('Sister (Half) of Jane Campbell')
+        expect(page).to have_content('Sister (Half) of John Florence, PhD')
       end
     end
 

--- a/spec/javascripts/utils/nameFormatterSpec.js
+++ b/spec/javascripts/utils/nameFormatterSpec.js
@@ -1,9 +1,33 @@
 import {
+  addSuffix,
   isCommaSuffix,
   formatNameSuffix,
   formatHighlightedSuffix,
+  removeLooseSuffix,
   default as nameFormatter,
 } from 'utils/nameFormatter'
+
+describe('addSuffix', () => {
+  it('should add suffix', () => {
+    expect(addSuffix('Luke Skywalker', 'jr')).toEqual('Luke Skywalker, Jr')
+    expect(addSuffix('Anakin Skywalker', 'Phd')).toEqual('Anakin Skywalker, PhD')
+    expect(addSuffix('Ben Solo', '2')).toEqual('Ben Solo II')
+    expect(addSuffix('Ben Solo', 'ii')).toEqual('Ben Solo II')
+  })
+
+  it('should add suffix even if there is special character in suffix', () => {
+    expect(addSuffix('Luke Skywalker', 'jr.')).toEqual('Luke Skywalker, Jr')
+    expect(addSuffix('Anakin Skywalker', 'md!')).toEqual('Anakin Skywalker, MD')
+    expect(addSuffix('Ben Solo', '2.')).toEqual('Ben Solo II')
+    expect(addSuffix('Ben Solo', '.ii')).toEqual('Ben Solo II')
+  })
+
+  it('should not add suffix when it is not a string or an invalid suffix', () => {
+    expect(addSuffix('Luke Skywalker', 2)).toEqual('Luke Skywalker')
+    expect(addSuffix('Anakin Skywalker', null)).toEqual('Anakin Skywalker')
+    expect(addSuffix('Han Solo', undefined)).toEqual('Han Solo')
+  })
+})
 
 describe('isCommaSuffix', () => {
   it('should be true for name suffixes', () => {
@@ -34,6 +58,28 @@ describe('isCommaSuffix', () => {
     expect(isCommaSuffix('Primate of Italy')).toEqual(false)
     expect(isCommaSuffix(null)).toEqual(false)
     expect(isCommaSuffix(3)).toEqual(false)
+  })
+})
+
+describe('removeLooseSuffix', () => {
+  it('should remove special characters', () => {
+    expect(removeLooseSuffix('jr.')).toEqual('jr')
+    expect(removeLooseSuffix('sr/')).toEqual('sr')
+    expect(removeLooseSuffix('/sr')).toEqual('sr')
+    expect(removeLooseSuffix('!')).toEqual('')
+    expect(removeLooseSuffix('2?')).toEqual('2')
+    expect(removeLooseSuffix('ii.')).toEqual('ii')
+    expect(removeLooseSuffix('l!')).toEqual('l')
+  })
+
+  it('should return empty string if suffix is an empty string', () => {
+    expect(removeLooseSuffix('')).toEqual('')
+  })
+
+  it('should return false if the suffix is not a string', () => {
+    expect(removeLooseSuffix(null)).toBe(false)
+    expect(removeLooseSuffix(2)).toBe(false)
+    expect(removeLooseSuffix(undefined)).toBe(false)
   })
 })
 
@@ -227,6 +273,7 @@ describe('nameFormatter', () => {
         name_suffix: '4',
       })).toEqual('Bill S. Preston IV')
     })
+
     it('returns empty for suffix name is undefined', () => {
       expect(nameFormatter({
         first_name: 'Bill',
@@ -234,6 +281,36 @@ describe('nameFormatter', () => {
         last_name: 'Preston',
         name_suffix: undefined,
       })).toEqual('Bill S. Preston')
+    })
+
+    it('returns the name with suffix for a suffix with special char.', () => {
+      expect(nameFormatter({
+        first_name: 'Bill',
+        middle_name: 'S.',
+        last_name: 'Preston',
+        name_suffix: 'jr.',
+      })).toEqual('Bill S. Preston, Jr')
+
+      expect(nameFormatter({
+        first_name: 'Bill',
+        middle_name: 'S.',
+        last_name: 'Preston',
+        name_suffix: '.pHD',
+      })).toEqual('Bill S. Preston, PhD')
+
+      expect(nameFormatter({
+        first_name: 'Bill',
+        middle_name: 'S.',
+        last_name: 'Preston',
+        name_suffix: 'V.',
+      })).toEqual('Bill S. Preston V')
+
+      expect(nameFormatter({
+        first_name: 'Bill',
+        middle_name: 'S.',
+        last_name: 'Preston',
+        name_suffix: '5 ',
+      })).toEqual('Bill S. Preston V')
     })
   })
 


### PR DESCRIPTION
### Jira Story

- [Suffixes are missing on the relationship card RL-158](https://osi-cwds.atlassian.net/browse/RL-158)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

- Display First, Middle, Last and Suffix of person on header and table on the relationship card edit and create cards
- This will also impact snapshot.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

