### PR TITLE
Trim spaces from the ends of names

### DIFF
--- a/app/javascript/utils/nameFormatter.js
+++ b/app/javascript/utils/nameFormatter.js
@@ -44,9 +44,9 @@ const nameFormatter = ({
 }) => {
   if (first_name || last_name) {
     const name = [
-      first_name || '(Unknown first name)',
-      middle_name,
-      last_name || '(Unknown last name)',
+      (first_name || '(Unknown first name)').trim(),
+      middle_name && middle_name.trim(),
+      (last_name || '(Unknown last name)').trim(),
     ].filter(Boolean).join(' ')
 
     return addSuffix(name, name_suffix)

--- a/spec/javascripts/utils/nameFormatterSpec.js
+++ b/spec/javascripts/utils/nameFormatterSpec.js
@@ -151,6 +151,14 @@ describe('nameFormatter', () => {
     })).toEqual('Foo Bar')
   })
 
+  it('trims spaces from the ends of names', () => {
+    expect(nameFormatter({
+      first_name: ' Foo Foo ',
+      middle_name: '  Inigo Montoya  ',
+      last_name: ' Van Der Bar  ',
+    })).toEqual('Foo Foo Inigo Montoya Van Der Bar')
+  })
+
   it('renders with a blank first name', () => {
     expect(nameFormatter({
       first_name: null,


### PR DESCRIPTION
### Jira Story

Possibly related to RL-158, but I found it in independent testing.
- [Suffixes are missing on the relationship card RL-158](https://osi-cwds.atlassian.net/browse/RL-158)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
The relationships endpoint returns last names with a space on the
end. This is probably bad data, but it also draws attention to a
case that we should probably be able to handle.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
