### PR TITLE
HOT-2157 - Reset scroll on Screening Info save

### DIFF
--- a/app/javascript/containers/screenings/AllegationsFormContainer.jsx
+++ b/app/javascript/containers/screenings/AllegationsFormContainer.jsx
@@ -21,7 +21,7 @@ const mapStateToProps = (state) => (
   }
 )
 
-const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
@@ -32,9 +32,9 @@ const mapDispatchToProps = (dispatch) => ({
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#allegations-card-anchor'
   },
   dispatch,
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(AllegationsForm)
-

--- a/app/javascript/containers/screenings/AllegationsFormContainer.jsx
+++ b/app/javascript/containers/screenings/AllegationsFormContainer.jsx
@@ -25,6 +25,7 @@ export const mapDispatchToProps = (dispatch) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#allegations-card-anchor'
   },
   onChange: (props) => {
     dispatch(setAllegationTypes(props))

--- a/app/javascript/containers/screenings/AllegationsFormContainer.jsx
+++ b/app/javascript/containers/screenings/AllegationsFormContainer.jsx
@@ -9,6 +9,7 @@ import {
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
 import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import {setAllegationTypes} from 'actions/allegationsFormActions'
+import {setHash} from 'utils/navigation'
 
 export const cardName = 'allegations-card'
 
@@ -25,7 +26,7 @@ export const mapDispatchToProps = (dispatch) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#allegations-card-anchor'
+    setHash('#allegations-card-anchor')
   },
   onChange: (props) => {
     dispatch(setAllegationTypes(props))
@@ -33,7 +34,7 @@ export const mapDispatchToProps = (dispatch) => ({
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#allegations-card-anchor'
+    setHash('#allegations-card-anchor')
   },
   dispatch,
 })

--- a/app/javascript/containers/screenings/DecisionFormContainer.jsx
+++ b/app/javascript/containers/screenings/DecisionFormContainer.jsx
@@ -21,6 +21,7 @@ import {
   touchAllFields,
 } from 'actions/screeningDecisionFormActions'
 import {sdmPath} from 'common/config'
+import {setHash} from 'utils/navigation'
 
 export const cardName = 'decision-card'
 
@@ -46,7 +47,7 @@ export const mapDispatchToProps = (dispatch) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#decision-card-anchor'
+    setHash('#decision-card-anchor')
   },
   onChange: (field, value) => {
     dispatch(setField({field, value}))
@@ -62,7 +63,7 @@ export const mapDispatchToProps = (dispatch) => ({
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#decision-card-anchor'
+    setHash('#decision-card-anchor')
   },
   dispatch,
 })

--- a/app/javascript/containers/screenings/DecisionFormContainer.jsx
+++ b/app/javascript/containers/screenings/DecisionFormContainer.jsx
@@ -46,6 +46,7 @@ export const mapDispatchToProps = (dispatch) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#decision-card-anchor'
   },
   onChange: (field, value) => {
     dispatch(setField({field, value}))

--- a/app/javascript/containers/screenings/DecisionFormContainer.jsx
+++ b/app/javascript/containers/screenings/DecisionFormContainer.jsx
@@ -41,7 +41,7 @@ const mapStateToProps = (state) => (
   }
 )
 
-const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch) => ({
   onBlur: (field) => dispatch(touchField({field})),
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
@@ -61,9 +61,9 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#decision-card-anchor'
   },
   dispatch,
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(ScreeningDecisionForm)
-

--- a/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
+++ b/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
@@ -39,6 +39,7 @@ export const mapDispatchToProps = (dispatch) => ({
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#incident-information-card-anchor'
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {

--- a/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
+++ b/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
@@ -18,6 +18,7 @@ import {
 } from 'actions/incidentInformationFormActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
 import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
+import {setHash} from 'utils/navigation'
 
 export const cardName = 'incident-information-card'
 
@@ -39,14 +40,14 @@ export const mapDispatchToProps = (dispatch) => ({
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#incident-information-card-anchor'
+    setHash('#incident-information-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#incident-information-card-anchor'
+    setHash('#incident-information-card-anchor')
   },
 })
 

--- a/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
+++ b/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
@@ -33,7 +33,7 @@ const mapStateToProps = (state) => ({
   locationOfChildren: getLocationOfChildrenSelector(state),
 })
 
-const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch) => ({
   onBlur: (fieldName) => dispatch(touchField(fieldName)),
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
@@ -45,6 +45,7 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#incident-information-card-anchor'
   },
 })
 

--- a/app/javascript/containers/screenings/NarrativeFormContainer.jsx
+++ b/app/javascript/containers/screenings/NarrativeFormContainer.jsx
@@ -7,6 +7,7 @@ import {setField, touchField, touchAllFields} from 'actions/narrativeFormActions
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
 import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import {connect} from 'react-redux'
+import {setHash} from 'utils/navigation'
 
 export const cardName = 'narrative-card'
 
@@ -25,14 +26,14 @@ export const mapDispatchToProps = (dispatch) => ({
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#narrative-card-anchor'
+    setHash('#narrative-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#narrative-card-anchor'
+    setHash('#narrative-card-anchor')
   },
 })
 

--- a/app/javascript/containers/screenings/NarrativeFormContainer.jsx
+++ b/app/javascript/containers/screenings/NarrativeFormContainer.jsx
@@ -25,6 +25,7 @@ export const mapDispatchToProps = (dispatch) => ({
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#narrative-card-anchor'
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {

--- a/app/javascript/containers/screenings/NarrativeFormContainer.jsx
+++ b/app/javascript/containers/screenings/NarrativeFormContainer.jsx
@@ -19,7 +19,7 @@ const mapStateToProps = (state) => (
   }
 )
 
-const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch) => ({
   onBlur: (fieldName) => dispatch(touchField(fieldName)),
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
@@ -31,6 +31,7 @@ const mapDispatchToProps = (dispatch) => ({
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#narrative-card-anchor'
   },
 })
 

--- a/app/javascript/containers/screenings/PersonCardContainer.js
+++ b/app/javascript/containers/screenings/PersonCardContainer.js
@@ -19,7 +19,7 @@ const mapStateToProps = (state, {personId}) => ({
   informationPill: selectDeceased(state).get(personId) ? 'Deceased' : null,
 })
 
-const mapDispatchToProps = (dispatch, {personId}) => ({
+export const mapDispatchToProps = (dispatch, {personId}) => ({
   onCancel: () => dispatch(setPersonCardMode(personId, 'show')),
   onDelete: () => dispatch(deletePerson(personId)),
   onEdit: () => dispatch(setPersonCardMode(personId, 'edit')),
@@ -27,6 +27,7 @@ const mapDispatchToProps = (dispatch, {personId}) => ({
     dispatch(savePerson(personId))
     dispatch(touchAllFields(personId))
     dispatch(setPersonCardMode(personId, 'show'))
+    window.location.hash = `#participants-card-${personId}`
   },
 })
 

--- a/app/javascript/containers/screenings/PersonCardContainer.js
+++ b/app/javascript/containers/screenings/PersonCardContainer.js
@@ -9,6 +9,7 @@ import {
 import {savePerson, deletePerson} from 'actions/personCardActions'
 import {setPersonCardMode} from 'actions/screeningPageActions'
 import {touchAllFields} from 'actions/peopleFormActions'
+import {setHash} from 'utils/navigation'
 
 const mapStateToProps = (state, {personId}) => ({
   mode: getModeValueSelector(state, personId),
@@ -22,7 +23,7 @@ const mapStateToProps = (state, {personId}) => ({
 export const mapDispatchToProps = (dispatch, {personId}) => ({
   onCancel: () => {
     dispatch(setPersonCardMode(personId, 'show'))
-    window.location.hash = `#participants-card-${personId}`
+    setHash(`#participants-card-${personId}`)
   },
   onDelete: () => dispatch(deletePerson(personId)),
   onEdit: () => dispatch(setPersonCardMode(personId, 'edit')),
@@ -30,7 +31,7 @@ export const mapDispatchToProps = (dispatch, {personId}) => ({
     dispatch(savePerson(personId))
     dispatch(touchAllFields(personId))
     dispatch(setPersonCardMode(personId, 'show'))
-    window.location.hash = `#participants-card-${personId}`
+    setHash(`#participants-card-${personId}`)
   },
 })
 

--- a/app/javascript/containers/screenings/PersonCardContainer.js
+++ b/app/javascript/containers/screenings/PersonCardContainer.js
@@ -20,7 +20,10 @@ const mapStateToProps = (state, {personId}) => ({
 })
 
 export const mapDispatchToProps = (dispatch, {personId}) => ({
-  onCancel: () => dispatch(setPersonCardMode(personId, 'show')),
+  onCancel: () => {
+    dispatch(setPersonCardMode(personId, 'show'))
+    window.location.hash = `#participants-card-${personId}`
+  },
   onDelete: () => dispatch(deletePerson(personId)),
   onEdit: () => dispatch(setPersonCardMode(personId, 'edit')),
   onSave: () => {

--- a/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
+++ b/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
@@ -39,12 +39,13 @@ const mapStateToProps = (state) => {
   }
 }
 
-const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch) => ({
   onBlur: (fieldName) => dispatch(touchField(fieldName)),
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#screening-information-card-anchor'
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   dispatch,

--- a/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
+++ b/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
@@ -62,6 +62,7 @@ export const mergeProps = (stateProps, dispatchProps, ownProps) => ({
     }
     dispatchProps.dispatch(touchAllFields())
     dispatchProps.dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#screening-information-card-anchor'
   },
 })
 

--- a/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
+++ b/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
@@ -11,6 +11,7 @@ import {generateBabyDoe} from 'actions/safelySurrenderedBabyActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
 import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import {getScreeningSelector} from 'selectors/screeningSelectors'
+import {setHash} from 'utils/navigation'
 
 export const cardName = 'screening-information-card'
 
@@ -45,7 +46,7 @@ export const mapDispatchToProps = (dispatch) => ({
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#screening-information-card-anchor'
+    setHash('#screening-information-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   dispatch,
@@ -63,7 +64,7 @@ export const mergeProps = (stateProps, dispatchProps, ownProps) => ({
     }
     dispatchProps.dispatch(touchAllFields())
     dispatchProps.dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#screening-information-card-anchor'
+    setHash('#screening-information-card-anchor')
   },
 })
 

--- a/app/javascript/containers/screenings/WorkerSafetyFormContainer.jsx
+++ b/app/javascript/containers/screenings/WorkerSafetyFormContainer.jsx
@@ -28,6 +28,7 @@ export const mapDispatchToProps = (dispatch) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#worker-safety-card-anchor'
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {

--- a/app/javascript/containers/screenings/WorkerSafetyFormContainer.jsx
+++ b/app/javascript/containers/screenings/WorkerSafetyFormContainer.jsx
@@ -24,7 +24,7 @@ const mapStateToProps = (state) => (
   }
 )
 
-const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
@@ -33,6 +33,7 @@ const mapDispatchToProps = (dispatch) => ({
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
+    window.location.hash = '#worker-safety-card-anchor'
   },
   dispatch,
 })

--- a/app/javascript/containers/screenings/WorkerSafetyFormContainer.jsx
+++ b/app/javascript/containers/screenings/WorkerSafetyFormContainer.jsx
@@ -9,6 +9,7 @@ import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import SAFETY_ALERT from 'enums/SafetyAlert'
 import selectOptions from 'utils/selectHelper'
 import {connect} from 'react-redux'
+import {setHash} from 'utils/navigation'
 
 export const cardName = 'worker-safety-card'
 
@@ -28,13 +29,13 @@ export const mapDispatchToProps = (dispatch) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#worker-safety-card-anchor'
+    setHash('#worker-safety-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(setCardMode(cardName, SHOW_MODE))
-    window.location.hash = '#worker-safety-card-anchor'
+    setHash('#worker-safety-card-anchor')
   },
   dispatch,
 })

--- a/app/javascript/utils/navigation.js
+++ b/app/javascript/utils/navigation.js
@@ -1,0 +1,5 @@
+export const setHash = (newHash) => {
+  // Some browsers (Webkit) won't navigate to the same hash twice, so reset it
+  window.location.hash = ''
+  window.location.hash = newHash
+}

--- a/app/javascript/views/CrossReportForm.jsx
+++ b/app/javascript/views/CrossReportForm.jsx
@@ -15,6 +15,7 @@ import {
   LAW_ENFORCEMENT,
 } from 'enums/CrossReport'
 import {SHOW_MODE} from 'actions/screeningPageActions'
+import {setHash} from 'utils/navigation'
 
 const CrossReportForm = ({
   allegationsRequireCrossReports,
@@ -52,13 +53,14 @@ const CrossReportForm = ({
   const cancel = () => {
     clearCardEdits(cardName)
     setCardMode(cardName, SHOW_MODE)
+    setHash('#cross-report-card-anchor')
   }
   const save = () => {
     saveCard(cardName)
     saveCrossReport(screeningWithEdits)
     touchAllFields()
     setCardMode(cardName, SHOW_MODE)
-    window.location.hash = '#cross-report-card-anchor'
+    setHash('#cross-report-card-anchor')
   }
   const agencyFieldActions = {
     setAgencyTypeField,

--- a/app/javascript/views/CrossReportForm.jsx
+++ b/app/javascript/views/CrossReportForm.jsx
@@ -58,6 +58,7 @@ const CrossReportForm = ({
     saveCrossReport(screeningWithEdits)
     touchAllFields()
     setCardMode(cardName, SHOW_MODE)
+    window.location.hash = '#cross-report-card-anchor'
   }
   const agencyFieldActions = {
     setAgencyTypeField,

--- a/spec/features/screening/submit_screening_spec.rb
+++ b/spec/features/screening/submit_screening_spec.rb
@@ -58,8 +58,8 @@ feature 'Submit Screening' do
       within('.card', text: 'Incident Information') { click_button 'Save' }
       within('.card', text: 'Allegations') { click_button 'Save' }
       within('.card', text: 'Worker Safety') { click_button 'Save' }
-      within('.card', text: 'Cross Report') { click_button 'Save' }
       within('.card', text: 'Decision') { click_button 'Save' }
+      within('.card', text: 'Cross Report') { click_button 'Save' }
       expect(page).to have_button('Submit', disabled: false)
     end
 
@@ -93,9 +93,9 @@ feature 'Submit Screening' do
       within('.card', text: 'Incident Information') { click_button 'Save' }
       within('.card', text: 'Allegations') { click_button 'Save' }
       within('.card', text: 'Worker Safety') { click_button 'Save' }
-      within('.card', text: 'Cross Report') { click_button 'Save' }
-      expect(page).to have_button('Submit', disabled: true)
       within('.card', text: 'Decision') { click_button 'Save' }
+      expect(page).to have_button('Submit', disabled: true)
+      within('.card', text: 'Cross Report') { click_button 'Save' }
       expect(page).to have_button('Submit', disabled: false)
     end
   end

--- a/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
@@ -1,19 +1,17 @@
 import {mapDispatchToProps} from 'containers/screenings/AllegationsFormContainer'
+import * as Navigation from 'utils/navigation'
 
 describe('AllegationsFormContainer', () => {
   describe('mapDispatchToProps', () => {
     beforeEach(() => {
-      window.location.hash = ''
-    })
-    afterEach(() => {
-      window.location.hash = ''
+      spyOn(Navigation, 'setHash')
     })
     describe('when saving', () => {
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch)
         onSave()
-        expect(window.location.hash).toEqual('#allegations-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#allegations-card-anchor')
       })
     })
     describe('when canceling', () => {
@@ -21,7 +19,7 @@ describe('AllegationsFormContainer', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onCancel} = mapDispatchToProps(dispatch)
         onCancel()
-        expect(window.location.hash).toEqual('#allegations-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#allegations-card-anchor')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
@@ -1,0 +1,20 @@
+import {mapDispatchToProps} from 'containers/screenings/AllegationsFormContainer'
+
+describe('AllegationsFormContainer', () => {
+  describe('mapDispatchToProps', () => {
+    describe('when saving', () => {
+      beforeEach(() => {
+        window.location.hash = ''
+      })
+      afterEach(() => {
+        window.location.hash = ''
+      })
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onSave} = mapDispatchToProps(dispatch)
+        onSave()
+        expect(window.location.hash).toEqual('#allegations-card-anchor')
+      })
+    })
+  })
+})

--- a/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
@@ -2,17 +2,25 @@ import {mapDispatchToProps} from 'containers/screenings/AllegationsFormContainer
 
 describe('AllegationsFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    beforeEach(() => {
+      window.location.hash = ''
+    })
+    afterEach(() => {
+      window.location.hash = ''
+    })
     describe('when saving', () => {
-      beforeEach(() => {
-        window.location.hash = ''
-      })
-      afterEach(() => {
-        window.location.hash = ''
-      })
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch)
         onSave()
+        expect(window.location.hash).toEqual('#allegations-card-anchor')
+      })
+    })
+    describe('when canceling', () => {
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onCancel} = mapDispatchToProps(dispatch)
+        onCancel()
         expect(window.location.hash).toEqual('#allegations-card-anchor')
       })
     })

--- a/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
@@ -1,0 +1,20 @@
+import {mapDispatchToProps} from 'containers/screenings/DecisionFormContainer'
+
+describe('DecisionFormContainer', () => {
+  describe('mapDispatchToProps', () => {
+    describe('when saving', () => {
+      beforeEach(() => {
+        window.location.hash = ''
+      })
+      afterEach(() => {
+        window.location.hash = ''
+      })
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onSave} = mapDispatchToProps(dispatch)
+        onSave()
+        expect(window.location.hash).toEqual('#decision-card-anchor')
+      })
+    })
+  })
+})

--- a/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
@@ -2,17 +2,25 @@ import {mapDispatchToProps} from 'containers/screenings/DecisionFormContainer'
 
 describe('DecisionFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    beforeEach(() => {
+      window.location.hash = ''
+    })
+    afterEach(() => {
+      window.location.hash = ''
+    })
     describe('when saving', () => {
-      beforeEach(() => {
-        window.location.hash = ''
-      })
-      afterEach(() => {
-        window.location.hash = ''
-      })
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch)
         onSave()
+        expect(window.location.hash).toEqual('#decision-card-anchor')
+      })
+    })
+    describe('when canceling', () => {
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onCancel} = mapDispatchToProps(dispatch)
+        onCancel()
         expect(window.location.hash).toEqual('#decision-card-anchor')
       })
     })

--- a/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
@@ -1,19 +1,17 @@
 import {mapDispatchToProps} from 'containers/screenings/DecisionFormContainer'
+import * as Navigation from 'utils/navigation'
 
 describe('DecisionFormContainer', () => {
   describe('mapDispatchToProps', () => {
     beforeEach(() => {
-      window.location.hash = ''
-    })
-    afterEach(() => {
-      window.location.hash = ''
+      spyOn(Navigation, 'setHash')
     })
     describe('when saving', () => {
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch)
         onSave()
-        expect(window.location.hash).toEqual('#decision-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#decision-card-anchor')
       })
     })
     describe('when canceling', () => {
@@ -21,7 +19,7 @@ describe('DecisionFormContainer', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onCancel} = mapDispatchToProps(dispatch)
         onCancel()
-        expect(window.location.hash).toEqual('#decision-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#decision-card-anchor')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
@@ -2,17 +2,25 @@ import {mapDispatchToProps} from 'containers/screenings/IncidentInformationFormC
 
 describe('IncidentInformationFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    beforeEach(() => {
+      window.location.hash = ''
+    })
+    afterEach(() => {
+      window.location.hash = ''
+    })
     describe('when saving', () => {
-      beforeEach(() => {
-        window.location.hash = ''
-      })
-      afterEach(() => {
-        window.location.hash = ''
-      })
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch)
         onSave()
+        expect(window.location.hash).toEqual('#incident-information-card-anchor')
+      })
+    })
+    describe('when canceling', () => {
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onCancel} = mapDispatchToProps(dispatch)
+        onCancel()
         expect(window.location.hash).toEqual('#incident-information-card-anchor')
       })
     })

--- a/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
@@ -1,19 +1,17 @@
 import {mapDispatchToProps} from 'containers/screenings/IncidentInformationFormContainer'
+import * as Navigation from 'utils/navigation'
 
 describe('IncidentInformationFormContainer', () => {
   describe('mapDispatchToProps', () => {
     beforeEach(() => {
-      window.location.hash = ''
-    })
-    afterEach(() => {
-      window.location.hash = ''
+      spyOn(Navigation, 'setHash')
     })
     describe('when saving', () => {
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch)
         onSave()
-        expect(window.location.hash).toEqual('#incident-information-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#incident-information-card-anchor')
       })
     })
     describe('when canceling', () => {
@@ -21,7 +19,7 @@ describe('IncidentInformationFormContainer', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onCancel} = mapDispatchToProps(dispatch)
         onCancel()
-        expect(window.location.hash).toEqual('#incident-information-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#incident-information-card-anchor')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
@@ -1,0 +1,20 @@
+import {mapDispatchToProps} from 'containers/screenings/IncidentInformationFormContainer'
+
+describe('IncidentInformationFormContainer', () => {
+  describe('mapDispatchToProps', () => {
+    describe('when saving', () => {
+      beforeEach(() => {
+        window.location.hash = ''
+      })
+      afterEach(() => {
+        window.location.hash = ''
+      })
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onSave} = mapDispatchToProps(dispatch)
+        onSave()
+        expect(window.location.hash).toEqual('#incident-information-card-anchor')
+      })
+    })
+  })
+})

--- a/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
@@ -1,19 +1,17 @@
 import {mapDispatchToProps} from 'containers/screenings/NarrativeFormContainer'
+import * as Navigation from 'utils/navigation'
 
 describe('NarrativeFormContainer', () => {
   describe('mapDispatchToProps', () => {
     beforeEach(() => {
-      window.location.hash = ''
-    })
-    afterEach(() => {
-      window.location.hash = ''
+      spyOn(Navigation, 'setHash')
     })
     describe('when saving', () => {
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch)
         onSave()
-        expect(window.location.hash).toEqual('#narrative-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#narrative-card-anchor')
       })
     })
     describe('when canceling', () => {
@@ -21,7 +19,7 @@ describe('NarrativeFormContainer', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onCancel} = mapDispatchToProps(dispatch)
         onCancel()
-        expect(window.location.hash).toEqual('#narrative-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#narrative-card-anchor')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
@@ -2,17 +2,25 @@ import {mapDispatchToProps} from 'containers/screenings/NarrativeFormContainer'
 
 describe('NarrativeFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    beforeEach(() => {
+      window.location.hash = ''
+    })
+    afterEach(() => {
+      window.location.hash = ''
+    })
     describe('when saving', () => {
-      beforeEach(() => {
-        window.location.hash = ''
-      })
-      afterEach(() => {
-        window.location.hash = ''
-      })
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch)
         onSave()
+        expect(window.location.hash).toEqual('#narrative-card-anchor')
+      })
+    })
+    describe('when canceling', () => {
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onCancel} = mapDispatchToProps(dispatch)
+        onCancel()
         expect(window.location.hash).toEqual('#narrative-card-anchor')
       })
     })

--- a/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
@@ -1,0 +1,20 @@
+import {mapDispatchToProps} from 'containers/screenings/NarrativeFormContainer'
+
+describe('NarrativeFormContainer', () => {
+  describe('mapDispatchToProps', () => {
+    describe('when saving', () => {
+      beforeEach(() => {
+        window.location.hash = ''
+      })
+      afterEach(() => {
+        window.location.hash = ''
+      })
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onSave} = mapDispatchToProps(dispatch)
+        onSave()
+        expect(window.location.hash).toEqual('#narrative-card-anchor')
+      })
+    })
+  })
+})

--- a/spec/javascripts/containers/screenings/PersonCardContainerSpec.js
+++ b/spec/javascripts/containers/screenings/PersonCardContainerSpec.js
@@ -1,19 +1,17 @@
 import {mapDispatchToProps} from 'containers/screenings/PersonCardContainer'
+import * as Navigation from 'utils/navigation'
 
 describe('PersonCardContainer', () => {
   describe('mapDispatchToProps', () => {
     beforeEach(() => {
-      window.location.hash = ''
-    })
-    afterEach(() => {
-      window.location.hash = ''
+      spyOn(Navigation, 'setHash')
     })
     describe('when saving', () => {
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch, {personId: '34592'})
         onSave()
-        expect(window.location.hash).toEqual('#participants-card-34592')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#participants-card-34592')
       })
     })
     describe('when canceling', () => {
@@ -21,7 +19,7 @@ describe('PersonCardContainer', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onCancel} = mapDispatchToProps(dispatch, {personId: '34592'})
         onCancel()
-        expect(window.location.hash).toEqual('#participants-card-34592')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#participants-card-34592')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/PersonCardContainerSpec.js
+++ b/spec/javascripts/containers/screenings/PersonCardContainerSpec.js
@@ -2,17 +2,25 @@ import {mapDispatchToProps} from 'containers/screenings/PersonCardContainer'
 
 describe('PersonCardContainer', () => {
   describe('mapDispatchToProps', () => {
+    beforeEach(() => {
+      window.location.hash = ''
+    })
+    afterEach(() => {
+      window.location.hash = ''
+    })
     describe('when saving', () => {
-      beforeEach(() => {
-        window.location.hash = ''
-      })
-      afterEach(() => {
-        window.location.hash = ''
-      })
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch, {personId: '34592'})
         onSave()
+        expect(window.location.hash).toEqual('#participants-card-34592')
+      })
+    })
+    describe('when canceling', () => {
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onCancel} = mapDispatchToProps(dispatch, {personId: '34592'})
+        onCancel()
         expect(window.location.hash).toEqual('#participants-card-34592')
       })
     })

--- a/spec/javascripts/containers/screenings/PersonCardContainerSpec.js
+++ b/spec/javascripts/containers/screenings/PersonCardContainerSpec.js
@@ -1,0 +1,20 @@
+import {mapDispatchToProps} from 'containers/screenings/PersonCardContainer'
+
+describe('PersonCardContainer', () => {
+  describe('mapDispatchToProps', () => {
+    describe('when saving', () => {
+      beforeEach(() => {
+        window.location.hash = ''
+      })
+      afterEach(() => {
+        window.location.hash = ''
+      })
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onSave} = mapDispatchToProps(dispatch, {personId: '34592'})
+        onSave()
+        expect(window.location.hash).toEqual('#participants-card-34592')
+      })
+    })
+  })
+})

--- a/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
@@ -7,15 +7,13 @@ import {
   mapDispatchToProps,
   mergeProps,
 } from 'containers/screenings/ScreeningInformationFormContainer'
+import * as Navigation from 'utils/navigation'
 
 describe('ScreeningInformationFormContainer', () => {
   describe('mapDispatchToProps', () => {
     describe('when canceling', () => {
       beforeEach(() => {
-        window.location.hash = ''
-      })
-      afterEach(() => {
-        window.location.hash = ''
+        spyOn(Navigation, 'setHash')
       })
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
@@ -23,7 +21,7 @@ describe('ScreeningInformationFormContainer', () => {
 
         onCancel()
 
-        expect(window.location.hash).toEqual('#screening-information-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#screening-information-card-anchor')
       })
     })
   })
@@ -50,10 +48,7 @@ describe('ScreeningInformationFormContainer', () => {
 
     describe('when saving', () => {
       beforeEach(() => {
-        window.location.hash = ''
-      })
-      afterEach(() => {
-        window.location.hash = ''
+        spyOn(Navigation, 'setHash')
       })
       it('saves the card, touches the fields, sets show mode, and navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
@@ -67,7 +62,7 @@ describe('ScreeningInformationFormContainer', () => {
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
         expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
 
-        expect(window.location.hash).toEqual('#screening-information-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#screening-information-card-anchor')
       })
 
       it('triggers SSB when report type changes to SSB', () => {
@@ -81,7 +76,7 @@ describe('ScreeningInformationFormContainer', () => {
 
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
         expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
-        expect(window.location.hash).toEqual('#screening-information-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#screening-information-card-anchor')
       })
 
       it('does not trigger SSB when report type was already SSB', () => {

--- a/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
@@ -27,7 +27,10 @@ describe('ScreeningInformationFormContainer', () => {
     })
 
     describe('when saving', () => {
-      it('saves the card, touches the fields, and sets show mode', () => {
+      beforeEach(() => {
+        window.location.hash = ''
+      })
+      it('saves the card, touches the fields, sets show mode, and navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const onSave = mergeProps({screeningId: '3'}, {dispatch}, {}).onSave
 
@@ -38,6 +41,8 @@ describe('ScreeningInformationFormContainer', () => {
 
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
         expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
+
+        expect(window.location.hash).toEqual('#screening-information-card-anchor')
       })
 
       it('triggers SSB when report type changes to SSB', () => {
@@ -51,6 +56,7 @@ describe('ScreeningInformationFormContainer', () => {
 
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
         expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
+        expect(window.location.hash).toEqual('#screening-information-card-anchor')
       })
 
       it('does not trigger SSB when report type was already SSB', () => {

--- a/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
@@ -2,9 +2,31 @@ import {generateBabyDoe} from 'actions/safelySurrenderedBabyActions'
 import {saveCard} from 'actions/screeningActions'
 import {touchAllFields} from 'actions/screeningInformationFormActions'
 import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
-import {cardName, mergeProps} from 'containers/screenings/ScreeningInformationFormContainer'
+import {
+  cardName,
+  mapDispatchToProps,
+  mergeProps,
+} from 'containers/screenings/ScreeningInformationFormContainer'
 
 describe('ScreeningInformationFormContainer', () => {
+  describe('mapDispatchToProps', () => {
+    describe('when canceling', () => {
+      beforeEach(() => {
+        window.location.hash = ''
+      })
+      afterEach(() => {
+        window.location.hash = ''
+      })
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onCancel} = mapDispatchToProps(dispatch)
+
+        onCancel()
+
+        expect(window.location.hash).toEqual('#screening-information-card-anchor')
+      })
+    })
+  })
   describe('mergeProps', () => {
     it('combines all props from stateProps, dispatchProps, and ownProps', () => {
       const stateProps = {
@@ -28,6 +50,9 @@ describe('ScreeningInformationFormContainer', () => {
 
     describe('when saving', () => {
       beforeEach(() => {
+        window.location.hash = ''
+      })
+      afterEach(() => {
         window.location.hash = ''
       })
       it('saves the card, touches the fields, sets show mode, and navigates to the card', () => {

--- a/spec/javascripts/containers/screenings/WorkerSafetyFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/WorkerSafetyFormContainerSpec.js
@@ -1,0 +1,20 @@
+import {mapDispatchToProps} from 'containers/screenings/WorkerSafetyFormContainer'
+
+describe('WorkerSafetyFormContainer', () => {
+  describe('mapDispatchToProps', () => {
+    describe('when saving', () => {
+      beforeEach(() => {
+        window.location.hash = ''
+      })
+      afterEach(() => {
+        window.location.hash = ''
+      })
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onSave} = mapDispatchToProps(dispatch)
+        onSave()
+        expect(window.location.hash).toEqual('#worker-safety-card-anchor')
+      })
+    })
+  })
+})

--- a/spec/javascripts/containers/screenings/WorkerSafetyFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/WorkerSafetyFormContainerSpec.js
@@ -1,19 +1,17 @@
 import {mapDispatchToProps} from 'containers/screenings/WorkerSafetyFormContainer'
+import * as Navigation from 'utils/navigation'
 
 describe('WorkerSafetyFormContainer', () => {
   describe('mapDispatchToProps', () => {
     beforeEach(() => {
-      window.location.hash = ''
-    })
-    afterEach(() => {
-      window.location.hash = ''
+      spyOn(Navigation, 'setHash')
     })
     describe('when saving', () => {
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onSave} = mapDispatchToProps(dispatch)
         onSave()
-        expect(window.location.hash).toEqual('#worker-safety-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#worker-safety-card-anchor')
       })
     })
     describe('when canceling', () => {
@@ -27,7 +25,7 @@ describe('WorkerSafetyFormContainer', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const {onCancel} = mapDispatchToProps(dispatch)
         onCancel()
-        expect(window.location.hash).toEqual('#worker-safety-card-anchor')
+        expect(Navigation.setHash).toHaveBeenCalledWith('#worker-safety-card-anchor')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/WorkerSafetyFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/WorkerSafetyFormContainerSpec.js
@@ -2,7 +2,21 @@ import {mapDispatchToProps} from 'containers/screenings/WorkerSafetyFormContaine
 
 describe('WorkerSafetyFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    beforeEach(() => {
+      window.location.hash = ''
+    })
+    afterEach(() => {
+      window.location.hash = ''
+    })
     describe('when saving', () => {
+      it('navigates to the card', () => {
+        const dispatch = jasmine.createSpy('dispatch')
+        const {onSave} = mapDispatchToProps(dispatch)
+        onSave()
+        expect(window.location.hash).toEqual('#worker-safety-card-anchor')
+      })
+    })
+    describe('when canceling', () => {
       beforeEach(() => {
         window.location.hash = ''
       })
@@ -11,8 +25,8 @@ describe('WorkerSafetyFormContainer', () => {
       })
       it('navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
-        const {onSave} = mapDispatchToProps(dispatch)
-        onSave()
+        const {onCancel} = mapDispatchToProps(dispatch)
+        onCancel()
         expect(window.location.hash).toEqual('#worker-safety-card-anchor')
       })
     })

--- a/spec/javascripts/utils/navigationSpec.js
+++ b/spec/javascripts/utils/navigationSpec.js
@@ -1,0 +1,10 @@
+import {setHash} from 'utils/navigation'
+describe('Navigation', () => {
+  describe('setHash', () => {
+    it('sets the hash on the window location', () => {
+      window.location.hash = '#foo'
+      setHash('#bar')
+      expect(window.location.hash).toEqual('#bar')
+    })
+  })
+})

--- a/spec/javascripts/views/CrossReportFormSpec.jsx
+++ b/spec/javascripts/views/CrossReportFormSpec.jsx
@@ -357,6 +357,12 @@ describe('CrossReportForm', () => {
     })
   })
   describe('clicking on save', () => {
+    beforeEach(() => {
+      window.location.hash = ''
+    })
+    afterEach(() => {
+      window.location.hash = ''
+    })
     it('fires toggleShow, saveCard', () => {
       const saveCard = jasmine.createSpy('saveCard')
       const touchAllFields = jasmine.createSpy('touchAllFields')
@@ -370,6 +376,7 @@ describe('CrossReportForm', () => {
       expect(saveCrossReport).toHaveBeenCalledWith(screeningWithEdits)
       expect(touchAllFields).toHaveBeenCalled()
       expect(setCardMode).toHaveBeenCalledWith(cardName, SHOW_MODE)
+      expect(window.location.hash).toEqual('#cross-report-card-anchor')
     })
   })
 })

--- a/spec/javascripts/views/CrossReportFormSpec.jsx
+++ b/spec/javascripts/views/CrossReportFormSpec.jsx
@@ -2,6 +2,7 @@ import CrossReportForm from 'views/CrossReportForm'
 import React from 'react'
 import {shallow} from 'enzyme'
 import {SHOW_MODE} from 'actions/screeningPageActions'
+import * as Navigation from 'utils/navigation'
 
 describe('CrossReportForm', () => {
   function renderCrossReportForm({
@@ -347,6 +348,7 @@ describe('CrossReportForm', () => {
   })
   describe('clicking on cancel', () => {
     it('fires setCardMode, clearCardEdits', () => {
+      spyOn(Navigation, 'setHash')
       const clearCardEdits = jasmine.createSpy('clearCardEdits')
       const setCardMode = jasmine.createSpy('setCardMode')
       const cardName = 'cross-report-card'
@@ -354,16 +356,12 @@ describe('CrossReportForm', () => {
       component.find('.btn.btn-default').simulate('click')
       expect(setCardMode).toHaveBeenCalledWith(cardName, SHOW_MODE)
       expect(clearCardEdits).toHaveBeenCalledWith(cardName)
+      expect(Navigation.setHash).toHaveBeenCalledWith('#cross-report-card-anchor')
     })
   })
   describe('clicking on save', () => {
-    beforeEach(() => {
-      window.location.hash = ''
-    })
-    afterEach(() => {
-      window.location.hash = ''
-    })
     it('fires toggleShow, saveCard', () => {
+      spyOn(Navigation, 'setHash')
       const saveCard = jasmine.createSpy('saveCard')
       const touchAllFields = jasmine.createSpy('touchAllFields')
       const saveCrossReport = jasmine.createSpy('saveCrossReport')
@@ -376,7 +374,7 @@ describe('CrossReportForm', () => {
       expect(saveCrossReport).toHaveBeenCalledWith(screeningWithEdits)
       expect(touchAllFields).toHaveBeenCalled()
       expect(setCardMode).toHaveBeenCalledWith(cardName, SHOW_MODE)
-      expect(window.location.hash).toEqual('#cross-report-card-anchor')
+      expect(Navigation.setHash).toHaveBeenCalledWith('#cross-report-card-anchor')
     })
   })
 })

--- a/spec/support/helpers/screening_helpers.rb
+++ b/spec/support/helpers/screening_helpers.rb
@@ -82,8 +82,8 @@ module ScreeningHelpers
     within('.card', text: 'Incident Information') { click_button 'Save' }
     within('.card', text: 'Allegations') { click_button 'Save' }
     within('.card', text: 'Worker Safety') { click_button 'Save' }
-    within('.card', text: 'Cross Report') { click_button 'Save' }
     within('.card', text: 'Decision') { click_button 'Save' }
+    within('.card', text: 'Cross Report') { click_button 'Save' }
   end
 
   def cancel_all_cards
@@ -92,8 +92,8 @@ module ScreeningHelpers
     within('.card', text: 'Incident Information') { click_button 'Cancel' }
     within('.card', text: 'Allegations') { click_button 'Cancel' }
     within('.card', text: 'Worker Safety') { click_button 'Cancel' }
-    within('.card', text: 'Cross Report') { click_button 'Cancel' }
     within('.card', text: 'Decision') { click_button 'Cancel' }
+    within('.card', text: 'Cross Report') { click_button 'Cancel' }
   end
 end
 


### PR DESCRIPTION
### Jira Story

- [Page remains static when a card is saved HOT-2157](https://osi-cwds.atlassian.net/browse/HOT-2157)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
The goal of this story is to set the scroll focus to the top of each card after saving. This is one way of doing that. There are some improvements I'd like to make, but those refactors are all looking surprisingly big... so I wanted to get opinions on how worthwhile we think they are before I actually tackle them.

1. This modifies the window location directly. Modifying global state from a callback does not play well with Redux nor unit tests, and so I would love to use React Router here. However, I think I'd have to wrap all of these cards in [the withRouter` component](https://github.com/ReactTraining/react-router/blob/master/packages/react-router/docs/api/withRouter.md) in order to do that.
2. I am hard-coding the anchor hash. This is already hardcoded in our Sidebar and verified in feature-tests, so this doesn't sound terrible. However, it's *so close* to having the id available as a prop. I could thread it through or do the following refactor to avoid hard-coding it.
2. If I set it in this location, I have to add it to every single card individually. I'd like to refactor the card component structure (containers, CardView, ScreeningPage) so that I can put this in a single location. But...that only matters if we feel bad duplicating a single line of code six or seven times.

Anyways... let me know if you have any thoughts or care, I guess?

Edit: This PR is now a full implementation of that simple approach, without any refactors. It handles resetting of scroll on both card save and cancel. I'd like to have this reviewed and merged if possible, and I will create a second PR later today depending on how far I get into the refactors.

## Tests
- [x] I have included unit tests
- [ ] I have included feature tests
- [ ] I have included other tests
- [ ] I have NOT included tests
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

