### PR TITLE
Gender-Display-Fix

### DIFF
--- a/app/javascript/common/relationship/EditRelationshipForm.jsx
+++ b/app/javascript/common/relationship/EditRelationshipForm.jsx
@@ -4,6 +4,7 @@ import CheckboxField from 'common/CheckboxField'
 import DateField from 'common/DateField'
 import {RELATIONSHIP_TYPES} from 'enums/RelationshipTypes'
 import {GENDERS_LEGACY} from 'enums/Genders'
+import GENDERS from '../../enums/Genders'
 
 const isAbsentParentDisabled = (type) => (
   !type.toLowerCase().match(/\bfather\b|\bmother\b|\bparent\b/)
@@ -39,7 +40,7 @@ const EditRelationshipForm = ({onChange, person, relationship}) => {
               <ul className='unstyled-list'>
                 <li>{person.name}</li>
                 <li>{person.age}</li>
-                <li>{GENDERS_LEGACY[person.gender] || ''}</li>
+                <li>{GENDERS_LEGACY[person.gender] || GENDERS[person.gender] || ''}</li>
               </ul>
             </td>
             <td>
@@ -62,7 +63,7 @@ const EditRelationshipForm = ({onChange, person, relationship}) => {
               <ul className='unstyled-list'>
                 <li>{relationship.name}</li>
                 <li>{relationship.age}</li>
-                <li>{GENDERS_LEGACY[relationship.gender]}</li>
+                <li>{GENDERS_LEGACY[relationship.gender] || GENDERS[relationship.gender] || ''}</li>
               </ul>
             </td>
           </tr>

--- a/app/javascript/common/relationship/EditRelationshipForm.jsx
+++ b/app/javascript/common/relationship/EditRelationshipForm.jsx
@@ -3,8 +3,7 @@ import PropTypes from 'prop-types'
 import CheckboxField from 'common/CheckboxField'
 import DateField from 'common/DateField'
 import {RELATIONSHIP_TYPES} from 'enums/RelationshipTypes'
-import {GENDERS_LEGACY} from 'enums/Genders'
-import GENDERS from '../../enums/Genders'
+import GENDERS, {GENDERS_LEGACY} from 'enums/Genders'
 
 const isAbsentParentDisabled = (type) => (
   !type.toLowerCase().match(/\bfather\b|\bmother\b|\bparent\b/)

--- a/app/javascript/views/ScreeningCreateRelationship.jsx
+++ b/app/javascript/views/ScreeningCreateRelationship.jsx
@@ -5,6 +5,7 @@ import SelectField from 'common/SelectField'
 import PropTypes from 'prop-types'
 import {RELATIONSHIP_TYPES} from 'enums/RelationshipTypes'
 import {GENDERS_LEGACY} from 'enums/Genders'
+import GENDERS from 'enums/Genders'
 
 const textWrap = {whiteSpace: 'normal'}
 export default class ScreeningCreateRelationship extends React.Component {
@@ -35,7 +36,7 @@ export default class ScreeningCreateRelationship extends React.Component {
         <ul className='unstyled-list'>
           <li>{name}</li>
           <li>{age}</li>
-          <li>{GENDERS_LEGACY[gender]}</li>
+          <li>{GENDERS_LEGACY[gender] || GENDERS[gender] || ''}</li>
         </ul>
       </div>
     )

--- a/spec/javascripts/components/common/relationship/EditRelationshipFormSpec.jsx
+++ b/spec/javascripts/components/common/relationship/EditRelationshipFormSpec.jsx
@@ -9,13 +9,13 @@ describe('EditRelationshipForm', () => {
     person: {
       name: 'Luke Skywalker',
       age: '20 yrs',
-      gender: 'M' || 'male',
+      gender: 'M',
     },
     relationship: {
       absent_parent_code: 'Y',
       name: 'Darth Vader',
       age: '30 yrs',
-      gender: 'M' || 'male',
+      gender: 'M',
       secondaryRelationship: 'Father',
       same_home_code: 'N',
       type_code: '210',
@@ -55,13 +55,13 @@ describe('EditRelationshipForm', () => {
       person: {
         name: 'Luke Skywalker',
         age: '20 yrs',
-        gender: 'M' || 'male',
+        gender: 'M',
       },
       relationship: {
         absent_parent_code: 'Y',
         name: 'Darth Vader',
         age: '30 yrs',
-        gender: 'M' || 'male',
+        gender: 'M',
         secondaryRelationship: 'No Relation',
         same_home_code: 'N',
         type_code: '175',
@@ -71,13 +71,13 @@ describe('EditRelationshipForm', () => {
       person: {
         name: 'Luke Skywalker',
         age: '20 yrs',
-        gender: 'M' || 'male',
+        gender: 'M',
       },
       relationship: {
         absent_parent_code: 'Y',
         name: 'Darth Vader',
         age: '30 yrs',
-        gender: 'M' || 'male',
+        gender: 'M',
         secondaryRelationship: 'Father (Birth)',
         same_home_code: 'N',
         type_code: '190',

--- a/spec/javascripts/components/common/relationship/EditRelationshipFormSpec.jsx
+++ b/spec/javascripts/components/common/relationship/EditRelationshipFormSpec.jsx
@@ -9,13 +9,13 @@ describe('EditRelationshipForm', () => {
     person: {
       name: 'Luke Skywalker',
       age: '20 yrs',
-      gender: 'M',
+      gender: 'M' || 'male',
     },
     relationship: {
       absent_parent_code: 'Y',
       name: 'Darth Vader',
       age: '30 yrs',
-      gender: 'M',
+      gender: 'M' || 'male',
       secondaryRelationship: 'Father',
       same_home_code: 'N',
       type_code: '210',
@@ -55,13 +55,13 @@ describe('EditRelationshipForm', () => {
       person: {
         name: 'Luke Skywalker',
         age: '20 yrs',
-        gender: 'M',
+        gender: 'M' || 'male',
       },
       relationship: {
         absent_parent_code: 'Y',
         name: 'Darth Vader',
         age: '30 yrs',
-        gender: 'M',
+        gender: 'M' || 'male',
         secondaryRelationship: 'No Relation',
         same_home_code: 'N',
         type_code: '175',
@@ -71,13 +71,13 @@ describe('EditRelationshipForm', () => {
       person: {
         name: 'Luke Skywalker',
         age: '20 yrs',
-        gender: 'M',
+        gender: 'M' || 'male',
       },
       relationship: {
         absent_parent_code: 'Y',
         name: 'Darth Vader',
         age: '30 yrs',
-        gender: 'M',
+        gender: 'M' || 'male',
         secondaryRelationship: 'Father (Birth)',
         same_home_code: 'N',
         type_code: '190',
@@ -96,6 +96,93 @@ describe('EditRelationshipForm', () => {
           .find('#absent_parent_code')
           .prop('disabled'))
         .toBe(false)
+    })
+  })
+  describe('Display Gender if the data is male/female/unknown/intersex', () => {
+    const genderProps = {
+      person: {
+        name: 'Luke Skywalker',
+        age: '20 yrs',
+        gender: 'male',
+      },
+      relationship: {
+        absent_parent_code: 'Y',
+        name: 'Darth Vader',
+        age: '30 yrs',
+        gender: 'male',
+        secondaryRelationship: 'Father',
+        same_home_code: 'N',
+        type_code: '210',
+      },
+    }
+    const renderEditRelationshipForm = (genderProps) => shallow(<EditRelationshipForm {...genderProps}/>)
+    it('Displays gender as Male if the data is male', () => {
+      const component = renderEditRelationshipForm(genderProps)
+
+      expect(component.find('ul').first().find('li').first().text()).toEqual('Luke Skywalker')
+      expect(component.find('ul').first().find('li').at(1).text()).toEqual('20 yrs')
+      expect(component.find('ul').first().find('li').last().text()).toEqual('Male')
+      expect(component.find('ul').last().find('li').first().text()).toEqual('Darth Vader')
+      expect(component.find('ul').last().find('li').at(1).text()).toEqual('30 yrs')
+      expect(component.find('ul').last().find('li').last().text()).toEqual('Male')
+    })
+  })
+  describe('Display Gender if the data is M/F/U/I', () => {
+    const genderProps = {
+      person: {
+        name: 'Luke Skywalker',
+        age: '20 yrs',
+        gender: 'M',
+      },
+      relationship: {
+        absent_parent_code: 'Y',
+        name: 'Darth Vader',
+        age: '30 yrs',
+        gender: 'M',
+        secondaryRelationship: 'Father',
+        same_home_code: 'N',
+        type_code: '210',
+      },
+    }
+    const renderEditRelationshipForm = (genderProps) => shallow(<EditRelationshipForm {...genderProps}/>)
+    it('Displays gender as Male if the data is M', () => {
+      const component = renderEditRelationshipForm(genderProps)
+
+      expect(component.find('ul').first().find('li').first().text()).toEqual('Luke Skywalker')
+      expect(component.find('ul').first().find('li').at(1).text()).toEqual('20 yrs')
+      expect(component.find('ul').first().find('li').last().text()).toEqual('Male')
+      expect(component.find('ul').last().find('li').first().text()).toEqual('Darth Vader')
+      expect(component.find('ul').last().find('li').at(1).text()).toEqual('30 yrs')
+      expect(component.find('ul').last().find('li').last().text()).toEqual('Male')
+    })
+  })
+  describe('Display Gender if the data is a mix of M/F/U/I or male/female/unknown/intersex ', () => {
+    const mixGenderProps = {
+      person: {
+        name: 'Luke Skywalker',
+        age: '20 yrs',
+        gender: 'male',
+      },
+      relationship: {
+        absent_parent_code: 'Y',
+        name: 'Darth Vader',
+        age: '30 yrs',
+        gender: 'M',
+        secondaryRelationship: 'Father',
+        same_home_code: 'N',
+        type_code: '210',
+      },
+    }
+    const renderEditRelationshipForm = (mixGenderProps) => shallow(<EditRelationshipForm {...mixGenderProps}/>)
+    it('Displays gender as Male if the data is M', () => {
+      const component = renderEditRelationshipForm(mixGenderProps)
+
+      expect(component.find('ul').first().find('li').first().text()).toEqual('Luke Skywalker')
+      expect(component.find('ul').first().find('li').at(1).text()).toEqual('20 yrs')
+      expect(component.find('ul').first().find('li').last().text()).toEqual('Male')
+      expect(component.find('ul').last().find('li').first().text()).toEqual('Darth Vader')
+      expect(component.find('ul').last().find('li').at(1).text()).toEqual('30 yrs')
+      expect(component.find('ul').last().find('li').last().text()).toEqual('Male')
     })
   })
 })

--- a/spec/javascripts/views/ScreeningCreateRelationshipSpec.jsx
+++ b/spec/javascripts/views/ScreeningCreateRelationshipSpec.jsx
@@ -47,3 +47,35 @@ describe('ScreeningCreateRelationship', () => {
     expect(displayTable.find('ul').first().find('li').last().text()).toEqual('Male')
   })
 })
+describe('Display Gender if the data is male/female/unknown/intersex', () => {
+  const genderData = [{
+    focus_person: 'Sally Fields 25 yrs Male',
+    related_person: 'Sam Fields 30 yrs Male',
+  }]
+  const cell = {name: 'Sally Fields', age: '25 yrs', gender: 'male'}
+  const wrapper = shallow(<ScreeningCreateRelationship data={genderData}/>)
+  it('Displays gender as Male if the data is male', () => {
+    const displayTable = shallow(wrapper.instance().displayFormatter(cell))
+    expect(displayTable.find('ul').length).toBe(1)
+    expect(displayTable.find('li').length).toBe(3)
+    expect(displayTable.find('ul').first().find('li').first().text()).toEqual('Sally Fields')
+    expect(displayTable.find('ul').first().find('li').at(1).text()).toEqual('25 yrs')
+    expect(displayTable.find('ul').first().find('li').last().text()).toEqual('Male')
+  })
+})
+describe('Display Gender if the data is M/F/I/U', () => {
+  const genderData = [{
+    focus_person: 'Sally Fields 25 yrs Male',
+    related_person: 'Sam Fields 30 yrs Male',
+  }]
+  const cell = {name: 'Sally Fields', age: '25 yrs', gender: 'M'}
+  const wrapper = shallow(<ScreeningCreateRelationship data={genderData}/>)
+  it('Displays gender as Male if the data is M', () => {
+    const displayTable = shallow(wrapper.instance().displayFormatter(cell))
+    expect(displayTable.find('ul').length).toBe(1)
+    expect(displayTable.find('li').length).toBe(3)
+    expect(displayTable.find('ul').first().find('li').first().text()).toEqual('Sally Fields')
+    expect(displayTable.find('ul').first().find('li').at(1).text()).toEqual('25 yrs')
+    expect(displayTable.find('ul').first().find('li').last().text()).toEqual('Male')
+  })
+})


### PR DESCRIPTION


### Jira Story

- [Display Age and Gender on the Create Relationship Form](https://osi-cwds.atlassian.net/browse/RL-189)

## Description
This PR is a bug fix for the above story. PGSQL has mixed data for genders, i.e M, male. It's not consistent, so using both the Gender enums to display genders on edit and create relationships cards 

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

