### PR TITLE
SNAP 407 Anomaly in Search Start Time

### DIFF
--- a/app/javascript/reducers/peopleSearchReducer.js
+++ b/app/javascript/reducers/peopleSearchReducer.js
@@ -35,9 +35,12 @@ export default createReducer(initialState, {
   [SET_SEARCH_TERM](state, {payload: {searchTerm}}) {
     if (state.get('startTime')) {
       return state.set('searchTerm', searchTerm)
-    } else {
+    } else if (searchTerm) {
       return state.set('searchTerm', searchTerm)
         .set('startTime', moment().toISOString())
+    } else {
+      return state.set('searchTerm', searchTerm)
+        .set('startTime', null)
     }
   },
   [LOAD_MORE_RESULTS_COMPLETE](state, {payload: {results}, error}) {

--- a/spec/javascripts/components/common/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/AutocompleterSpec.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import Autocomplete from 'react-autocomplete'
 import {shallow, mount} from 'enzyme'
 import * as Analytics from 'utils/analytics'
+import moment from 'moment'
 
 describe('<Autocompleter />', () => {
   function mountAutocompleter({
@@ -31,7 +32,7 @@ describe('<Autocompleter />', () => {
         searchTerm={searchTerm}
         onSearch={onSearch}
         staffId={staffId}
-        startTime={500}
+        startTime='2018-08-01T16:42:59.674Z'
       />
     )
   }
@@ -61,7 +62,7 @@ describe('<Autocompleter />', () => {
         searchTerm={searchTerm}
         onSearch={onSearch}
         staffId={staffId}
-        startTime={500}
+        startTime='2018-08-01T16:42:59.674Z'
       />, {disableLifecycleMethods: true}
     )
   }
@@ -122,7 +123,7 @@ describe('<Autocompleter />', () => {
           .toHaveBeenCalledWith('searchResultClick', {
             searchIndex: 0,
             staffId: '0x3',
-            startTime: 500,
+            startTime: moment('2018-08-01T16:42:59.674Z').valueOf(),
           })
       })
     })
@@ -187,7 +188,7 @@ describe('<Autocompleter />', () => {
         .toHaveBeenCalledWith('searchResultClick', {
           searchIndex: 2,
           staffId: '0x3',
-          startTime: 500,
+          startTime: moment('2018-08-01T16:42:59.674Z').valueOf(),
         })
     })
 

--- a/spec/javascripts/reducers/peopleSearchReducerSpec.js
+++ b/spec/javascripts/reducers/peopleSearchReducerSpec.js
@@ -73,13 +73,13 @@ describe('peopleSearchReducer', () => {
     })
   })
   describe('on SET_SEARCH_TERM', () => {
-    const initialState = fromJS({
-      searchTerm: 'newSearchTerm',
-      total: 3,
-      results: ['result_one', 'result_two', 'result_three'],
-    })
-    const action = setSearchTerm('something')
     it('resets results, total and sets startTime', () => {
+      const action = setSearchTerm('something')
+      const initialState = fromJS({
+        searchTerm: 'newSearchTerm',
+        total: 3,
+        results: ['result_one', 'result_two', 'result_three'],
+      })
       const today = moment('2015-10-19').toDate()
       jasmine.clock().mockDate(today)
       expect(peopleSearchReducer(initialState, action)).toEqualImmutable(
@@ -91,6 +91,23 @@ describe('peopleSearchReducer', () => {
         })
       )
       jasmine.clock().uninstall()
+    })
+
+    it('resets the start time when there is no search term', () => {
+      const action = setSearchTerm('')
+      const initialState = fromJS({
+        searchTerm: '',
+        total: 0,
+        results: [],
+      })
+      expect(peopleSearchReducer(initialState, action)).toEqualImmutable(
+        fromJS({
+          searchTerm: '',
+          total: 0,
+          results: [],
+          startTime: null,
+        })
+      )
     })
   })
   describe('on LOAD_MORE_RESULTS_COMPLETE', () => {


### PR DESCRIPTION
### Jira Story

- [Add to Analytics Dashboard: Avg Duration of time spent searching for people SNAP-407](https://osi-cwds.atlassian.net/browse/SNAP-407)

## Description
There was an anomaly in how the search start time was being set.

since we do the following in the autocompleter:
```
    if (item.legacyDescriptor) {
      if (isSelectable(item)) {
        logEvent('searchResultClick', {
          searchIndex: this.props.results.indexOf(item),
          staffId,
          startTime: moment(startTime).valueOf(),
        })
        onClear()
        onChange('')
        onSelect(item)
        this.hideMenu()
        return
      }
```

The search start time was being cleared with `onClear()` and then immediately reset with the `onChange('')` function call. So the time being logged in the next search was the time the previous search result was clicked (which is wrong since the user can stop searching and then start searching again).

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

