### PR TITLE
DS-425 - Update Jenkinsfile to build with loaded credentials

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -74,6 +74,7 @@ node('intake-slave') {
 
         withCredentials([usernameColonPassword(credentialsId: 'fa186416-faac-44c0-a2fa-089aed50ca17', variable: 'jenkinsauth')]) {
           sh "curl -v -u $jenkinsauth 'http://jenkins.mgmt.cwds.io:8080/job/preint/job/intake-app-pipeline/buildWithParameters" +
+            "?token=${JENKINS_TRIGGER_TOKEN}" +
             "&cause=Caused%20by%20Build%20${env.BUILD_ID}" +
             "&INTAKE_APP_VERSION=${VERSION}'"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,12 +71,14 @@ node('intake-slave') {
       }
 
       stage('Deploy Preint') {
-        sh "curl -v 'http://${JENKINS_USER}:${JENKINS_API_TOKEN}@jenkins.mgmt.cwds.io:8080/job/preint/job/intake-app-pipeline/buildWithParameters" +
-          "?token=${JENKINS_TRIGGER_TOKEN}" +
-          "&cause=Caused%20by%20Build%20${env.BUILD_ID}" +
-          "&INTAKE_APP_VERSION=${VERSION}'"
-          pipelineStatus = 'SUCCEEDED'
-          currentBuild.result = 'SUCCESS'
+
+        withCredentials([usernameColonPassword(credentialsId: 'fa186416-faac-44c0-a2fa-089aed50ca17', variable: 'jenkinsauth')]) {
+          sh "curl -v -u $jenkinsauth 'http://jenkins.mgmt.cwds.io:8080/job/preint/job/intake-app-pipeline/buildWithParameters" +
+            "&cause=Caused%20by%20Build%20${env.BUILD_ID}" +
+            "&INTAKE_APP_VERSION=${VERSION}'"
+        }
+        pipelineStatus = 'SUCCEEDED'
+        currentBuild.result = 'SUCCESS'
       }
 
       stage('Trigger Security scan') {


### PR DESCRIPTION
### Jira Story

- [Enable Intake-app auto deployments to Pre-int and Int DS-425](https://osi-cwds.atlassian.net/browse/DS-425)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This updates our Jenkins file to use stored credentials to deploy to Preint, rather than person user credentials.

We have not tested directly, as merging with master is necessary to check whether the deploy will be successful. Note, however, that builds are currently *not* going out to Preint, so this cannot break it any worse than it is today.


## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->
See above.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x]  Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

