### PR TITLE
HOT-1617 - Refactors of card Show mode

### DIFF
--- a/app/javascript/containers/screenings/AllegationsFormContainer.jsx
+++ b/app/javascript/containers/screenings/AllegationsFormContainer.jsx
@@ -8,7 +8,6 @@ import {
 } from 'selectors/screening/allegationsFormSelectors'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
 import {setAllegationTypes} from 'actions/allegationsFormActions'
-import {setHash} from 'utils/navigation'
 
 export const cardName = 'allegations-card'
 
@@ -25,7 +24,6 @@ export const mapDispatchToProps = (dispatch, {onShow}) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     onShow()
-    setHash('#allegations-card-anchor')
   },
   onChange: (props) => {
     dispatch(setAllegationTypes(props))
@@ -33,7 +31,6 @@ export const mapDispatchToProps = (dispatch, {onShow}) => ({
   onSave: () => {
     dispatch(saveCard(cardName))
     onShow()
-    setHash('#allegations-card-anchor')
   },
   dispatch,
 })

--- a/app/javascript/containers/screenings/AllegationsFormContainer.jsx
+++ b/app/javascript/containers/screenings/AllegationsFormContainer.jsx
@@ -7,7 +7,6 @@ import {
   getAllegationsAlertErrorMessageSelector,
 } from 'selectors/screening/allegationsFormSelectors'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
-import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import {setAllegationTypes} from 'actions/allegationsFormActions'
 import {setHash} from 'utils/navigation'
 
@@ -22,10 +21,10 @@ const mapStateToProps = (state) => (
   }
 )
 
-export const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch, {onShow}) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#allegations-card-anchor')
   },
   onChange: (props) => {
@@ -33,7 +32,7 @@ export const mapDispatchToProps = (dispatch) => ({
   },
   onSave: () => {
     dispatch(saveCard(cardName))
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#allegations-card-anchor')
   },
   dispatch,

--- a/app/javascript/containers/screenings/CardContainer.js
+++ b/app/javascript/containers/screenings/CardContainer.js
@@ -5,6 +5,7 @@ import {
   getCardModeValueSelector,
   getCardIsEditableSelector,
 } from 'selectors/screening/screeningPageSelectors'
+import {setHash} from 'utils/navigation'
 
 const mapStateToProps = (state, {id}) => ({
   editable: getCardIsEditableSelector(state, id),
@@ -13,7 +14,10 @@ const mapStateToProps = (state, {id}) => ({
 
 export const mapDispatchToProps = (dispatch, {id}) => ({
   onEdit: () => dispatch(setCardMode(id, EDIT_MODE)),
-  onShow: () => dispatch(setCardMode(id, SHOW_MODE)),
+  onShow: () => {
+    dispatch(setCardMode(id, SHOW_MODE))
+    setHash(`#${id}-anchor`)
+  },
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(CardView)

--- a/app/javascript/containers/screenings/CardContainer.js
+++ b/app/javascript/containers/screenings/CardContainer.js
@@ -1,6 +1,6 @@
 import {connect} from 'react-redux'
 import CardView from 'views/CardView'
-import {setCardMode, EDIT_MODE} from 'actions/screeningPageActions'
+import {setCardMode, EDIT_MODE, SHOW_MODE} from 'actions/screeningPageActions'
 import {
   getCardModeValueSelector,
   getCardIsEditableSelector,
@@ -11,9 +11,9 @@ const mapStateToProps = (state, {id}) => ({
   mode: getCardModeValueSelector(state, id),
 })
 
-const mapDispatchToProps = (dispatch, {id}) => ({
+export const mapDispatchToProps = (dispatch, {id}) => ({
   onEdit: () => dispatch(setCardMode(id, EDIT_MODE)),
+  onShow: () => dispatch(setCardMode(id, SHOW_MODE)),
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(CardView)
-

--- a/app/javascript/containers/screenings/CrossReportFormContainer.jsx
+++ b/app/javascript/containers/screenings/CrossReportFormContainer.jsx
@@ -27,7 +27,6 @@ import {
   touchField,
 } from 'actions/crossReportFormActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
-import {setCardMode} from 'actions/screeningPageActions'
 import {
   getAllegationsRequireCrossReportsValueSelector,
   getVisibleErrorsSelector,
@@ -42,7 +41,7 @@ import {selectCounties} from 'selectors/systemCodeSelectors'
 
 export const cardName = 'cross-report-card'
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = (state, {onShow}) => ({
   allegationsRequireCrossReports: getAllegationsRequireCrossReportsValueSelector(state),
   areCrossReportsRequired: getAllegationsRequireCrossReportsValueSelector(state),
   cardName: cardName,
@@ -64,6 +63,7 @@ const mapStateToProps = (state) => ({
   method: state.getIn(['crossReportForm', 'method', 'value']) || '',
   screeningWithEdits: getScreeningWithEditsSelector(state).toJS(),
   userCounty: getUserCountySelector(state),
+  onShow,
 })
 const mapDispatchToProps = (dispatch) => ({
   actions: bindActionCreators({
@@ -78,7 +78,6 @@ const mapDispatchToProps = (dispatch) => ({
     touchField,
     saveCard,
     fetchCountyAgencies,
-    setCardMode,
     clearCardEdits,
   }, dispatch),
 })

--- a/app/javascript/containers/screenings/DecisionFormContainer.jsx
+++ b/app/javascript/containers/screenings/DecisionFormContainer.jsx
@@ -20,7 +20,6 @@ import {
   touchAllFields,
 } from 'actions/screeningDecisionFormActions'
 import {sdmPath} from 'common/config'
-import {setHash} from 'utils/navigation'
 
 export const cardName = 'decision-card'
 
@@ -46,7 +45,6 @@ export const mapDispatchToProps = (dispatch, {onShow}) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     onShow()
-    setHash('#decision-card-anchor')
   },
   onChange: (field, value) => {
     dispatch(setField({field, value}))
@@ -62,7 +60,6 @@ export const mapDispatchToProps = (dispatch, {onShow}) => ({
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
     onShow()
-    setHash('#decision-card-anchor')
   },
   dispatch,
 })

--- a/app/javascript/containers/screenings/DecisionFormContainer.jsx
+++ b/app/javascript/containers/screenings/DecisionFormContainer.jsx
@@ -14,7 +14,6 @@ import {
   selectContactReference,
 } from 'selectors/screening/decisionFormSelectors'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
-import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import {
   setField,
   touchField,
@@ -42,11 +41,11 @@ const mapStateToProps = (state) => (
   }
 )
 
-export const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch, {onShow}) => ({
   onBlur: (field) => dispatch(touchField({field})),
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#decision-card-anchor')
   },
   onChange: (field, value) => {
@@ -62,7 +61,7 @@ export const mapDispatchToProps = (dispatch) => ({
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#decision-card-anchor')
   },
   dispatch,

--- a/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
+++ b/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
@@ -17,7 +17,6 @@ import {
   touchField,
 } from 'actions/incidentInformationFormActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
-import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import {setHash} from 'utils/navigation'
 
 export const cardName = 'incident-information-card'
@@ -34,19 +33,19 @@ const mapStateToProps = (state) => ({
   locationOfChildren: getLocationOfChildrenSelector(state),
 })
 
-export const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch, {onShow}) => ({
   onBlur: (fieldName) => dispatch(touchField(fieldName)),
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#incident-information-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#incident-information-card-anchor')
   },
 })

--- a/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
+++ b/app/javascript/containers/screenings/IncidentInformationFormContainer.jsx
@@ -17,7 +17,6 @@ import {
   touchField,
 } from 'actions/incidentInformationFormActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
-import {setHash} from 'utils/navigation'
 
 export const cardName = 'incident-information-card'
 
@@ -39,14 +38,12 @@ export const mapDispatchToProps = (dispatch, {onShow}) => ({
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
     onShow()
-    setHash('#incident-information-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
     onShow()
-    setHash('#incident-information-card-anchor')
   },
 })
 

--- a/app/javascript/containers/screenings/NarrativeFormContainer.jsx
+++ b/app/javascript/containers/screenings/NarrativeFormContainer.jsx
@@ -5,7 +5,6 @@ import {
 } from 'selectors/screening/narrativeFormSelectors'
 import {setField, touchField, touchAllFields} from 'actions/narrativeFormActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
-import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import {connect} from 'react-redux'
 import {setHash} from 'utils/navigation'
 
@@ -20,19 +19,19 @@ const mapStateToProps = (state) => (
   }
 )
 
-export const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch, {onShow}) => ({
   onBlur: (fieldName) => dispatch(touchField(fieldName)),
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#narrative-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#narrative-card-anchor')
   },
 })

--- a/app/javascript/containers/screenings/NarrativeFormContainer.jsx
+++ b/app/javascript/containers/screenings/NarrativeFormContainer.jsx
@@ -6,7 +6,6 @@ import {
 import {setField, touchField, touchAllFields} from 'actions/narrativeFormActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
 import {connect} from 'react-redux'
-import {setHash} from 'utils/navigation'
 
 export const cardName = 'narrative-card'
 
@@ -25,14 +24,12 @@ export const mapDispatchToProps = (dispatch, {onShow}) => ({
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
     onShow()
-    setHash('#narrative-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {
     dispatch(saveCard(cardName))
     dispatch(touchAllFields())
     onShow()
-    setHash('#narrative-card-anchor')
   },
 })
 

--- a/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
+++ b/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
@@ -9,7 +9,6 @@ import {
 } from 'selectors/screening/screeningInformationFormSelectors'
 import {generateBabyDoe} from 'actions/safelySurrenderedBabyActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
-import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import {getScreeningSelector} from 'selectors/screeningSelectors'
 import {setHash} from 'utils/navigation'
 
@@ -40,12 +39,12 @@ const mapStateToProps = (state) => {
   }
 }
 
-export const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch, {onShow}) => ({
   onBlur: (fieldName) => dispatch(touchField(fieldName)),
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#screening-information-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
@@ -63,7 +62,7 @@ export const mergeProps = (stateProps, dispatchProps, ownProps) => ({
       dispatchProps.dispatch(saveCard(cardName))
     }
     dispatchProps.dispatch(touchAllFields())
-    dispatchProps.dispatch(setCardMode(cardName, SHOW_MODE))
+    ownProps.onShow()
     setHash('#screening-information-card-anchor')
   },
 })

--- a/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
+++ b/app/javascript/containers/screenings/ScreeningInformationFormContainer.js
@@ -10,7 +10,6 @@ import {
 import {generateBabyDoe} from 'actions/safelySurrenderedBabyActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
 import {getScreeningSelector} from 'selectors/screeningSelectors'
-import {setHash} from 'utils/navigation'
 
 export const cardName = 'screening-information-card'
 
@@ -45,7 +44,6 @@ export const mapDispatchToProps = (dispatch, {onShow}) => ({
     dispatch(clearCardEdits(cardName))
     dispatch(touchAllFields())
     onShow()
-    setHash('#screening-information-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   dispatch,
@@ -63,7 +61,6 @@ export const mergeProps = (stateProps, dispatchProps, ownProps) => ({
     }
     dispatchProps.dispatch(touchAllFields())
     ownProps.onShow()
-    setHash('#screening-information-card-anchor')
   },
 })
 

--- a/app/javascript/containers/screenings/WorkerSafetyFormContainer.jsx
+++ b/app/javascript/containers/screenings/WorkerSafetyFormContainer.jsx
@@ -5,7 +5,6 @@ import {
 } from 'selectors/screening/workerSafetyFormSelectors'
 import {setField} from 'actions/workerSafetyFormActions'
 import {saveCard, clearCardEdits} from 'actions/screeningActions'
-import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import SAFETY_ALERT from 'enums/SafetyAlert'
 import selectOptions from 'utils/selectHelper'
 import {connect} from 'react-redux'
@@ -25,16 +24,16 @@ const mapStateToProps = (state) => (
   }
 )
 
-export const mapDispatchToProps = (dispatch) => ({
+export const mapDispatchToProps = (dispatch, {onShow}) => ({
   onCancel: () => {
     dispatch(clearCardEdits(cardName))
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#worker-safety-card-anchor')
   },
   onChange: (fieldName, value) => dispatch(setField(fieldName, value)),
   onSave: () => {
     dispatch(saveCard(cardName))
-    dispatch(setCardMode(cardName, SHOW_MODE))
+    onShow()
     setHash('#worker-safety-card-anchor')
   },
   dispatch,

--- a/app/javascript/views/CardView.jsx
+++ b/app/javascript/views/CardView.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import ClassNames from 'classnames'
 import EditLink from 'common/EditLink'
 
-const CardView = ({edit, editable, id, mode, onEdit, show, title}) => (
+const CardView = ({edit, editable, id, mode, onEdit, onShow, show, title}) => (
   <div>
     <a className='anchor' id={`${id}-anchor`}/>
     <div className={ClassNames('card', mode || 'edit', 'double-gap-bottom', 'position-relative')} id={id}>
@@ -19,19 +19,20 @@ const CardView = ({edit, editable, id, mode, onEdit, show, title}) => (
           />
         }
       </div>
-      {(mode === 'edit' || mode === undefined) && edit}
+      {(mode === 'edit' || mode === undefined) && edit && React.cloneElement(edit, {onShow})}
       {mode === 'show' && show}
     </div>
   </div>
 )
 
 CardView.propTypes = {
-  edit: PropTypes.object,
+  edit: PropTypes.element,
   editable: PropTypes.bool,
   id: PropTypes.string,
   mode: PropTypes.string,
   onEdit: PropTypes.func,
-  show: PropTypes.object,
+  onShow: PropTypes.func,
+  show: PropTypes.element,
   title: PropTypes.string,
 }
 

--- a/app/javascript/views/CrossReportForm.jsx
+++ b/app/javascript/views/CrossReportForm.jsx
@@ -32,6 +32,7 @@ const CrossReportForm = ({
   inform_date,
   lawEnforcement,
   method,
+  onShow,
   screeningWithEdits,
   userCounty,
   actions: {
@@ -43,7 +44,6 @@ const CrossReportForm = ({
     saveCard,
     setAgencyField,
     setAgencyTypeField,
-    setCardMode,
     setField,
     touchAgencyField,
     touchAllFields,
@@ -52,15 +52,13 @@ const CrossReportForm = ({
 }) => {
   const cancel = () => {
     clearCardEdits(cardName)
-    setCardMode(cardName, SHOW_MODE)
-    setHash('#cross-report-card-anchor')
+    onShow()
   }
   const save = () => {
     saveCard(cardName)
     saveCrossReport(screeningWithEdits)
     touchAllFields()
-    setCardMode(cardName, SHOW_MODE)
-    setHash('#cross-report-card-anchor')
+    onShow()
   }
   const agencyFieldActions = {
     setAgencyTypeField,
@@ -215,6 +213,7 @@ CrossReportForm.propTypes = {
   inform_date: PropTypes.string,
   lawEnforcement: PropTypes.object.isRequired,
   method: PropTypes.string,
+  onShow: PropTypes.func.isRequired,
   screeningWithEdits: PropTypes.object,
   userCounty: PropTypes.string,
 }

--- a/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
@@ -3,21 +3,36 @@ import * as Navigation from 'utils/navigation'
 
 describe('AllegationsFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    let dispatch
+    let onShow
+    let props
     beforeEach(() => {
+      dispatch = jasmine.createSpy('dispatch')
+      onShow = jasmine.createSpy('onShow')
       spyOn(Navigation, 'setHash')
+
+      props = mapDispatchToProps(dispatch, {onShow})
     })
     describe('when saving', () => {
+      it('sets the card to show mode', () => {
+        const {onSave} = props
+        onSave()
+        expect(onShow).toHaveBeenCalled()
+      })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onSave} = mapDispatchToProps(dispatch)
+        const {onSave} = props
         onSave()
         expect(Navigation.setHash).toHaveBeenCalledWith('#allegations-card-anchor')
       })
     })
     describe('when canceling', () => {
+      it('sets the card to show mode', () => {
+        const {onCancel} = props
+        onCancel()
+        expect(onShow).toHaveBeenCalled()
+      })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onCancel} = mapDispatchToProps(dispatch)
+        const {onCancel} = props
         onCancel()
         expect(Navigation.setHash).toHaveBeenCalledWith('#allegations-card-anchor')
       })

--- a/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/AllegationsFormContainerSpec.js
@@ -1,5 +1,4 @@
 import {mapDispatchToProps} from 'containers/screenings/AllegationsFormContainer'
-import * as Navigation from 'utils/navigation'
 
 describe('AllegationsFormContainer', () => {
   describe('mapDispatchToProps', () => {
@@ -9,8 +8,6 @@ describe('AllegationsFormContainer', () => {
     beforeEach(() => {
       dispatch = jasmine.createSpy('dispatch')
       onShow = jasmine.createSpy('onShow')
-      spyOn(Navigation, 'setHash')
-
       props = mapDispatchToProps(dispatch, {onShow})
     })
     describe('when saving', () => {
@@ -19,22 +16,12 @@ describe('AllegationsFormContainer', () => {
         onSave()
         expect(onShow).toHaveBeenCalled()
       })
-      it('navigates to the card', () => {
-        const {onSave} = props
-        onSave()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#allegations-card-anchor')
-      })
     })
     describe('when canceling', () => {
       it('sets the card to show mode', () => {
         const {onCancel} = props
         onCancel()
         expect(onShow).toHaveBeenCalled()
-      })
-      it('navigates to the card', () => {
-        const {onCancel} = props
-        onCancel()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#allegations-card-anchor')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/CardContainerSpec.js
+++ b/spec/javascripts/containers/screenings/CardContainerSpec.js
@@ -1,10 +1,15 @@
 import {setCardMode, EDIT_MODE, SHOW_MODE} from 'actions/screeningPageActions'
 import {mapDispatchToProps} from 'containers/screenings/CardContainer'
+import * as Navigation from 'utils/navigation'
 
 describe('CardContainer', () => {
+  let dispatch
+  beforeEach(() => {
+    dispatch = jasmine.createSpy('dispatch')
+    spyOn(Navigation, 'setHash')
+  })
   describe('onEdit', () => {
     it('sets card mode to edit', () => {
-      const dispatch = jasmine.createSpy('dispatch')
       const {onEdit} = mapDispatchToProps(dispatch, {id: 'fluffy'})
 
       onEdit()
@@ -14,11 +19,17 @@ describe('CardContainer', () => {
 
   describe('onShow', () => {
     it('sets the card mode to show', () => {
-      const dispatch = jasmine.createSpy('dispatch')
       const {onShow} = mapDispatchToProps(dispatch, {id: 'fluffer'})
 
       onShow()
       expect(dispatch).toHaveBeenCalledWith(setCardMode('fluffer', SHOW_MODE))
+    })
+
+    it('navigates to the anchor for the card', () => {
+      const {onShow} = mapDispatchToProps(dispatch, {id: 'hello'})
+
+      onShow()
+      expect(Navigation.setHash).toHaveBeenCalledWith('#hello-anchor')
     })
   })
 })

--- a/spec/javascripts/containers/screenings/CardContainerSpec.js
+++ b/spec/javascripts/containers/screenings/CardContainerSpec.js
@@ -1,0 +1,24 @@
+import {setCardMode, EDIT_MODE, SHOW_MODE} from 'actions/screeningPageActions'
+import {mapDispatchToProps} from 'containers/screenings/CardContainer'
+
+describe('CardContainer', () => {
+  describe('onEdit', () => {
+    it('sets card mode to edit', () => {
+      const dispatch = jasmine.createSpy('dispatch')
+      const {onEdit} = mapDispatchToProps(dispatch, {id: 'fluffy'})
+
+      onEdit()
+      expect(dispatch).toHaveBeenCalledWith(setCardMode('fluffy', EDIT_MODE))
+    })
+  })
+
+  describe('onShow', () => {
+    it('sets the card mode to show', () => {
+      const dispatch = jasmine.createSpy('dispatch')
+      const {onShow} = mapDispatchToProps(dispatch, {id: 'fluffer'})
+
+      onShow()
+      expect(dispatch).toHaveBeenCalledWith(setCardMode('fluffer', SHOW_MODE))
+    })
+  })
+})

--- a/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
@@ -1,5 +1,4 @@
 import {mapDispatchToProps} from 'containers/screenings/DecisionFormContainer'
-import * as Navigation from 'utils/navigation'
 
 describe('DecisionFormContainer', () => {
   describe('mapDispatchToProps', () => {
@@ -9,8 +8,6 @@ describe('DecisionFormContainer', () => {
     beforeEach(() => {
       dispatch = jasmine.createSpy('dispatch')
       onShow = jasmine.createSpy('onShow')
-      spyOn(Navigation, 'setHash')
-
       props = mapDispatchToProps(dispatch, {onShow})
     })
     describe('when saving', () => {
@@ -19,22 +16,12 @@ describe('DecisionFormContainer', () => {
         onSave()
         expect(onShow).toHaveBeenCalled()
       })
-      it('navigates to the card', () => {
-        const {onSave} = props
-        onSave()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#decision-card-anchor')
-      })
     })
     describe('when canceling', () => {
       it('sets the card to show mode', () => {
         const {onCancel} = props
         onCancel()
         expect(onShow).toHaveBeenCalled()
-      })
-      it('navigates to the card', () => {
-        const {onCancel} = props
-        onCancel()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#decision-card-anchor')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/DecisionFormContainerSpec.js
@@ -3,21 +3,36 @@ import * as Navigation from 'utils/navigation'
 
 describe('DecisionFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    let dispatch
+    let onShow
+    let props
     beforeEach(() => {
+      dispatch = jasmine.createSpy('dispatch')
+      onShow = jasmine.createSpy('onShow')
       spyOn(Navigation, 'setHash')
+
+      props = mapDispatchToProps(dispatch, {onShow})
     })
     describe('when saving', () => {
+      it('sets the card to show mode', () => {
+        const {onSave} = props
+        onSave()
+        expect(onShow).toHaveBeenCalled()
+      })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onSave} = mapDispatchToProps(dispatch)
+        const {onSave} = props
         onSave()
         expect(Navigation.setHash).toHaveBeenCalledWith('#decision-card-anchor')
       })
     })
     describe('when canceling', () => {
+      it('sets the card to show mode', () => {
+        const {onCancel} = props
+        onCancel()
+        expect(onShow).toHaveBeenCalled()
+      })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onCancel} = mapDispatchToProps(dispatch)
+        const {onCancel} = props
         onCancel()
         expect(Navigation.setHash).toHaveBeenCalledWith('#decision-card-anchor')
       })

--- a/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
@@ -3,21 +3,36 @@ import * as Navigation from 'utils/navigation'
 
 describe('IncidentInformationFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    let dispatch
+    let onShow
+    let props
     beforeEach(() => {
+      dispatch = jasmine.createSpy('dispatch')
+      onShow = jasmine.createSpy('onShow')
       spyOn(Navigation, 'setHash')
+
+      props = mapDispatchToProps(dispatch, {onShow})
     })
     describe('when saving', () => {
+      it('sets the card to show mode', () => {
+        const {onSave} = props
+        onSave()
+        expect(onShow).toHaveBeenCalled()
+      })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onSave} = mapDispatchToProps(dispatch)
+        const {onSave} = props
         onSave()
         expect(Navigation.setHash).toHaveBeenCalledWith('#incident-information-card-anchor')
       })
     })
     describe('when canceling', () => {
+      it('sets the card to show mode', () => {
+        const {onCancel} = props
+        onCancel()
+        expect(onShow).toHaveBeenCalled()
+      })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onCancel} = mapDispatchToProps(dispatch)
+        const {onCancel} = props
         onCancel()
         expect(Navigation.setHash).toHaveBeenCalledWith('#incident-information-card-anchor')
       })

--- a/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/IncidentInformationFormContainerSpec.js
@@ -1,5 +1,4 @@
 import {mapDispatchToProps} from 'containers/screenings/IncidentInformationFormContainer'
-import * as Navigation from 'utils/navigation'
 
 describe('IncidentInformationFormContainer', () => {
   describe('mapDispatchToProps', () => {
@@ -9,8 +8,6 @@ describe('IncidentInformationFormContainer', () => {
     beforeEach(() => {
       dispatch = jasmine.createSpy('dispatch')
       onShow = jasmine.createSpy('onShow')
-      spyOn(Navigation, 'setHash')
-
       props = mapDispatchToProps(dispatch, {onShow})
     })
     describe('when saving', () => {
@@ -19,22 +16,12 @@ describe('IncidentInformationFormContainer', () => {
         onSave()
         expect(onShow).toHaveBeenCalled()
       })
-      it('navigates to the card', () => {
-        const {onSave} = props
-        onSave()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#incident-information-card-anchor')
-      })
     })
     describe('when canceling', () => {
       it('sets the card to show mode', () => {
         const {onCancel} = props
         onCancel()
         expect(onShow).toHaveBeenCalled()
-      })
-      it('navigates to the card', () => {
-        const {onCancel} = props
-        onCancel()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#incident-information-card-anchor')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
@@ -3,21 +3,36 @@ import * as Navigation from 'utils/navigation'
 
 describe('NarrativeFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    let dispatch
+    let onShow
+    let props
     beforeEach(() => {
+      dispatch = jasmine.createSpy('dispatch')
+      onShow = jasmine.createSpy('onShow')
       spyOn(Navigation, 'setHash')
+
+      props = mapDispatchToProps(dispatch, {onShow})
     })
     describe('when saving', () => {
+      it('sets the card to show mode', () => {
+        const {onSave} = props
+        onSave()
+        expect(onShow).toHaveBeenCalled()
+      })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onSave} = mapDispatchToProps(dispatch)
+        const {onSave} = props
         onSave()
         expect(Navigation.setHash).toHaveBeenCalledWith('#narrative-card-anchor')
       })
     })
     describe('when canceling', () => {
+      it('sets the card to show mode', () => {
+        const {onCancel} = props
+        onCancel()
+        expect(onShow).toHaveBeenCalled()
+      })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onCancel} = mapDispatchToProps(dispatch)
+        const {onCancel} = props
         onCancel()
         expect(Navigation.setHash).toHaveBeenCalledWith('#narrative-card-anchor')
       })

--- a/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/NarrativeFormContainerSpec.js
@@ -1,5 +1,4 @@
 import {mapDispatchToProps} from 'containers/screenings/NarrativeFormContainer'
-import * as Navigation from 'utils/navigation'
 
 describe('NarrativeFormContainer', () => {
   describe('mapDispatchToProps', () => {
@@ -9,8 +8,6 @@ describe('NarrativeFormContainer', () => {
     beforeEach(() => {
       dispatch = jasmine.createSpy('dispatch')
       onShow = jasmine.createSpy('onShow')
-      spyOn(Navigation, 'setHash')
-
       props = mapDispatchToProps(dispatch, {onShow})
     })
     describe('when saving', () => {
@@ -19,22 +16,12 @@ describe('NarrativeFormContainer', () => {
         onSave()
         expect(onShow).toHaveBeenCalled()
       })
-      it('navigates to the card', () => {
-        const {onSave} = props
-        onSave()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#narrative-card-anchor')
-      })
     })
     describe('when canceling', () => {
       it('sets the card to show mode', () => {
         const {onCancel} = props
         onCancel()
         expect(onShow).toHaveBeenCalled()
-      })
-      it('navigates to the card', () => {
-        const {onCancel} = props
-        onCancel()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#narrative-card-anchor')
       })
     })
   })

--- a/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
@@ -6,15 +6,11 @@ import {
   mapDispatchToProps,
   mergeProps,
 } from 'containers/screenings/ScreeningInformationFormContainer'
-import * as Navigation from 'utils/navigation'
 
 describe('ScreeningInformationFormContainer', () => {
   describe('mapDispatchToProps', () => {
     describe('when canceling', () => {
-      beforeEach(() => {
-        spyOn(Navigation, 'setHash')
-      })
-      it('sets card to show mode and navigates to the card', () => {
+      it('sets card to show mode', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const onShow = jasmine.createSpy('onShow')
         const {onCancel} = mapDispatchToProps(dispatch, {onShow})
@@ -22,7 +18,6 @@ describe('ScreeningInformationFormContainer', () => {
         onCancel()
 
         expect(onShow).toHaveBeenCalled()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#screening-information-card-anchor')
       })
     })
   })
@@ -48,9 +43,6 @@ describe('ScreeningInformationFormContainer', () => {
     })
 
     describe('when saving', () => {
-      beforeEach(() => {
-        spyOn(Navigation, 'setHash')
-      })
       it('saves the card, touches the fields, and sets card to show mode', () => {
         const dispatch = jasmine.createSpy('dispatch')
         const onShow = jasmine.createSpy('onShow')
@@ -63,8 +55,6 @@ describe('ScreeningInformationFormContainer', () => {
 
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
         expect(onShow).toHaveBeenCalled()
-
-        expect(Navigation.setHash).toHaveBeenCalledWith('#screening-information-card-anchor')
       })
 
       it('triggers SSB when report type changes to SSB', () => {
@@ -79,7 +69,6 @@ describe('ScreeningInformationFormContainer', () => {
 
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
         expect(onShow).toHaveBeenCalled()
-        expect(Navigation.setHash).toHaveBeenCalledWith('#screening-information-card-anchor')
       })
 
       it('does not trigger SSB when report type was already SSB', () => {

--- a/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/ScreeningInformationFormContainerSpec.js
@@ -1,7 +1,6 @@
 import {generateBabyDoe} from 'actions/safelySurrenderedBabyActions'
 import {saveCard} from 'actions/screeningActions'
 import {touchAllFields} from 'actions/screeningInformationFormActions'
-import {setCardMode, SHOW_MODE} from 'actions/screeningPageActions'
 import {
   cardName,
   mapDispatchToProps,
@@ -15,12 +14,14 @@ describe('ScreeningInformationFormContainer', () => {
       beforeEach(() => {
         spyOn(Navigation, 'setHash')
       })
-      it('navigates to the card', () => {
+      it('sets card to show mode and navigates to the card', () => {
         const dispatch = jasmine.createSpy('dispatch')
-        const {onCancel} = mapDispatchToProps(dispatch)
+        const onShow = jasmine.createSpy('onShow')
+        const {onCancel} = mapDispatchToProps(dispatch, {onShow})
 
         onCancel()
 
+        expect(onShow).toHaveBeenCalled()
         expect(Navigation.setHash).toHaveBeenCalledWith('#screening-information-card-anchor')
       })
     })
@@ -50,9 +51,10 @@ describe('ScreeningInformationFormContainer', () => {
       beforeEach(() => {
         spyOn(Navigation, 'setHash')
       })
-      it('saves the card, touches the fields, sets show mode, and navigates to the card', () => {
+      it('saves the card, touches the fields, and sets card to show mode', () => {
         const dispatch = jasmine.createSpy('dispatch')
-        const onSave = mergeProps({screeningId: '3'}, {dispatch}, {}).onSave
+        const onShow = jasmine.createSpy('onShow')
+        const onSave = mergeProps({screeningId: '3'}, {dispatch}, {onShow}).onSave
 
         onSave()
 
@@ -60,14 +62,15 @@ describe('ScreeningInformationFormContainer', () => {
         expect(dispatch).not.toHaveBeenCalledWith(generateBabyDoe('3'))
 
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
-        expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
+        expect(onShow).toHaveBeenCalled()
 
         expect(Navigation.setHash).toHaveBeenCalledWith('#screening-information-card-anchor')
       })
 
       it('triggers SSB when report type changes to SSB', () => {
         const dispatch = jasmine.createSpy('dispatch')
-        const onSave = mergeProps({persistedReportType: '', screeningId: '3', reportType: 'ssb'}, {dispatch}, {}).onSave
+        const onShow = jasmine.createSpy('onShow')
+        const onSave = mergeProps({persistedReportType: '', screeningId: '3', reportType: 'ssb'}, {dispatch}, {onShow}).onSave
 
         onSave()
 
@@ -75,13 +78,14 @@ describe('ScreeningInformationFormContainer', () => {
         expect(dispatch).toHaveBeenCalledWith(generateBabyDoe('3'))
 
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
-        expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
+        expect(onShow).toHaveBeenCalled()
         expect(Navigation.setHash).toHaveBeenCalledWith('#screening-information-card-anchor')
       })
 
       it('does not trigger SSB when report type was already SSB', () => {
         const dispatch = jasmine.createSpy('dispatch')
-        const onSave = mergeProps({persistedReportType: 'ssb', screeningId: '3', reportType: 'ssb'}, {dispatch}, {}).onSave
+        const onShow = jasmine.createSpy('onShow')
+        const onSave = mergeProps({persistedReportType: 'ssb', screeningId: '3', reportType: 'ssb'}, {dispatch}, {onShow}).onSave
 
         onSave()
 
@@ -89,7 +93,7 @@ describe('ScreeningInformationFormContainer', () => {
         expect(dispatch).not.toHaveBeenCalledWith(generateBabyDoe('3'))
 
         expect(dispatch).toHaveBeenCalledWith(touchAllFields())
-        expect(dispatch).toHaveBeenCalledWith(setCardMode(cardName, SHOW_MODE))
+        expect(onShow).toHaveBeenCalled()
       })
     })
   })

--- a/spec/javascripts/containers/screenings/WorkerSafetyFormContainerSpec.js
+++ b/spec/javascripts/containers/screenings/WorkerSafetyFormContainerSpec.js
@@ -3,27 +3,36 @@ import * as Navigation from 'utils/navigation'
 
 describe('WorkerSafetyFormContainer', () => {
   describe('mapDispatchToProps', () => {
+    let dispatch
+    let onShow
+    let props
     beforeEach(() => {
+      dispatch = jasmine.createSpy('dispatch')
+      onShow = jasmine.createSpy('onShow')
       spyOn(Navigation, 'setHash')
+
+      props = mapDispatchToProps(dispatch, {onShow})
     })
     describe('when saving', () => {
+      it('sets the card to show mode', () => {
+        const {onSave} = props
+        onSave()
+        expect(onShow).toHaveBeenCalled()
+      })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onSave} = mapDispatchToProps(dispatch)
+        const {onSave} = props
         onSave()
         expect(Navigation.setHash).toHaveBeenCalledWith('#worker-safety-card-anchor')
       })
     })
     describe('when canceling', () => {
-      beforeEach(() => {
-        window.location.hash = ''
-      })
-      afterEach(() => {
-        window.location.hash = ''
+      it('sets the card to show mode', () => {
+        const {onCancel} = props
+        onCancel()
+        expect(onShow).toHaveBeenCalled()
       })
       it('navigates to the card', () => {
-        const dispatch = jasmine.createSpy('dispatch')
-        const {onCancel} = mapDispatchToProps(dispatch)
+        const {onCancel} = props
         onCancel()
         expect(Navigation.setHash).toHaveBeenCalledWith('#worker-safety-card-anchor')
       })

--- a/spec/javascripts/views/CardViewSpec.jsx
+++ b/spec/javascripts/views/CardViewSpec.jsx
@@ -68,6 +68,14 @@ describe('Card View', () => {
       expect(card.text()).toContain('Edit')
       expect(card.text()).not.toContain('Show')
     })
+
+    it('passes the onShow prop to the edit prop child', () => {
+      const edit = <span className='my-edit'>Edit</span>
+      const onShow = jasmine.createSpy('onShow')
+      const card = renderCardView({edit, mode, onShow})
+
+      expect(card.find('.my-edit').props().onShow).toEqual(onShow)
+    })
   })
 
   describe('when mode is show', () => {

--- a/spec/javascripts/views/CrossReportFormSpec.jsx
+++ b/spec/javascripts/views/CrossReportFormSpec.jsx
@@ -1,8 +1,6 @@
 import CrossReportForm from 'views/CrossReportForm'
 import React from 'react'
 import {shallow} from 'enzyme'
-import {SHOW_MODE} from 'actions/screeningPageActions'
-import * as Navigation from 'utils/navigation'
 
 describe('CrossReportForm', () => {
   function renderCrossReportForm({
@@ -64,7 +62,7 @@ describe('CrossReportForm', () => {
     hasAgencies = false,
     screening = {},
     screeningWithEdits = {},
-    toggleShow = () => null,
+    onShow = () => null,
   }) {
     const props = {
       actions,
@@ -85,7 +83,7 @@ describe('CrossReportForm', () => {
       hasAgencies,
       screening,
       screeningWithEdits,
-      toggleShow,
+      onShow,
     }
     return shallow(<CrossReportForm {...props} />, {disableLifecycleMethods: true})
   }
@@ -347,34 +345,30 @@ describe('CrossReportForm', () => {
     expect(cancelButton.text()).toContain('Cancel')
   })
   describe('clicking on cancel', () => {
-    it('fires setCardMode, clearCardEdits', () => {
-      spyOn(Navigation, 'setHash')
+    it('calls onShow, fires clearCardEdits', () => {
       const clearCardEdits = jasmine.createSpy('clearCardEdits')
-      const setCardMode = jasmine.createSpy('setCardMode')
+      const onShow = jasmine.createSpy('onShow')
       const cardName = 'cross-report-card'
-      const component = renderCrossReportForm({actions: {clearCardEdits, setCardMode}, cardName})
+      const component = renderCrossReportForm({actions: {clearCardEdits}, cardName, onShow})
       component.find('.btn.btn-default').simulate('click')
-      expect(setCardMode).toHaveBeenCalledWith(cardName, SHOW_MODE)
+      expect(onShow).toHaveBeenCalled()
       expect(clearCardEdits).toHaveBeenCalledWith(cardName)
-      expect(Navigation.setHash).toHaveBeenCalledWith('#cross-report-card-anchor')
     })
   })
   describe('clicking on save', () => {
-    it('fires toggleShow, saveCard', () => {
-      spyOn(Navigation, 'setHash')
+    it('calls onShow, fires saveCard', () => {
       const saveCard = jasmine.createSpy('saveCard')
       const touchAllFields = jasmine.createSpy('touchAllFields')
       const saveCrossReport = jasmine.createSpy('saveCrossReport')
-      const setCardMode = jasmine.createSpy('setCardMode')
+      const onShow = jasmine.createSpy('onShow')
       const screeningWithEdits = {id: 123, crossReports: []}
       const cardName = 'cross-report-card'
-      const component = renderCrossReportForm({actions: {saveCard, saveCrossReport, touchAllFields, setCardMode}, screeningWithEdits, cardName})
+      const component = renderCrossReportForm({actions: {saveCard, saveCrossReport, touchAllFields}, screeningWithEdits, cardName, onShow})
       component.find('button.btn-primary').simulate('click')
       expect(saveCard).toHaveBeenCalledWith(cardName)
       expect(saveCrossReport).toHaveBeenCalledWith(screeningWithEdits)
       expect(touchAllFields).toHaveBeenCalled()
-      expect(setCardMode).toHaveBeenCalledWith(cardName, SHOW_MODE)
-      expect(Navigation.setHash).toHaveBeenCalledWith('#cross-report-card-anchor')
+      expect(onShow).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
### Jira Story

- Follow-up to [Page remains static when a card is saved HOT-2157](https://osi-cwds.atlassian.net/browse/HOT-2157)
- Sets the stage for [Display loading and saving animations HOT-1617](https://osi-cwds.atlassian.net/browse/HOT-1617)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This refactors our CardContainers a little bit, so that the common CardContainer component can handle shared 'mode' behavior (switching from Edit to Show and navigating to the card hash). I wanted to get to this as part of HOT-2157, but ran out of time. However, it's really helpful to have this in place as I start in on HOT-1617 work on loading spinners.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

