### PR TITLE
HOT-2272 Log staffId with relationships query cycle time

### DIFF
--- a/app/javascript/sagas/fetchRelationshipsSaga.js
+++ b/app/javascript/sagas/fetchRelationshipsSaga.js
@@ -11,6 +11,7 @@ import {clearTime} from 'actions/personCardActions'
 import moment from 'moment'
 import {getPersonCreatedAtTimeSelector} from 'selectors/peopleSearchSelectors'
 import {logEvent} from 'utils/analytics'
+import {getStaffIdSelector} from 'selectors/userInfoSelectors'
 
 export const currentTime = () => moment().valueOf()
 
@@ -18,12 +19,14 @@ export function* fetchRelationships({payload: {ids, screeningId}}) {
   try {
     const response = yield call(get, `/api/v1/relationships?clientIds=${ids.join(',')}&screeningId=${screeningId}`)
     yield put(fetchRelationshipsSuccess(response))
+    const staffId = yield select(getStaffIdSelector)
     const personCreatedAtTime = yield select(getPersonCreatedAtTimeSelector)
     const fetchRelationshipTime = yield select(currentTime)
     if (personCreatedAtTime) {
       const relationshipsQueryCycleTime = fetchRelationshipTime - personCreatedAtTime
       yield call(logEvent, 'relationshipsQueryCycleTime', {
         relationshipsQueryCycleTime: relationshipsQueryCycleTime,
+        staffId: staffId,
       })
       yield put(clearTime())
     }

--- a/spec/javascripts/sagas/fetchRelationshipsSagaSpec.js
+++ b/spec/javascripts/sagas/fetchRelationshipsSagaSpec.js
@@ -12,6 +12,7 @@ import {getPersonCreatedAtTimeSelector} from 'selectors/peopleSearchSelectors'
 import moment from 'moment'
 import {logEvent} from 'utils/analytics'
 import {clearTime} from 'actions/personCardActions'
+import {getStaffIdSelector} from 'selectors/userInfoSelectors'
 
 describe('fetchRelationshipsSaga', () => {
   it('fetches relationships on FETCH_RELATIONSHIPS', () => {
@@ -27,6 +28,7 @@ describe('fetchRelationships', () => {
   const screeningId = '123'
   const action = actions.fetchRelationships(ids, screeningId)
   const personCreatedAtTime = 1534190832860
+  const staffId = '0X5'
 
   it('should fetch and put relationships', () => {
     const gen = fetchRelationships(action)
@@ -40,6 +42,9 @@ describe('fetchRelationships', () => {
       put(actions.fetchRelationshipsSuccess(relationships))
     )
     expect(gen.next().value).toEqual(
+      select(getStaffIdSelector)
+    )
+    expect(gen.next(staffId).value).toEqual(
       select(getPersonCreatedAtTimeSelector)
     )
     const fetchRelationshipTime = moment().valueOf()
@@ -47,6 +52,7 @@ describe('fetchRelationships', () => {
     expect(gen.next(personCreatedAtTime).value).toEqual(select(currentTime))
     expect(gen.next(fetchRelationshipTime).value).toEqual(call(logEvent, 'relationshipsQueryCycleTime', {
       relationshipsQueryCycleTime: relationshipsQueryCycleTime,
+      staffId: staffId,
     }))
     expect(gen.next().value).toEqual(
       put(clearTime())


### PR DESCRIPTION
### Jira Story

- [Relationships query cycle time logged by Staff ID](https://osi-cwds.atlassian.net/browse/HOT-2272)

## Description
Staff Id is logged with Relationships query cycle time to New Relic.
Check JIRA for New Relic screenshot.


## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

