### PR TITLE
SNAP-128 

### DIFF
--- a/app/javascript/sagas/fetchHistoryOfInvolvementsSaga.js
+++ b/app/javascript/sagas/fetchHistoryOfInvolvementsSaga.js
@@ -1,4 +1,4 @@
-import {takeEvery, put, call} from 'redux-saga/effects'
+import {takeLatest, put, call} from 'redux-saga/effects'
 import {get} from 'utils/http'
 import {
   fetchHistoryOfInvolvementsSuccess,
@@ -33,5 +33,5 @@ export function fetchHistoryOfInvolvements({payload: {type, id, ids}}) {
   return fetchHistoryForUnitOfWork(type, id)
 }
 export function* fetchHistoryOfInvolvementsSaga() {
-  yield takeEvery(FETCH_HISTORY_OF_INVOLVEMENTS, fetchHistoryOfInvolvements)
+  yield takeLatest(FETCH_HISTORY_OF_INVOLVEMENTS, fetchHistoryOfInvolvements)
 }

--- a/app/javascript/sagas/fetchRelationshipsSaga.js
+++ b/app/javascript/sagas/fetchRelationshipsSaga.js
@@ -1,4 +1,4 @@
-import {takeEvery, put, call} from 'redux-saga/effects'
+import {takeLatest, put, call} from 'redux-saga/effects'
 import {get} from 'utils/http'
 import {
   fetchRelationshipsSuccess,
@@ -18,5 +18,5 @@ export function* fetchRelationships({payload: {ids}}) {
 }
 
 export function* fetchRelationshipsSaga() {
-  yield takeEvery(FETCH_RELATIONSHIPS, fetchRelationships)
+  yield takeLatest(FETCH_RELATIONSHIPS, fetchRelationships)
 }

--- a/spec/javascripts/sagas/fetchHistoryOfInvolvementsSagaSpec.js
+++ b/spec/javascripts/sagas/fetchHistoryOfInvolvementsSagaSpec.js
@@ -1,5 +1,5 @@
 import 'babel-polyfill'
-import {takeEvery, put, call} from 'redux-saga/effects'
+import {takeLatest, put, call} from 'redux-saga/effects'
 import {get} from 'utils/http'
 import {
   fetchHistoryOfInvolvementsSaga,
@@ -12,7 +12,7 @@ describe('fetchHistoryOfInvolvementsSaga', () => {
   it('fetches involvements on FETCH_HISTORY_OF_INVOLVEMENTS', () => {
     const gen = fetchHistoryOfInvolvementsSaga()
     expect(gen.next().value).toEqual(
-      takeEvery(FETCH_HISTORY_OF_INVOLVEMENTS, fetchHistoryOfInvolvements)
+      takeLatest(FETCH_HISTORY_OF_INVOLVEMENTS, fetchHistoryOfInvolvements)
     )
   })
 })

--- a/spec/javascripts/sagas/fetchRelationshipsSagaSpec.js
+++ b/spec/javascripts/sagas/fetchRelationshipsSagaSpec.js
@@ -1,5 +1,5 @@
 import 'babel-polyfill'
-import {takeEvery, put, call} from 'redux-saga/effects'
+import {takeLatest, put, call} from 'redux-saga/effects'
 import {get} from 'utils/http'
 import {
   fetchRelationshipsSaga,
@@ -12,7 +12,7 @@ describe('fetchRelationshipsSaga', () => {
   it('fetches relationships on FETCH_RELATIONSHIPS', () => {
     const gen = fetchRelationshipsSaga()
     expect(gen.next().value).toEqual(
-      takeEvery(FETCH_RELATIONSHIPS, fetchRelationships)
+      takeLatest(FETCH_RELATIONSHIPS, fetchRelationships)
     )
   })
 })


### PR DESCRIPTION
takeEvery -> takeLatest in fetch HOI and Relationships sagas due to concurrency reasons.

### Jira Story

- [Name of Story SNAP-128](https://osi-cwds.atlassian.net/browse/SNAP-128)

## Description
takeLatest helper instead of takeEvery. 
There was a concurrency issue, when first request used to take more time than last one, state received result of the first "outdated" request later than from the last "up to date" request, and data was overwritten. takeLatest helper will cancel old request, and only latest request will be performed. 

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

