### PR TITLE
Snap 250 replace disposition with conclusions in hoi card

### DIFF
--- a/app/javascript/views/history/ReferralView.jsx
+++ b/app/javascript/views/history/ReferralView.jsx
@@ -33,7 +33,7 @@ const ReferralView = ({
           <tr>
             <th scope='col' className='victim semibold'>Victim</th>
             <th scope='col' className='perpetrator semibold'>Perpetrator</th>
-            <th scope='col' className='allegations disposition semibold'>Allegation(s) &amp; Disposition</th>
+            <th scope='col' className='allegations disposition semibold'>Allegation(s) &amp; Conclusion(s)</th>
           </tr>
         </thead>
         <tbody>

--- a/spec/features/screening/history_of_involvement_spec.rb
+++ b/spec/features/screening/history_of_involvement_spec.rb
@@ -341,7 +341,7 @@ feature 'History card' do
               within allegation_rows[0] do
                 expect(page).to have_content('Victim')
                 expect(page).to have_content('Perpetrator')
-                expect(page).to have_content('Allegation(s) & Disposition')
+                expect(page).to have_content('Allegation(s) & Conclusion(s)')
               end
 
               within allegation_rows[1] do
@@ -369,7 +369,7 @@ feature 'History card' do
               within allegation_rows[0] do
                 expect(page).to have_content('Victim')
                 expect(page).to have_content('Perpetrator')
-                expect(page).to have_content('Allegation(s) & Disposition')
+                expect(page).to have_content('Allegation(s) & Conclusion(s)')
               end
 
               within allegation_rows[1] do
@@ -478,7 +478,7 @@ feature 'History card' do
               within allegation_rows[0] do
                 expect(page).to have_content('Victim')
                 expect(page).to have_content('Perpetrator')
-                expect(page).to have_content('Allegation(s) & Disposition')
+                expect(page).to have_content('Allegation(s) & Conclusion(s)')
               end
 
               within allegation_rows[1] do
@@ -506,7 +506,7 @@ feature 'History card' do
               within allegation_rows[0] do
                 expect(page).to have_content('Victim')
                 expect(page).to have_content('Perpetrator')
-                expect(page).to have_content('Allegation(s) & Disposition')
+                expect(page).to have_content('Allegation(s) & Conclusion(s)')
               end
 
               within allegation_rows[1] do
@@ -665,7 +665,7 @@ feature 'History card' do
                 within allegation_rows[0] do
                   expect(page).to have_content('Victim')
                   expect(page).to have_content('Perpetrator')
-                  expect(page).to have_content('Allegation(s) & Disposition')
+                  expect(page).to have_content('Allegation(s) & Conclusion(s)')
                 end
 
                 within allegation_rows[1] do
@@ -693,7 +693,7 @@ feature 'History card' do
                 within allegation_rows[0] do
                   expect(page).to have_content('Victim')
                   expect(page).to have_content('Perpetrator')
-                  expect(page).to have_content('Allegation(s) & Disposition')
+                  expect(page).to have_content('Allegation(s) & Conclusion(s)')
                 end
 
                 within allegation_rows[1] do

--- a/spec/features/snapshot/history_of_involvement_spec.rb
+++ b/spec/features/snapshot/history_of_involvement_spec.rb
@@ -290,7 +290,7 @@ feature 'Snapshot History of Involvement' do
               within allegation_rows[0] do
                 expect(page).to have_content('Victim')
                 expect(page).to have_content('Perpetrator')
-                expect(page).to have_content('Allegation(s) & Disposition')
+                expect(page).to have_content('Allegation(s) & Conclusion(s)')
               end
 
               within allegation_rows[1] do
@@ -318,7 +318,7 @@ feature 'Snapshot History of Involvement' do
               within allegation_rows[0] do
                 expect(page).to have_content('Victim')
                 expect(page).to have_content('Perpetrator')
-                expect(page).to have_content('Allegation(s) & Disposition')
+                expect(page).to have_content('Allegation(s) & Conclusion(s)')
               end
 
               within allegation_rows[1] do
@@ -449,7 +449,7 @@ feature 'Snapshot History of Involvement' do
               within allegation_rows[0] do
                 expect(page).to have_content('Victim')
                 expect(page).to have_content('Perpetrator')
-                expect(page).to have_content('Allegation(s) & Disposition')
+                expect(page).to have_content('Allegation(s) & Conclusion(s)')
               end
 
               within allegation_rows[1] do
@@ -477,7 +477,7 @@ feature 'Snapshot History of Involvement' do
               within allegation_rows[0] do
                 expect(page).to have_content('Victim')
                 expect(page).to have_content('Perpetrator')
-                expect(page).to have_content('Allegation(s) & Disposition')
+                expect(page).to have_content('Allegation(s) & Conclusion(s)')
               end
 
               within allegation_rows[1] do

--- a/spec/javascripts/views/history/ReferralViewSpec.jsx
+++ b/spec/javascripts/views/history/ReferralViewSpec.jsx
@@ -59,7 +59,7 @@ describe('ReferralView', () => {
       const component = renderReferralView({})
       expect(component.find('.people-and-roles').find('th.victim').text()).toEqual('Victim')
       expect(component.find('.people-and-roles').find('th.perpetrator').text()).toEqual('Perpetrator')
-      expect(component.find('.people-and-roles').find('th.allegations.disposition').text()).toEqual('Allegation(s) & Disposition')
+      expect(component.find('.people-and-roles').find('th.allegations.disposition').text()).toEqual('Allegation(s) & Conclusion(s)')
     })
 
     it('renders a victim for each person', () => {


### PR DESCRIPTION
### Jira Story

- [In the history card, "Conclusion," will replace, "Disposition," in SNAP and HOT SNAP-250](https://osi-cwds.atlassian.net/browse/SNAP-250)

## Description
Just a cosmetic change as 
Business Value: 
The word conclusion will replace Disposition. The outcome of the referral will be considered the conclusion of the investigation. The term disposition was confusing users.

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Not sure which one to pick. Story says feature request but as per code this is refactor imo.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

