### PR TITLE
HOT-1617 Card action rows and (unused) saving buttons

### DIFF
--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -223,3 +223,17 @@ input.rw-input {
 .text-area-show {
   word-wrap: break-word;
 }
+
+.loading-indicator {
+  font-size: 1.8rem;
+  line-height: 1.4rem;
+  vertical-align: top;
+}
+
+.btn.btn-icon {
+  padding-left: 1.5rem;
+
+  .fa {
+    margin-right: 1.5rem;
+  }
+}

--- a/app/assets/stylesheets/form.scss
+++ b/app/assets/stylesheets/form.scss
@@ -1,4 +1,5 @@
 @import 'constants';
+@import 'icon/animated';
 /////////////////////////////////////////
 
 // - Forms - //
@@ -222,5 +223,3 @@ input.rw-input {
 .text-area-show {
   word-wrap: break-word;
 }
-
-

--- a/app/assets/stylesheets/icon/_animated.scss
+++ b/app/assets/stylesheets/icon/_animated.scss
@@ -1,36 +1,6 @@
 // Spinning Icons
 // --------------------------
-
-.#{$fa-css-prefix}-spin {
-  -webkit-animation: fa-spin 2s infinite linear;
-  animation: fa-spin 2s infinite linear;
-}
-
-.#{$fa-css-prefix}-pulse {
-  -webkit-animation: fa-spin 1s infinite steps(8);
-  animation: fa-spin 1s infinite steps(8);
-}
-
-@-webkit-keyframes fa-spin {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(359deg);
-    transform: rotate(359deg);
-  }
-}
-
-@keyframes fa-spin {
-  0% {
-    -webkit-transform: rotate(0deg);
-    transform: rotate(0deg);
-  }
-
-  100% {
-    -webkit-transform: rotate(359deg);
-    transform: rotate(359deg);
-  }
+.fa-spin-faster {
+  -webkit-animation: fa-spin 1s infinite linear;
+  animation: fa-spin 1s infinite linear;
 }

--- a/app/javascript/common/LoadingButton.jsx
+++ b/app/javascript/common/LoadingButton.jsx
@@ -1,0 +1,16 @@
+import LoadingIndicator from 'common/LoadingIndicator'
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const LoadingButton = ({text = ''}) => (
+  <button className='btn btn-primary btn-icon' disabled={true}>
+    <LoadingIndicator />
+    {text}
+  </button>
+)
+
+LoadingButton.propTypes = {
+  text: PropTypes.string,
+}
+
+export default LoadingButton

--- a/app/javascript/common/LoadingIndicator.jsx
+++ b/app/javascript/common/LoadingIndicator.jsx
@@ -1,5 +1,7 @@
 import React from 'react'
 
-const LoadingIndicator = () => (<i className='fa fa-spinner fa-spin-faster' />)
+const LoadingIndicator = () => (
+  <i className='loading-indicator fa fa-spinner fa-spin-faster' />
+)
 
 export default LoadingIndicator

--- a/app/javascript/common/LoadingIndicator.jsx
+++ b/app/javascript/common/LoadingIndicator.jsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const LoadingIndicator = () => (<i className='fa fa-spinner fa-spin-faster' />)
+
+export default LoadingIndicator

--- a/app/javascript/screenings/CardActionRow.jsx
+++ b/app/javascript/screenings/CardActionRow.jsx
@@ -1,18 +1,23 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import LoadingButton from 'common/LoadingButton'
 
-const CardActionRow = ({onCancel, onSave}) => (
+const CardActionRow = ({isLoading, onCancel, onSave}) => (
   <div className='row'>
     <div className='col-md-12'>
       <div className='pull-right'>
-        <button className='btn btn-default' onClick={onCancel}>Cancel</button>
-        <button className='btn btn-primary' onClick={onSave}>Save</button>
+        {!isLoading &&
+          <button className='btn btn-default' onClick={onCancel}>Cancel</button>}
+        {isLoading ?
+          <LoadingButton text='Saving'/> :
+          <button className='btn btn-primary' onClick={onSave}>Save</button>}
       </div>
     </div>
   </div>
 )
 
 CardActionRow.propTypes = {
+  isLoading: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onSave: PropTypes.func.isRequired,
 }

--- a/app/javascript/screenings/CardActionRow.jsx
+++ b/app/javascript/screenings/CardActionRow.jsx
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+
+const CardActionRow = ({onCancel, onSave}) => (
+  <div className='row'>
+    <div className='col-md-12'>
+      <div className='pull-right'>
+        <button className='btn btn-default' onClick={onCancel}>Cancel</button>
+        <button className='btn btn-primary' onClick={onSave}>Save</button>
+      </div>
+    </div>
+  </div>
+)
+
+CardActionRow.propTypes = {
+  onCancel: PropTypes.func.isRequired,
+  onSave: PropTypes.func.isRequired,
+}
+
+export default CardActionRow

--- a/app/javascript/views/AllegationsForm.jsx
+++ b/app/javascript/views/AllegationsForm.jsx
@@ -2,6 +2,7 @@ import AlertErrorMessage from 'common/AlertErrorMessage'
 import React from 'react'
 import PropTypes from 'prop-types'
 import Select from 'react-select'
+import CardActionRow from 'screenings/CardActionRow'
 
 const AllegationsForm = ({
   alertErrorMessage,
@@ -55,14 +56,7 @@ const AllegationsForm = ({
         </table>
       </div>
     </div>
-    <div className='row'>
-      <div className='col-md-12'>
-        <div className='pull-right'>
-          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
-          <button className='btn btn-primary' onClick={onSave}>Save</button>
-        </div>
-      </div>
-    </div>
+    <CardActionRow onCancel={onCancel} onSave={onSave} />
   </div>
 )
 

--- a/app/javascript/views/CrossReportForm.jsx
+++ b/app/javascript/views/CrossReportForm.jsx
@@ -14,6 +14,7 @@ import {
   DISTRICT_ATTORNEY,
   LAW_ENFORCEMENT,
 } from 'enums/CrossReport'
+import CardActionRow from 'screenings/CardActionRow'
 
 const CrossReportForm = ({
   allegationsRequireCrossReports,
@@ -183,14 +184,7 @@ const CrossReportForm = ({
           </fieldset>
         }
       </div>
-      <div className='row'>
-        <div className='col-md-12'>
-          <div className='pull-right'>
-            <button className='btn btn-default' onClick={cancel}>Cancel</button>
-            <button className='btn btn-primary' onClick={save}>Save</button>
-          </div>
-        </div>
-      </div>
+      <CardActionRow onCancel={cancel} onSave={save} />
     </div>
   )
 }

--- a/app/javascript/views/IncidentInformationForm.jsx
+++ b/app/javascript/views/IncidentInformationForm.jsx
@@ -4,6 +4,7 @@ import DateField from 'common/DateField'
 import InputField from 'common/InputField'
 import SelectField from 'common/SelectField'
 import TextAreaCount from 'common/TextAreaCount'
+import CardActionRow from 'screenings/CardActionRow'
 
 const IncidentInformationForm = ({incidentDate, errors, onChange, onBlur, address, usStates, selectedCounty, counties,
   selectedLocationType, locationTypes, locationOfChildren, onSave, onCancel}) => (
@@ -110,14 +111,7 @@ const IncidentInformationForm = ({incidentDate, errors, onChange, onBlur, addres
         />
       </div>
     </div>
-    <div className='row'>
-      <div className='col-md-12'>
-        <div className='pull-right'>
-          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
-          <button className='btn btn-primary' onClick={onSave}>Save</button>
-        </div>
-      </div>
-    </div>
+    <CardActionRow onCancel={onCancel} onSave={onSave} />
   </div>
 )
 

--- a/app/javascript/views/NarrativeForm.jsx
+++ b/app/javascript/views/NarrativeForm.jsx
@@ -1,6 +1,7 @@
 import FormField from 'common/FormField'
 import PropTypes from 'prop-types'
 import React from 'react'
+import CardActionRow from 'screenings/CardActionRow'
 
 const NarrativeForm = ({
   onBlur,
@@ -27,14 +28,7 @@ const NarrativeForm = ({
         />
       </FormField>
     </div>
-    <div className='row'>
-      <div className='col-md-12'>
-        <div className='pull-right'>
-          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
-          <button className='btn btn-primary' onClick={onSave}>Save</button>
-        </div>
-      </div>
-    </div>
+    <CardActionRow onCancel={onCancel} onSave={onSave} />
   </div>
 )
 

--- a/app/javascript/views/ScreeningDecisionForm.jsx
+++ b/app/javascript/views/ScreeningDecisionForm.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types'
 import SelectField from 'common/SelectField'
 import InputField from 'common/InputField'
 import FormField from 'common/FormField'
+import CardActionRow from 'screenings/CardActionRow'
 
 const ScreeningDecisionForm = ({
   accessRestriction,
@@ -134,14 +135,7 @@ const ScreeningDecisionForm = ({
         <a href={sdmPath} target='_blank' id='complete_sdm'>Complete SDM</a>
       </div>
     </div>
-    <div className='row'>
-      <div className='col-md-12'>
-        <div className='pull-right'>
-          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
-          <button className='btn btn-primary' onClick={onSave}>Save</button>
-        </div>
-      </div>
-    </div>
+    <CardActionRow onCancel={onCancel} onSave={onSave} />
   </div>
 )
 

--- a/app/javascript/views/ScreeningInformationForm.jsx
+++ b/app/javascript/views/ScreeningInformationForm.jsx
@@ -4,7 +4,8 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import SelectField from 'common/SelectField'
 import AlertInfoMessage from 'common/AlertInfoMessage'
-import {SafelySurrenderedBabyMessage} from './ScreeningInformationHelpTextBox'
+import {SafelySurrenderedBabyMessage} from 'views/ScreeningInformationHelpTextBox'
+import CardActionRow from 'screenings/CardActionRow'
 
 const ScreeningInformationForm = ({
   assignee,
@@ -96,14 +97,7 @@ const ScreeningInformationForm = ({
         {communicationMethods.map(({value, label}) => <option key={value} value={value}>{label}</option>)}
       </SelectField>
     </div>
-    <div className='row'>
-      <div className='col-md-12'>
-        <div className='pull-right'>
-          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
-          <button className='btn btn-primary' onClick={onSave}>Save</button>
-        </div>
-      </div>
-    </div>
+    <CardActionRow onCancel={onCancel} onSave={onSave} />
   </div>
 )
 ScreeningInformationForm.propTypes = {

--- a/app/javascript/views/WorkerSafetyForm.jsx
+++ b/app/javascript/views/WorkerSafetyForm.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import Select from 'react-select'
+import CardActionRow from 'screenings/CardActionRow'
 
 const WorkerSafetyForm = ({
   alertOptions,
@@ -37,14 +38,7 @@ const WorkerSafetyForm = ({
         />
       </div>
     </div>
-    <div className='row'>
-      <div className='col-md-12'>
-        <div className='pull-right'>
-          <button className='btn btn-default' onClick={onCancel}>Cancel</button>
-          <button className='btn btn-primary' onClick={onSave}>Save</button>
-        </div>
-      </div>
-    </div>
+    <CardActionRow onCancel={onCancel} onSave={onSave} />
   </div>
 )
 

--- a/app/javascript/views/people/PersonCard.jsx
+++ b/app/javascript/views/people/PersonCard.jsx
@@ -1,6 +1,7 @@
 import PersonCardHeader from 'views/people/PersonCardHeader'
 import PropTypes from 'prop-types'
 import React from 'react'
+import CardActionRow from 'screenings/CardActionRow'
 
 const PersonCard = ({
   deletable,
@@ -30,16 +31,7 @@ const PersonCard = ({
     <div className='card-body'>
       {mode === 'show' && show}
       {mode === 'edit' && edit}
-      {mode === 'edit' &&
-        <div className='row'>
-          <div className='col-md-12'>
-            <div className='pull-right'>
-              <button className='btn btn-default' onClick={onCancel}>Cancel</button>
-              <button className='btn btn-primary' onClick={onSave}>Save</button>
-            </div>
-          </div>
-        </div>
-      }
+      {mode === 'edit' && <CardActionRow onCancel={onCancel} onSave={onSave} />}
     </div>
   </div>
 )

--- a/spec/javascripts/common/LoadingButtonSpec.jsx
+++ b/spec/javascripts/common/LoadingButtonSpec.jsx
@@ -1,0 +1,27 @@
+import LoadingButton from 'common/LoadingButton'
+import React from 'react'
+import {shallow} from 'enzyme'
+
+describe('LoadingButton', () => {
+  const render = (props) => shallow(<LoadingButton {...props}/>)
+
+  it('is a button', () => {
+    expect(render().find('button').exists()).toEqual(true)
+  })
+
+  it('is disabled', () => {
+    expect(render().find('button').props().disabled).toEqual(true)
+  })
+
+  it('has an btn-icon class', () => {
+    expect(render().find('.btn-icon').exists()).toEqual(true)
+  })
+
+  it('renders a Loading Indicator', () => {
+    expect(render().find('button LoadingIndicator').exists()).toEqual(true)
+  })
+
+  it('renders the given text', () => {
+    expect(render({text: 'Hello, world!'}).text()).toContain('Hello, world!')
+  })
+})

--- a/spec/javascripts/common/LoadingIndicatorSpec.jsx
+++ b/spec/javascripts/common/LoadingIndicatorSpec.jsx
@@ -1,0 +1,15 @@
+import {shallow} from 'enzyme'
+import LoadingIndicator from 'common/LoadingIndicator'
+import React from 'react'
+
+describe('LoadingIndicator', () => {
+  it('renders a loading icon', () => {
+    const root = shallow(<LoadingIndicator />)
+    expect(root.find('.fa.fa-spinner').exists()).toEqual(true)
+  })
+
+  it('spins faster', () => {
+    const root = shallow(<LoadingIndicator />)
+    expect(root.find('.fa-spin-faster').exists()).toEqual(true)
+  })
+})

--- a/spec/javascripts/components/screenings/CardActionRowSpec.jsx
+++ b/spec/javascripts/components/screenings/CardActionRowSpec.jsx
@@ -7,31 +7,53 @@ describe('CardActionRow', () => {
     shallow(<CardActionRow onCancel={onCancel} onSave={onSave} {...props} />)
   )
 
-  it('renders a full row with cancel and save buttons pulled right', () => {
-    const component = render()
+  describe('default', () => {
+    it('renders a full row with cancel and save buttons pulled right', () => {
+      const component = render()
 
-    const row = component.find('.row .col-md-12 .pull-right')
-    expect(row.exists()).toEqual(true)
+      const row = component.find('.row .col-md-12 .pull-right')
+      expect(row.exists()).toEqual(true)
 
-    expect(row.find('button').at(0).text()).toEqual('Cancel')
-    expect(row.find('button').at(1).text()).toEqual('Save')
+      expect(row.find('button').at(0).text()).toEqual('Cancel')
+      expect(row.find('button').at(1).text()).toEqual('Save')
+    })
+
+    it('calls onCancel when cancel button is clicked', () => {
+      const onCancel = jasmine.createSpy('onCancel')
+      const component = render({onCancel})
+      const cancelButton = component.find('.btn-default')
+
+      cancelButton.simulate('click')
+      expect(onCancel).toHaveBeenCalled()
+    })
+
+    it('calls onSave when save button is clicked', () => {
+      const onSave = jasmine.createSpy('onSave')
+      const component = render({onSave})
+      const saveButton = component.find('.btn-primary')
+
+      saveButton.simulate('click')
+      expect(onSave).toHaveBeenCalled()
+    })
   })
 
-  it('calls onCancel when cancel button is clicked', () => {
-    const onCancel = jasmine.createSpy('onCancel')
-    const component = render({onCancel})
-    const cancelButton = component.find('.btn-default')
+  describe('when isLoading', () => {
+    it('renders a row with a Saving button and no Cancel button', () => {
+      const component = render({isLoading: true})
 
-    cancelButton.simulate('click')
-    expect(onCancel).toHaveBeenCalled()
-  })
+      const row = component.find('.row .col-md-12 .pull-right')
+      expect(row.exists()).toEqual(true)
+      expect(row.find('LoadingButton').exists()).toEqual(true)
+      expect(row.find('LoadingButton').props().text).toEqual('Saving')
+      expect(row.find('button').length).toEqual(0)
+    })
 
-  it('calls onSave when save button is clicked', () => {
-    const onSave = jasmine.createSpy('onSave')
-    const component = render({onSave})
-    const saveButton = component.find('.btn-primary')
+    it('does not call onSave again when saving button is clicked', () => {
+      const onSave = jasmine.createSpy('onSave')
+      const component = render({onSave, isLoading: true})
+      const saveButton = component.find('LoadingButton')
 
-    saveButton.simulate('click')
-    expect(onSave).toHaveBeenCalled()
+      expect(saveButton.props().onClick).not.toBeDefined()
+    })
   })
 })

--- a/spec/javascripts/components/screenings/CardActionRowSpec.jsx
+++ b/spec/javascripts/components/screenings/CardActionRowSpec.jsx
@@ -1,0 +1,37 @@
+import CardActionRow from 'screenings/CardActionRow'
+import React from 'react'
+import {shallow} from 'enzyme'
+
+describe('CardActionRow', () => {
+  const render = ({onCancel = () => {}, onSave = () => {}, ...props} = {}) => (
+    shallow(<CardActionRow onCancel={onCancel} onSave={onSave} {...props} />)
+  )
+
+  it('renders a full row with cancel and save buttons pulled right', () => {
+    const component = render()
+
+    const row = component.find('.row .col-md-12 .pull-right')
+    expect(row.exists()).toEqual(true)
+
+    expect(row.find('button').at(0).text()).toEqual('Cancel')
+    expect(row.find('button').at(1).text()).toEqual('Save')
+  })
+
+  it('calls onCancel when cancel button is clicked', () => {
+    const onCancel = jasmine.createSpy('onCancel')
+    const component = render({onCancel})
+    const cancelButton = component.find('.btn-default')
+
+    cancelButton.simulate('click')
+    expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('calls onSave when save button is clicked', () => {
+    const onSave = jasmine.createSpy('onSave')
+    const component = render({onSave})
+    const saveButton = component.find('.btn-primary')
+
+    saveButton.simulate('click')
+    expect(onSave).toHaveBeenCalled()
+  })
+})

--- a/spec/javascripts/views/AllegationsFormSpec.jsx
+++ b/spec/javascripts/views/AllegationsFormSpec.jsx
@@ -3,23 +3,28 @@ import {shallow} from 'enzyme'
 import AllegationsForm from 'views/AllegationsForm'
 
 describe('AllegationsForm', () => {
-  const renderAllegationsForm = ({allegations = [], ...args}) => {
-    const props = {allegations, ...args}
+  const renderAllegationsForm = ({allegations = [], onCancel = () => {}, onSave = () => {}, ...args}) => {
+    const props = {allegations, onCancel, onSave, ...args}
     return shallow(<AllegationsForm {...props}/>, {disableLifecycleMethods: true})
   }
 
-  it('calls onSave when the save button is clicked', () => {
-    const onSave = jasmine.createSpy('onSave')
-    const component = renderAllegationsForm({onSave})
-    component.find('.btn-primary').simulate('click')
-    expect(onSave).toHaveBeenCalled()
+  it('renders a card action row', () => {
+    const component = renderAllegationsForm({})
+    expect(component.find('CardActionRow').exists()).toEqual(true)
   })
 
-  it('calls onCancel when the cancel button is clicked', () => {
+  it('canceling edit calls onCancel', () => {
     const onCancel = jasmine.createSpy('onCancel')
     const component = renderAllegationsForm({onCancel})
-    component.find('.btn-default').simulate('click')
+    component.find('CardActionRow').props().onCancel()
     expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('saving changes calls onSave', () => {
+    const onSave = jasmine.createSpy('onSave')
+    const component = renderAllegationsForm({onSave})
+    component.find('CardActionRow').props().onSave()
+    expect(onSave).toHaveBeenCalled()
   })
 
   it('displays an alert error message if one is passed', () => {

--- a/spec/javascripts/views/CrossReportFormSpec.jsx
+++ b/spec/javascripts/views/CrossReportFormSpec.jsx
@@ -337,12 +337,9 @@ describe('CrossReportForm', () => {
       expect(component.find('AlertInfoMessage').exists()).toEqual(false)
     })
   })
-  it('displays the save and cancel button', () => {
+  it('renders a card action row', () => {
     const component = renderCrossReportForm({})
-    const saveButton = component.find('button.btn-primary')
-    expect(saveButton.text()).toContain('Save')
-    const cancelButton = component.find('button.btn-default')
-    expect(cancelButton.text()).toContain('Cancel')
+    expect(component.find('CardActionRow').exists()).toEqual(true)
   })
   describe('clicking on cancel', () => {
     it('calls onShow, fires clearCardEdits', () => {
@@ -350,7 +347,9 @@ describe('CrossReportForm', () => {
       const onShow = jasmine.createSpy('onShow')
       const cardName = 'cross-report-card'
       const component = renderCrossReportForm({actions: {clearCardEdits}, cardName, onShow})
-      component.find('.btn.btn-default').simulate('click')
+
+      component.find('CardActionRow').props().onCancel()
+
       expect(onShow).toHaveBeenCalled()
       expect(clearCardEdits).toHaveBeenCalledWith(cardName)
     })
@@ -364,7 +363,9 @@ describe('CrossReportForm', () => {
       const screeningWithEdits = {id: 123, crossReports: []}
       const cardName = 'cross-report-card'
       const component = renderCrossReportForm({actions: {saveCard, saveCrossReport, touchAllFields}, screeningWithEdits, cardName, onShow})
-      component.find('button.btn-primary').simulate('click')
+
+      component.find('CardActionRow').props().onSave()
+
       expect(saveCard).toHaveBeenCalledWith(cardName)
       expect(saveCrossReport).toHaveBeenCalledWith(screeningWithEdits)
       expect(touchAllFields).toHaveBeenCalled()

--- a/spec/javascripts/views/IncidentInformationFormSpec.jsx
+++ b/spec/javascripts/views/IncidentInformationFormSpec.jsx
@@ -3,8 +3,17 @@ import {shallow} from 'enzyme'
 import IncidentInformationForm from 'views/IncidentInformationForm'
 
 describe('IncidentInformationForm', () => {
-  const renderIncidentInformationForm = ({errors = {incident_address: {}}, address = {}, counties = [], locationTypes = [], usStates = [], ...args}) => {
-    const props = {errors, address, counties, locationTypes, usStates, ...args}
+  const renderIncidentInformationForm = ({
+    errors = {incident_address: {}},
+    address = {},
+    counties = [],
+    locationTypes = [],
+    usStates = [],
+    onCancel = () => {},
+    onSave = () => {},
+    ...args
+  }) => {
+    const props = {errors, address, counties, locationTypes, usStates, onCancel, onSave, ...args}
     return shallow(<IncidentInformationForm {...props}/>, {disableLifecycleMethods: true})
   }
 
@@ -231,17 +240,22 @@ describe('IncidentInformationForm', () => {
     })
   })
 
-  it('renders the save button', () => {
-    const onSave = jasmine.createSpy('onSave')
-    const component = renderIncidentInformationForm({onSave})
-    component.find('.btn.btn-primary').simulate('click')
-    expect(onSave).toHaveBeenCalled()
+  it('renders a card action row', () => {
+    const component = renderIncidentInformationForm({})
+    expect(component.find('CardActionRow').exists()).toEqual(true)
   })
 
-  it('renders the cancel button', () => {
+  it('canceling edit calls onCancel', () => {
     const onCancel = jasmine.createSpy('onCancel')
     const component = renderIncidentInformationForm({onCancel})
-    component.find('.btn.btn-default').simulate('click')
+    component.find('CardActionRow').props().onCancel()
     expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('saving changes calls onSave', () => {
+    const onSave = jasmine.createSpy('onSave')
+    const component = renderIncidentInformationForm({onSave})
+    component.find('CardActionRow').props().onSave()
+    expect(onSave).toHaveBeenCalled()
   })
 })

--- a/spec/javascripts/views/NarrativeFormSpec.jsx
+++ b/spec/javascripts/views/NarrativeFormSpec.jsx
@@ -3,8 +3,11 @@ import React from 'react'
 import {shallow} from 'enzyme'
 
 describe('NarrativeForm', () => {
-  const renderNarrative = ({...props}) => (
-    shallow(<NarrativeForm {...props} />, {disableLifecycleMethods: true})
+  const renderNarrative = ({onCancel = () => {}, onSave = () => {}, ...props}) => (
+    shallow(
+      <NarrativeForm onCancel={onCancel} onSave={onSave} {...props} />,
+      {disableLifecycleMethods: true}
+    )
   )
 
   it('displays the narrative text field', () => {
@@ -33,17 +36,22 @@ describe('NarrativeForm', () => {
     expect(onBlur).toHaveBeenCalledWith('report_narrative')
   })
 
+  it('renders a card action row', () => {
+    const component = renderNarrative({})
+    expect(component.find('CardActionRow').exists()).toEqual(true)
+  })
+
   it('canceling edit calls onCancel', () => {
     const onCancel = jasmine.createSpy('onCancel')
     const component = renderNarrative({onCancel})
-    component.find('.btn.btn-default').simulate('click')
+    component.find('CardActionRow').props().onCancel()
     expect(onCancel).toHaveBeenCalled()
   })
 
   it('saving changes calls onSave', () => {
     const onSave = jasmine.createSpy('onSave')
     const component = renderNarrative({onSave})
-    component.find('.btn.btn-primary').simulate('click')
+    component.find('CardActionRow').props().onSave()
     expect(onSave).toHaveBeenCalled()
   })
 })

--- a/spec/javascripts/views/ScreeningDecisionFormSpec.jsx
+++ b/spec/javascripts/views/ScreeningDecisionFormSpec.jsx
@@ -13,6 +13,8 @@ describe('ScreeningDecisionForm', () => {
     decisionDetailOptions = [],
     restrictionRationale = {},
     isAdditionalInfoRequired = false,
+    onCancel = () => {},
+    onSave = () => {},
     ...options
   }) => {
     const props = {
@@ -25,6 +27,8 @@ describe('ScreeningDecisionForm', () => {
       decisionDetailOptions,
       restrictionRationale,
       isAdditionalInfoRequired,
+      onCancel,
+      onSave,
       ...options,
     }
     return shallow(<ScreeningDecisionForm {...props}/>, {disableLifecycleMethods: true})
@@ -44,33 +48,23 @@ describe('ScreeningDecisionForm', () => {
     expect(sdmLink.props().target).toEqual('_blank')
     expect(sdmLink.text()).toEqual('Complete SDM')
   })
-
-  it('renders a save button', () => {
+  it('renders a card action row', () => {
     const component = renderScreeningDecisionForm({})
-    const saveButton = component.find('button[children="Save"]')
-    expect(saveButton.exists()).toEqual(true)
+    expect(component.find('CardActionRow').exists()).toEqual(true)
   })
 
-  it('calls onSave when the save button is clicked', () => {
-    const onSave = jasmine.createSpy('onSave')
-    const component = renderScreeningDecisionForm({onSave})
-    const saveButton = component.find('button[children="Save"]')
-    saveButton.simulate('click')
-    expect(onSave).toHaveBeenCalled()
-  })
-
-  it('renders a cancel button', () => {
-    const component = renderScreeningDecisionForm({})
-    const cancelButton = component.find('button[children="Cancel"]')
-    expect(cancelButton.exists()).toEqual(true)
-  })
-
-  it('calls onCancel when the save button is clicked', () => {
+  it('canceling edit calls onCancel', () => {
     const onCancel = jasmine.createSpy('onCancel')
     const component = renderScreeningDecisionForm({onCancel})
-    const cancelButton = component.find('button[children="Cancel"]')
-    cancelButton.simulate('click')
+    component.find('CardActionRow').props().onCancel()
     expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('saving changes calls onSave', () => {
+    const onSave = jasmine.createSpy('onSave')
+    const component = renderScreeningDecisionForm({onSave})
+    component.find('CardActionRow').props().onSave()
+    expect(onSave).toHaveBeenCalled()
   })
 
   it('displays an alert error message if one is passed', () => {

--- a/spec/javascripts/views/ScreeningInformationFormSpec.jsx
+++ b/spec/javascripts/views/ScreeningInformationFormSpec.jsx
@@ -8,9 +8,11 @@ describe('ScreeningInformationForm', () => {
     errors = {},
     communicationMethods = [],
     reportTypes = [],
+    onCancel = () => {},
+    onSave = () => {},
     ...args
   }) {
-    const props = {errors, communicationMethods, reportTypes, ...args}
+    const props = {errors, communicationMethods, reportTypes, onCancel, onSave, ...args}
     return shallow(<ScreeningInformationForm {...props} />, {disableLifecycleMethods: true})
   }
 
@@ -235,23 +237,22 @@ describe('ScreeningInformationForm', () => {
     expect(selectOptions[3].props.value).toEqual('option_3')
   })
 
-  it('renders the save and cancel button', () => {
+  it('renders a card action row', () => {
     const component = renderScreeningInformationForm({})
-    expect(component.find('.btn.btn-primary').text()).toEqual('Save')
-    expect(component.find('.btn.btn-default').text()).toEqual('Cancel')
+    expect(component.find('CardActionRow').exists()).toEqual(true)
   })
 
-  it('fires the onSave function when save is clicked', () => {
-    const onSave = jasmine.createSpy('onSave')
-    renderScreeningInformationForm({onSave})
-      .find('.btn.btn-primary').simulate('click')
-    expect(onSave).toHaveBeenCalled()
-  })
-
-  it('fires the onCancel function when cancel is clicked', () => {
+  it('canceling edit calls onCancel', () => {
     const onCancel = jasmine.createSpy('onCancel')
-    renderScreeningInformationForm({onCancel})
-      .find('.btn.btn-default').simulate('click')
+    const component = renderScreeningInformationForm({onCancel})
+    component.find('CardActionRow').props().onCancel()
     expect(onCancel).toHaveBeenCalled()
+  })
+
+  it('saving changes calls onSave', () => {
+    const onSave = jasmine.createSpy('onSave')
+    const component = renderScreeningInformationForm({onSave})
+    component.find('CardActionRow').props().onSave()
+    expect(onSave).toHaveBeenCalled()
   })
 })

--- a/spec/javascripts/views/WorkerSafetyFormSpec.jsx
+++ b/spec/javascripts/views/WorkerSafetyFormSpec.jsx
@@ -5,9 +5,9 @@ import {shallow} from 'enzyme'
 describe('WorkerSafetyForm', () => {
   function renderWorkerSafety({
     alertOptions = [],
-    onCancel,
+    onCancel = () => {},
     onChange,
-    onSave,
+    onSave = () => {},
     safetyAlerts = {value: []},
     safetyInformation = {value: ''},
   }) {
@@ -58,17 +58,22 @@ describe('WorkerSafetyForm', () => {
     expect(onChange).toHaveBeenCalledWith('safety_information', 'something dangerous')
   })
 
+  it('renders a card action row', () => {
+    const component = renderWorkerSafety({})
+    expect(component.find('CardActionRow').exists()).toEqual(true)
+  })
+
   it('canceling edit calls onCancel', () => {
     const onCancel = jasmine.createSpy('onCancel')
     const component = renderWorkerSafety({onCancel})
-    component.find('.btn.btn-default').simulate('click')
+    component.find('CardActionRow').props().onCancel()
     expect(onCancel).toHaveBeenCalled()
   })
 
   it('saving changes calls onSave', () => {
     const onSave = jasmine.createSpy('onSave')
     const component = renderWorkerSafety({onSave})
-    component.find('.btn.btn-primary').simulate('click')
+    component.find('CardActionRow').props().onSave()
     expect(onSave).toHaveBeenCalled()
   })
 })

--- a/spec/javascripts/views/people/PersonCardSpec.jsx
+++ b/spec/javascripts/views/people/PersonCardSpec.jsx
@@ -64,6 +64,8 @@ describe('PersonCard', () => {
           edit={<p>Editing</p>}
           editable={true}
           mode='show'
+          onCancel={() => {}}
+          onSave={() => {}}
           personId='1234'
           personName='Bob Smith'
           isDeceased={true}
@@ -72,8 +74,9 @@ describe('PersonCard', () => {
       )
       expect(component.find('.card-body').children('p').at(0).text()).toEqual('Showing')
     })
-    it('does not render save and cancel buttons', () => {
+    it('does not render a card action row', () => {
       const component = renderPersonCard({mode: 'show'})
+      expect(component.find('CardActionRow').exists()).toEqual(false)
       expect(component.find('button.btn-primary').exists()).toEqual(false)
       expect(component.find('button.btn-default').exists()).toEqual(false)
     })
@@ -117,6 +120,8 @@ describe('PersonCard', () => {
           edit={<p>Editing</p>}
           editable={true}
           mode='edit'
+          onCancel={() => {}}
+          onSave={() => {}}
           personId='1234'
           personName='Bob Smith'
           show={<p>Showing</p>}
@@ -124,20 +129,24 @@ describe('PersonCard', () => {
       )
       expect(component.find('.card-body').children('p').at(0).text()).toEqual('Editing')
     })
-    it('does render save and cancel buttons', () => {
-      const onSave = jasmine.createSpy('onSave')
+
+    it('renders a card action row', () => {
+      const component = renderPersonCard({mode: 'edit'})
+      expect(component.find('CardActionRow').exists()).toEqual(true)
+    })
+
+    it('canceling edit calls onCancel', () => {
       const onCancel = jasmine.createSpy('onCancel')
-      const component = renderPersonCard({
-        onCancel,
-        onSave,
-        mode: 'edit',
-      })
-      const btnPrimary = component.find('button.btn-primary')
-      const btnDefault = component.find('button.btn-default')
-      expect(btnPrimary.exists()).toEqual(true)
-      expect(btnPrimary.props().onClick).toEqual(onSave)
-      expect(btnDefault.exists()).toEqual(true)
-      expect(btnDefault.props().onClick).toEqual(onCancel)
+      const component = renderPersonCard({onCancel, mode: 'edit'})
+      component.find('CardActionRow').props().onCancel()
+      expect(onCancel).toHaveBeenCalled()
+    })
+
+    it('saving changes calls onSave', () => {
+      const onSave = jasmine.createSpy('onSave')
+      const component = renderPersonCard({onSave, mode: 'edit'})
+      component.find('CardActionRow').props().onSave()
+      expect(onSave).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
### Jira Story

- [Display loading and saving animations HOT-1617](https://osi-cwds.atlassian.net/browse/HOT-1617)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This is a partial PR for the story. Safe to merge, but no complete feature yet. I'd like to merge it while it is still small.

It primarily contains a refactor of the Cancel and Save buttons at the bottom of each card, moving them into a component than can be shared across cards. This helps reduce duplicated JSX. It also allows me to add properties that affect all cards; in this case, I added an isLoading property that shows a loading spinner and hides the cancel button. This property is currently unused, so this is a pure refactor. I'll attach screenshots so you can see what it looks like, though.

Future work on this story will set up the Redux state and actions that switch the card between isLoading and not. That work is looking to be very complex, so I want to get these refactors merged while they are still easy to review.

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

