### PR TITLE
SNAP 407 Time Spent In Search

### DIFF
--- a/app/javascript/common/Autocompleter.jsx
+++ b/app/javascript/common/Autocompleter.jsx
@@ -6,6 +6,7 @@ import SuggestionHeader from 'common/SuggestionHeader'
 import CreateUnknownPerson from 'screenings/CreateUnknownPerson'
 import ShowMoreResults from 'common/ShowMoreResults'
 import {logEvent} from 'utils/analytics'
+import moment from 'moment'
 
 const menuStyle = {
   backgroundColor: '#fff',
@@ -98,12 +99,13 @@ export class Autocompleter extends Component {
   }
 
   onItemSelect(_value, item) {
-    const {isSelectable, onClear, onChange, onSelect, onLoadMoreResults, staffId} = this.props
+    const {isSelectable, onClear, onChange, onSelect, onLoadMoreResults, staffId, startTime} = this.props
     if (item.legacyDescriptor) {
       if (isSelectable(item)) {
         logEvent('searchResultClick', {
           searchIndex: this.props.results.indexOf(item),
           staffId,
+          startTime: moment(startTime).valueOf(),
         })
         onClear()
         onChange('')
@@ -238,6 +240,7 @@ Autocompleter.propTypes = {
   results: PropTypes.array,
   searchTerm: PropTypes.string,
   staffId: PropTypes.string,
+  startTime: PropTypes.string,
   total: PropTypes.number,
 }
 

--- a/app/javascript/common/Autocompleter.jsx
+++ b/app/javascript/common/Autocompleter.jsx
@@ -98,11 +98,12 @@ export class Autocompleter extends Component {
   }
 
   onItemSelect(_value, item) {
-    const {isSelectable, onClear, onChange, onSelect, onLoadMoreResults} = this.props
+    const {isSelectable, onClear, onChange, onSelect, onLoadMoreResults, staffId} = this.props
     if (item.legacyDescriptor) {
       if (isSelectable(item)) {
         logEvent('searchResultClick', {
           searchIndex: this.props.results.indexOf(item),
+          staffId,
         })
         onClear()
         onChange('')
@@ -236,6 +237,7 @@ Autocompleter.propTypes = {
   onSelect: PropTypes.func.isRequired,
   results: PropTypes.array,
   searchTerm: PropTypes.string,
+  staffId: PropTypes.string,
   total: PropTypes.number,
 }
 

--- a/app/javascript/containers/common/PersonSearchFormContainer.js
+++ b/app/javascript/containers/common/PersonSearchFormContainer.js
@@ -8,6 +8,7 @@ import {
 } from 'selectors/peopleSearchSelectors'
 import {search, setSearchTerm, clear, loadMoreResults} from 'actions/peopleSearchActions'
 import {canUserAddClient} from 'utils/authorization'
+import {getStaffIdSelector} from 'selectors/userInfoSelectors'
 
 const mapStateToProps = (state) => {
   const userInfo = state.get('userInfo').toJS()
@@ -19,6 +20,7 @@ const mapStateToProps = (state) => {
     results: getPeopleResultsSelector(state).toJS(),
     total: getResultsTotalValueSelector(state),
     searchTerm: getSearchTermValueSelector(state),
+    staffId: getStaffIdSelector(state),
     participants: selectParticipants(state).toJS(),
     isSelectable,
   }

--- a/app/javascript/containers/common/PersonSearchFormContainer.js
+++ b/app/javascript/containers/common/PersonSearchFormContainer.js
@@ -5,6 +5,7 @@ import {
   getPeopleResultsSelector,
   getResultsTotalValueSelector,
   getSearchTermValueSelector,
+  getStartTimeSelector,
 } from 'selectors/peopleSearchSelectors'
 import {search, setSearchTerm, clear, loadMoreResults} from 'actions/peopleSearchActions'
 import {canUserAddClient} from 'utils/authorization'
@@ -21,6 +22,7 @@ const mapStateToProps = (state) => {
     total: getResultsTotalValueSelector(state),
     searchTerm: getSearchTermValueSelector(state),
     staffId: getStaffIdSelector(state),
+    startTime: getStartTimeSelector(state),
     participants: selectParticipants(state).toJS(),
     isSelectable,
   }

--- a/app/javascript/reducers/peopleSearchReducer.js
+++ b/app/javascript/reducers/peopleSearchReducer.js
@@ -7,6 +7,7 @@ import {
   SET_SEARCH_TERM,
   LOAD_MORE_RESULTS_COMPLETE,
 } from 'actions/peopleSearchActions'
+import moment from 'moment'
 
 const initialState = fromJS({
   results: [],
@@ -29,9 +30,15 @@ export default createReducer(initialState, {
   [PEOPLE_SEARCH_CLEAR](state, _action) {
     return state.set('results', fromJS([]))
       .set('total', 0)
+      .set('startTime', null)
   },
   [SET_SEARCH_TERM](state, {payload: {searchTerm}}) {
-    return state.set('searchTerm', searchTerm)
+    if (state.get('startTime')) {
+      return state.set('searchTerm', searchTerm)
+    } else {
+      return state.set('searchTerm', searchTerm)
+        .set('startTime', moment().toISOString())
+    }
   },
   [LOAD_MORE_RESULTS_COMPLETE](state, {payload: {results}, error}) {
     if (error) {

--- a/app/javascript/selectors/peopleSearchSelectors.js
+++ b/app/javascript/selectors/peopleSearchSelectors.js
@@ -95,3 +95,6 @@ export const getPeopleResultsSelector = (state) => getPeopleSearchSelector(state
       isSealed: mapIsSealed(result),
     })
   })
+
+export const getStartTimeSelector = (state) => getPeopleSearchSelector(state)
+  .get('startTime')

--- a/app/javascript/views/people/PersonSearchForm.jsx
+++ b/app/javascript/views/people/PersonSearchForm.jsx
@@ -46,6 +46,7 @@ PersonSearchForm.propTypes = {
   results: PropTypes.array,
   searchPrompt: PropTypes.string.isRequired,
   searchTerm: PropTypes.string,
+  staffId: PropTypes.string,
   total: PropTypes.number,
 }
 

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -16,6 +16,7 @@ describe('<Autocompleter />', () => {
     results = [],
     searchTerm = '',
     total = 0,
+    staffId = '0x3',
   }) {
     return mount(
       <Autocompleter
@@ -29,6 +30,7 @@ describe('<Autocompleter />', () => {
         results={results}
         searchTerm={searchTerm}
         onSearch={onSearch}
+        staffId={staffId}
       />
     )
   }
@@ -43,6 +45,7 @@ describe('<Autocompleter />', () => {
     results = [],
     total = 0,
     id = null,
+    staffId = '0x3',
   }) {
     return shallow(
       <Autocompleter
@@ -56,6 +59,7 @@ describe('<Autocompleter />', () => {
         results={results}
         searchTerm={searchTerm}
         onSearch={onSearch}
+        staffId={staffId}
       />, {disableLifecycleMethods: true}
     )
   }
@@ -115,6 +119,7 @@ describe('<Autocompleter />', () => {
         expect(Analytics.logEvent)
           .toHaveBeenCalledWith('searchResultClick', {
             searchIndex: 0,
+            staffId: '0x3',
           })
       })
     })
@@ -178,6 +183,7 @@ describe('<Autocompleter />', () => {
       expect(Analytics.logEvent)
         .toHaveBeenCalledWith('searchResultClick', {
           searchIndex: 2,
+          staffId: '0x3',
         })
     })
 

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -31,6 +31,7 @@ describe('<Autocompleter />', () => {
         searchTerm={searchTerm}
         onSearch={onSearch}
         staffId={staffId}
+        startTime={500}
       />
     )
   }
@@ -60,6 +61,7 @@ describe('<Autocompleter />', () => {
         searchTerm={searchTerm}
         onSearch={onSearch}
         staffId={staffId}
+        startTime={500}
       />, {disableLifecycleMethods: true}
     )
   }
@@ -120,6 +122,7 @@ describe('<Autocompleter />', () => {
           .toHaveBeenCalledWith('searchResultClick', {
             searchIndex: 0,
             staffId: '0x3',
+            startTime: 500,
           })
       })
     })
@@ -184,6 +187,7 @@ describe('<Autocompleter />', () => {
         .toHaveBeenCalledWith('searchResultClick', {
           searchIndex: 2,
           staffId: '0x3',
+          startTime: 500,
         })
     })
 

--- a/spec/javascripts/reducers/peopleSearchReducerSpec.js
+++ b/spec/javascripts/reducers/peopleSearchReducerSpec.js
@@ -10,6 +10,7 @@ import {
 } from 'actions/peopleSearchActions'
 import peopleSearchReducer from 'reducers/peopleSearchReducer'
 import {Map, fromJS} from 'immutable'
+import moment from 'moment'
 
 describe('peopleSearchReducer', () => {
   beforeEach(() => jasmine.addMatchers(matchers))
@@ -60,12 +61,13 @@ describe('peopleSearchReducer', () => {
       results: ['result_one', 'result_two', 'result_three'],
     })
     const action = clear()
-    it('resets results and total', () => {
+    it('resets results, total, and startTime', () => {
       expect(peopleSearchReducer(initialState, action)).toEqualImmutable(
         fromJS({
           searchTerm: 'newSearchTerm',
           total: 0,
           results: [],
+          startTime: null,
         })
       )
     })
@@ -77,14 +79,18 @@ describe('peopleSearchReducer', () => {
       results: ['result_one', 'result_two', 'result_three'],
     })
     const action = setSearchTerm('something')
-    it('resets results and total', () => {
+    it('resets results, total and sets startTime', () => {
+      const today = moment('2015-10-19').toDate()
+      jasmine.clock().mockDate(today)
       expect(peopleSearchReducer(initialState, action)).toEqualImmutable(
         fromJS({
           searchTerm: 'something',
           total: 3,
           results: ['result_one', 'result_two', 'result_three'],
+          startTime: today.toISOString(),
         })
       )
+      jasmine.clock().uninstall()
     })
   })
   describe('on LOAD_MORE_RESULTS_COMPLETE', () => {

--- a/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
+++ b/spec/javascripts/selectors/peopleSearchSelectorsSpec.js
@@ -4,6 +4,7 @@ import {RESIDENCE_TYPE} from 'enums/AddressType'
 import {
   getPeopleResultsSelector,
   getLastResultsSortValueSelector,
+  getStartTimeSelector,
 } from 'selectors/peopleSearchSelectors'
 
 describe('peopleSearchSelectors', () => {
@@ -433,6 +434,24 @@ describe('peopleSearchSelectors', () => {
       })
       const peopleResults = getPeopleResultsSelector(state)
       expect(peopleResults.getIn([0, 'ssn'])).toEqual('<em>123-45-6789</em>')
+    })
+  })
+
+  describe('getStartTimeSelector', () => {
+    it('gets the start time when there is a start time', () => {
+      const peopleSearch = {
+        startTime: '10-10-2001',
+      }
+      const state = fromJS({peopleSearch})
+      expect(getStartTimeSelector(state)).toEqual('10-10-2001')
+    })
+
+    it('gets the start time when there is no start time', () => {
+      const peopleSearch = {
+        startTime: null,
+      }
+      const state = fromJS({peopleSearch})
+      expect(getStartTimeSelector(state)).toEqual(null)
     })
   })
 })


### PR DESCRIPTION
### Jira Story

- [Add to Analytics Dashboard: Avg Duration of time spent searching for people SNAP-407](https://osi-cwds.atlassian.net/browse/SNAP-407)

## Description
We need to log with search click events how long a user spent searching

This is a pretty good approximation of their time searching. It logs the time they start typing and sends that time with the analytics event on person click. The time is reset when the result is cleared, a new person is created, or a person is selected.

Im also sending staff ID with this event so that we can get the average time spent searching per user.

I have a tested query to satisfy the acceptance criteria that I will setup in NR Insights once this PR is merged and deployed. It uses `average(timestamp - startTime)` on `searchResultClick` events.

🎉 

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

