### PR TITLE
Do not reset scroll for hash navigation

### DIFF
--- a/app/javascript/common/app/ScrollToTop.jsx
+++ b/app/javascript/common/app/ScrollToTop.jsx
@@ -7,7 +7,9 @@ export class ScrollToTop extends PureComponent {
     this.focusTarget = React.createRef()
   }
   componentDidUpdate(prevProps) {
-    if (this.props.location !== prevProps.location) {
+    const location = this.props.location
+    const hasNoHash = location && !location.hash
+    if (location !== prevProps.location && hasNoHash) {
       window.scrollTo(0, 0)
       this.focusTarget.current.focus()
     }
@@ -23,6 +25,8 @@ export class ScrollToTop extends PureComponent {
 
 ScrollToTop.propTypes = {
   children: PropTypes.node.isRequired,
-  // A location from react-router, but we don't actually care about its shape:
-  location: PropTypes.any,
+  // A location from react-router:
+  location: PropTypes.shape({
+    hash: PropTypes.string,
+  }),
 }

--- a/spec/javascripts/common/app/ScrollToTopSpec.jsx
+++ b/spec/javascripts/common/app/ScrollToTopSpec.jsx
@@ -6,7 +6,7 @@ describe('ScrollToTop', () => {
   let root
   beforeEach(() => {
     // Must use mount, as refs are important part of functionality
-    root = mount(<ScrollToTop location='/'>Hello, World</ScrollToTop>)
+    root = mount(<ScrollToTop location={{path: '/'}}>Hello, World</ScrollToTop>)
   })
 
   it('renders a div and keeps it as a ref', () => {
@@ -25,7 +25,7 @@ describe('ScrollToTop', () => {
 
   it('scrolls to top after update when location changes', () => {
     const scrollTo = spyOn(window, 'scrollTo')
-    root.setProps({location: '/new_page'})
+    root.setProps({location: {path: '/new_page'}})
     expect(scrollTo).toHaveBeenCalledWith(0, 0)
   })
 
@@ -37,7 +37,7 @@ describe('ScrollToTop', () => {
 
   it('focuses on the div after update when location changes', () => {
     const focus = spyOn(root.instance().focusTarget.current, 'focus')
-    root.setProps({location: '/new_page'})
+    root.setProps({location: {path: '/new_page'}})
     expect(focus).toHaveBeenCalled()
   })
 
@@ -45,5 +45,20 @@ describe('ScrollToTop', () => {
     const focus = spyOn(root.instance().focusTarget.current, 'focus')
     root.setProps({children: 'Goodbye, Cruel World'})
     expect(focus).not.toHaveBeenCalled()
+  })
+
+  it('lets the browser handle scroll and focus when there is a hash', () => {
+    const scrollTo = spyOn(window, 'scrollTo')
+    const focus = spyOn(root.instance().focusTarget.current, 'focus')
+
+    root.setProps({location: {hash: '#from_none_to_one'}})
+    root.setProps({location: {hash: '#from_one_to_another'}})
+
+    expect(scrollTo).not.toHaveBeenCalled()
+    expect(focus).not.toHaveBeenCalled()
+
+    root.setProps({location: {hash: ''}})
+    expect(scrollTo).toHaveBeenCalled()
+    expect(focus).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
### Jira Story

- [Links for Privacy Policy and Conditions of Use pages should load to top of these pages SNAP-379](https://osi-cwds.atlassian.net/browse/SNAP-379)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
I overlooked hash routing (links to anchor tags within the same page) when dealing with the Router scroll restoration behavior. This caused sidebar navigation and table of contents links in Conditions of Use to break. :-(

This patch avoids that by only restoring the scroll position when the route changes *and* the new route has no hash. If it does have a hash, we assume that the browser will handle it to scroll wherever needed. (And indeed, long-term, pushState behavior is expected to be handled completely by browsers internally.)


## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

