### PR TITLE
HOT 2278 Fix Sticky Header CSS

### DIFF
--- a/app/assets/stylesheets/_constants.scss
+++ b/app/assets/stylesheets/_constants.scss
@@ -93,3 +93,4 @@ $border-radius-rounded: 30px;
 
 $banner-height: 6.1rem;
 $page-header-height: 8rem;
+$error-banner-height: 6.1rem;

--- a/app/assets/stylesheets/shame_overrides.scss
+++ b/app/assets/stylesheets/shame_overrides.scss
@@ -205,6 +205,10 @@ header {
   padding-top: $page-header-height + $banner-height;
 }
 
+.back-to-dashboard-error {
+  padding-top: $page-header-height + $banner-height + $error-banner-height;
+}
+
 .hotline-inner-container,
 .snapshot-inner-container,
 .back-to-dashboard {

--- a/app/assets/stylesheets/shame_overrides.scss
+++ b/app/assets/stylesheets/shame_overrides.scss
@@ -62,8 +62,8 @@
 
 .anchor {
   display: inline-block;
-  height: 13rem;
-  margin-top: -13rem;
+  height: $banner-height + $page-header-height + $error-banner-height;
+  margin-top: 0 - ($banner-height + $page-header-height + $error-banner-height);
   visibility: hidden;
 }
 

--- a/app/javascript/common/BreadCrumb.jsx
+++ b/app/javascript/common/BreadCrumb.jsx
@@ -3,17 +3,22 @@ import PropTypes from 'prop-types'
 
 export const BreadCrumb = ({
   navigationElements,
-}) => (
-  <div className='container back-to-dashboard'>
-    <div className='row'>
-      <div className='col-xs-7'>
-        <h5>Back to: <span><a href='/dashboard'>Dashboard</a> {navigationElements.map((nav, index) => (<span key={index}> {'>'} {nav}</span>))}</span></h5>
+  hasError,
+}) => {
+  const klasses = hasError ? 'container back-to-dashboard-error' : 'container back-to-dashboard'
+  return (
+    <div className={klasses}>
+      <div className='row'>
+        <div className='col-xs-7'>
+          <h5>Back to: <span><a href='/dashboard'>Dashboard</a> {navigationElements.map((nav, index) => (<span key={index}> {'>'} {nav}</span>))}</span></h5>
+        </div>
       </div>
     </div>
-  </div>
-)
+  )
+}
 
 BreadCrumb.propTypes = {
+  hasError: PropTypes.bool,
   navigationElements: PropTypes.array,
 }
 

--- a/app/javascript/containers/common/BreadCrumb.jsx
+++ b/app/javascript/containers/common/BreadCrumb.jsx
@@ -1,0 +1,10 @@
+import {connect} from 'react-redux'
+import {BreadCrumb} from 'common/BreadCrumb'
+import {getHasGenericErrorValueSelector} from 'selectors/errorsSelectors'
+
+const mapStateToProps = (state, {navigationElements}) => ({
+  hasError: getHasGenericErrorValueSelector(state),
+  navigationElements,
+})
+
+export default connect(mapStateToProps)(BreadCrumb)

--- a/app/javascript/containers/common/BreadCrumb.jsx
+++ b/app/javascript/containers/common/BreadCrumb.jsx
@@ -2,7 +2,7 @@ import {connect} from 'react-redux'
 import {BreadCrumb} from 'common/BreadCrumb'
 import {getHasGenericErrorValueSelector} from 'selectors/errorsSelectors'
 
-const mapStateToProps = (state, {navigationElements}) => ({
+export const mapStateToProps = (state, {navigationElements}) => ({
   hasError: getHasGenericErrorValueSelector(state),
   navigationElements,
 })

--- a/app/javascript/screenings/ScreeningPage.jsx
+++ b/app/javascript/screenings/ScreeningPage.jsx
@@ -17,7 +17,7 @@ import NarrativeCard from 'screenings/NarrativeCard'
 import ScreeningInformationCard from 'screenings/ScreeningInformationCard'
 import WorkerSafetyCard from 'screenings/WorkerSafetyCard'
 import PageHeader from 'common/PageHeader'
-import {BreadCrumb} from 'common/BreadCrumb'
+import BreadCrumb from 'containers/common/BreadCrumb'
 import {urlHelper} from 'common/url_helper.js.erb'
 
 const isDuplicatePerson = (participants, personOnScreening) => (

--- a/spec/javascripts/components/common/BreadCrumbSpec.jsx
+++ b/spec/javascripts/components/common/BreadCrumbSpec.jsx
@@ -19,4 +19,28 @@ describe('BreadCrumb', () => {
     expect(breadCrumb.text()).toContain('Back to:')
     expect(breadCrumb.find('a').length).toEqual(2)
   })
+
+  it('uses container and back-to-dashboard-error classes with errors', () => {
+    const navigationElements = [<a key='' href='/'>CaseLoad</a>]
+    const breadCrumb = shallow(
+      <BreadCrumb
+        hasError={true}
+        navigationElements={navigationElements}
+      />
+    )
+    expect(breadCrumb.hasClass('container')).toEqual(true)
+    expect(breadCrumb.hasClass('back-to-dashboard-error')).toEqual(true)
+  })
+
+  it('uses container and back-to-dashboard class without errors', () => {
+    const navigationElements = [<a key='' href='/'>CaseLoad</a>]
+    const breadCrumb = shallow(
+      <BreadCrumb
+        hasError={false}
+        navigationElements={navigationElements}
+      />
+    )
+    expect(breadCrumb.hasClass('container')).toEqual(true)
+    expect(breadCrumb.hasClass('back-to-dashboard')).toEqual(true)
+  })
 })

--- a/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
+++ b/spec/javascripts/components/screenings/ScreeningPageSpec.jsx
@@ -69,7 +69,7 @@ describe('ScreeningPage', () => {
 
   it('renders a breadCrumb', () => {
     const screeningPage = renderScreeningPage({})
-    expect(screeningPage.find('BreadCrumb').exists()).toEqual(true)
+    expect(screeningPage.find('Connect(BreadCrumb)').exists()).toEqual(true)
   })
 
   describe('componentDidMount', () => {

--- a/spec/javascripts/containers/common/BreadCrumbSpec.js
+++ b/spec/javascripts/containers/common/BreadCrumbSpec.js
@@ -1,0 +1,38 @@
+import {mapStateToProps} from 'containers/common/BreadCrumb'
+import React from 'react'
+import {fromJS} from 'immutable'
+
+describe('BreadCrumbContainer', () => {
+  describe('mapStateToProps', () => {
+    it('provides navigation elements', () => {
+      const state = fromJS({})
+      const navigationElements = [<a key='' href='/'>caseload</a>]
+      expect(mapStateToProps(state, {navigationElements})).toEqual({
+        hasError: false,
+        navigationElements,
+      })
+    })
+
+    it('provides error status', () => {
+      const state = fromJS({
+        errors: ['an error'],
+      })
+      const navigationElements = [<a key='' href='/'>caseload</a>]
+      expect(mapStateToProps(state, {navigationElements})).toEqual({
+        hasError: true,
+        navigationElements,
+      })
+    })
+
+    it('provides non-error status', () => {
+      const state = fromJS({
+        errors: [],
+      })
+      const navigationElements = [<a key='' href='/'>caseload</a>]
+      expect(mapStateToProps(state, {navigationElements})).toEqual({
+        hasError: false,
+        navigationElements,
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Jira Story

- [Page and Global level header must stick to the top when user scroll down INT-2278](https://osi-cwds.atlassian.net/browse/INT-2278)

## Description
Fix sticky header behavior when there is an error banner

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
Just CSS changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

