### PR TITLE
SNAP-364 Refactor create snapshot person saga to take every request for create person

### DIFF
--- a/app/javascript/sagas/createSnapshotPersonSaga.js
+++ b/app/javascript/sagas/createSnapshotPersonSaga.js
@@ -1,5 +1,5 @@
 import {fromJS} from 'immutable'
-import {takeLatest, put, call, select} from 'redux-saga/effects'
+import {takeEvery, put, call, select} from 'redux-saga/effects'
 import {STATUS_CODES, get} from 'utils/http'
 import {
   CREATE_SNAPSHOT_PERSON,
@@ -29,5 +29,5 @@ export function* createSnapshotPerson({payload: {id}}) {
   }
 }
 export function* createSnapshotPersonSaga() {
-  yield takeLatest(CREATE_SNAPSHOT_PERSON, createSnapshotPerson)
+  yield takeEvery(CREATE_SNAPSHOT_PERSON, createSnapshotPerson)
 }

--- a/spec/javascripts/sagas/createSnapshotPersonSagaSpec.js
+++ b/spec/javascripts/sagas/createSnapshotPersonSagaSpec.js
@@ -1,6 +1,6 @@
 import 'babel-polyfill'
 import {fromJS} from 'immutable'
-import {takeLatest, put, call, select} from 'redux-saga/effects'
+import {takeEvery, put, call, select} from 'redux-saga/effects'
 import {get} from 'utils/http'
 import {
   createSnapshotPerson,
@@ -16,7 +16,7 @@ import {RESIDENCE_TYPE} from 'enums/AddressType'
 describe('createSnapshotPersonSaga', () => {
   it('creates participant on CREATE_SNAPSHOT_PERSON', () => {
     const gen = createSnapshotPersonSaga()
-    expect(gen.next().value).toEqual(takeLatest(CREATE_SNAPSHOT_PERSON, createSnapshotPerson))
+    expect(gen.next().value).toEqual(takeEvery(CREATE_SNAPSHOT_PERSON, createSnapshotPerson))
   })
 })
 


### PR DESCRIPTION

### Jira Story

- [Attach link does not work for multiple persons SNAP-364](https://osi-cwds.atlassian.net/browse/SNAP-364)

## Description
Currently create snapshot person saga only takes latest request. But if you click the attach link very rapidly so that there is very minute gap it breaks the purpose of attach by not adding the person.
Business value: As a user, I want to attach as many people as in need to on the first try to the Snapshot, so that i can see all family members child welfare history

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

