### PR TITLE
SNAP-338 Stop jumping of attach to top of the page

### DIFF
--- a/app/javascript/common/relationship/AttachLink.jsx
+++ b/app/javascript/common/relationship/AttachLink.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 const attachLink = (onClick, relationship, maybeId) => (
-  <a href='#' aria-label='Attach Relationship' className='hidden-print' onClick = {() => { onClick(relationship, maybeId) }}>&nbsp;Attach</a>
+  <a href='#attach' aria-label='Attach Relationship' className='hidden-print' onClick = {() => { onClick(relationship, maybeId) }}>&nbsp;Attach</a>
 )
 
 const isPending = (relationship, pendingPeople) =>

--- a/spec/javascripts/components/common/relationship/AttachLinkSpec.jsx
+++ b/spec/javascripts/components/common/relationship/AttachLinkSpec.jsx
@@ -50,6 +50,6 @@ describe('AttachLink', () => {
 
   it('has href and aria-label', () => {
     expect(renderAttachLink(props).find('a[aria-label="Attach Relationship"]').props().href)
-      .toBe('#')
+      .toBe('#attach')
   })
 })


### PR DESCRIPTION
### Jira Story

- [SNAP-338](https://osi-cwds.atlassian.net/browse/SNAP-338)

## Description
When the attach link in snapshot is clicked its throwing the focus back on to top of the page, which is not the expected behavior.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

