### PR TITLE
Version update for LogOut Fix in react-wood-duck for Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-router-redux": "^4.0.8",
     "react-select": "^1.0.0-rc.5",
     "react-widgets": "^3.4.8",
-    "react-wood-duck": "0.1.77",
+    "react-wood-duck": "0.1.78",
     "redux": "3.6.0",
     "redux-devtools-extension": "^2.13.2",
     "redux-immutable": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6204,9 +6204,9 @@ react-widgets@^3.4.8:
     deconstruct-number-format "0.0.1"
     format-number-with-string "0.0.2"
 
-react-wood-duck@0.1.77:
-  version "0.1.77"
-  resolved "https://registry.yarnpkg.com/react-wood-duck/-/react-wood-duck-0.1.77.tgz#064c941cd9c5d0d85dc127d9178b4a8adddb8dfd"
+react-wood-duck@0.1.78:
+  version "0.1.78"
+  resolved "https://registry.yarnpkg.com/react-wood-duck/-/react-wood-duck-0.1.78.tgz#ea0ea95b3317ae35dbb9b5471ff334916ebf0cd6"
   dependencies:
     babel-runtime "^6.6.1"
     bootstrap "^3.3.7"


### PR DESCRIPTION
### Jira Story

https://osi-cwds.atlassian.net/browse/SNAP-420NN)

## Description
Safari is firing a @blur event when you mousedown on the link, so added onMouseDown={e => e.preventDefault()} before @blur event

**PR for React-wood-duck:** https://github.com/ca-cwds/react-wood-duck/pull/142