### PR TITLE
HOT-2065 keep the breadcrumb to the left side of app to be consistent

### DIFF
--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -161,7 +161,6 @@ export class ScreeningPage extends React.Component {
     const {referralId, editable, hasApiValidationErrors, submitReferralErrors} = this.props
     return (
       <div className='col-xs-8 col-md-9'>
-        <BreadCrumb navigationElements={[<Link key={this.props.params.id} to={urlHelper('/')}>CaseLoad</Link>]}/>
         {referralId && <h1>Referral #{referralId}</h1>}
         {hasApiValidationErrors && <ErrorDetail errors={submitReferralErrors} />}
         {this.renderScreeningInformationCard()}
@@ -199,6 +198,7 @@ export class ScreeningPage extends React.Component {
       <div>
         <div>
           <PageHeader pageTitle={this.props.screeningTitle} button={this.submitButton()} />
+          <BreadCrumb navigationElements={[<Link key={this.props.params.id} to={urlHelper('/')}>CaseLoad</Link>]}/>
         </div>
         <div className='container'>
           {this.renderScreening()}

--- a/app/javascript/snapshots/SnapshotPage.jsx
+++ b/app/javascript/snapshots/SnapshotPage.jsx
@@ -55,7 +55,6 @@ export class SnapshotPage extends React.Component {
     return (
       <div className='col-md-9 col-xs-8 '>
         <div className='row'>
-          <BreadCrumb />
           <SnapshotIntro />
           <PersonSearchFormContainer
             onSelect={(person) => this.onSelectPerson(person)}
@@ -78,6 +77,7 @@ export class SnapshotPage extends React.Component {
       <div>
         <div>
           <PageHeader pageTitle='Snapshot' button={this.startOverButton()} />
+          <BreadCrumb />
         </div>
         <div className='container'>
           <div className='row'>


### PR DESCRIPTION
### Jira Story

- [Link to go back to the Landing Page from a Screening](https://osi-cwds.atlassian.net/browse/HOT-2065)

## Description
The classname with row in the breadcrumb was causing to scroll horizontally because of it's placement in screening page/snapshot page. Fixed this by placing the breadcrumb consistent across the app.

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
The placement of the breadcrumb is only changed. The tests we already have will check if the page renders the breadcrumb and runs based in the nodes.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

