### PR TITLE
Specify exact version of react-wood-duck

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-router-redux": "^4.0.8",
     "react-select": "^1.0.0-rc.5",
     "react-widgets": "^3.4.8",
-    "react-wood-duck": "^0.1.71",
+    "react-wood-duck": "0.1.71",
     "redux": "3.6.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-immutable": "^4.0.0",


### PR DESCRIPTION
Since Intake uses more aggressive accessibility testing than
react-wood-duck, we are very sensitive to small changes in the
dependency library. So, we should be specifying the exact version
and controlling updates very carefully.

### Jira Story

- No Story

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

I didn't run anything. I just want this out to stop breaking PR and master builds.