### PR TITLE
SNAP-374 - Empty table cells should not be THs

### DIFF
--- a/app/javascript/views/history/HistoryTable.jsx
+++ b/app/javascript/views/history/HistoryTable.jsx
@@ -41,7 +41,7 @@ export default class HistoryTable extends React.Component {
     return (
       <thead>
         <tr>
-          <th scope='col'/>
+          <td />
           <th scope='col'>Date</th>
           <th scope='col'>Type/Status</th>
           <th scope='col'>County/Office</th>

--- a/spec/javascripts/views/history/HistoryTableSpec.jsx
+++ b/spec/javascripts/views/history/HistoryTableSpec.jsx
@@ -16,17 +16,20 @@ describe('HistoryTable', () => {
   describe('HistoryTable', () => {
     it('displays column headings', () => {
       const component = renderHistoryTable({})
-      const headingRow = component.find('table').find('thead').find('tr')
-      const columnHeadings = headingRow.children()
+      const columnHeadings = component.find('table > thead > tr').children()
 
       // For accessibility, empty column heading should not be a th
       expect(columnHeadings.at(0).name()).toEqual('td')
       expect(columnHeadings.at(0).text()).toEqual('')
 
       // Visible headings
+      expect(columnHeadings.at(1).name()).toEqual('th')
       expect(columnHeadings.at(1).text()).toEqual('Date')
+      expect(columnHeadings.at(2).name()).toEqual('th')
       expect(columnHeadings.at(2).text()).toEqual('Type/Status')
+      expect(columnHeadings.at(3).name()).toEqual('th')
       expect(columnHeadings.at(3).text()).toEqual('County/Office')
+      expect(columnHeadings.at(4).name()).toEqual('th')
       expect(columnHeadings.at(4).text()).toEqual('People and Roles')
     })
 

--- a/spec/javascripts/views/history/HistoryTableSpec.jsx
+++ b/spec/javascripts/views/history/HistoryTableSpec.jsx
@@ -16,8 +16,14 @@ describe('HistoryTable', () => {
   describe('HistoryTable', () => {
     it('displays column headings', () => {
       const component = renderHistoryTable({})
-      const columnHeadings = component.find('table').find('thead').find('tr').find('th')
-      expect(columnHeadings.at(0).text()).toEqual('') // Empty label for indices
+      const headingRow = component.find('table').find('thead').find('tr')
+      const columnHeadings = headingRow.children()
+
+      // For accessibility, empty column heading should not be a th
+      expect(columnHeadings.at(0).name()).toEqual('td')
+      expect(columnHeadings.at(0).text()).toEqual('')
+
+      // Visible headings
       expect(columnHeadings.at(1).text()).toEqual('Date')
       expect(columnHeadings.at(2).text()).toEqual('Type/Status')
       expect(columnHeadings.at(3).text()).toEqual('County/Office')


### PR DESCRIPTION
### Jira Story

- [Accessibility (ADA) test – Snapshot Page Accessibility Error of Empty Table Headers SNAP-374](https://osi-cwds.atlassian.net/browse/SNAP-374)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
Empty table header (TH) cells can cause confusion for screen readers navigating tables. Instead, it seems like the [recommended](https://www.levelaccess.com/accessibility-basics-series-qa-data-tables/) approach is that empty cells are OK, but they should be TDs.

Our HOI table has an empty cell at the top left corner. We want to keep it empty. So, it should be a TD.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

