### PR TITLE
Add Participants Card Anchor And Use it in Nav and When Saving

### DIFF
--- a/app/javascript/views/SideBarPeople.jsx
+++ b/app/javascript/views/SideBarPeople.jsx
@@ -11,7 +11,7 @@ const SideBarPeople = ({participants}) => (
           <NavLink
             key={id}
             text={nameFormatter({first_name, last_name, name_suffix})}
-            href={`#participants-card-${id}`}
+            href={`#participants-card-${id}-anchor`}
             preIcon='fa fa-user'
           />
         )}

--- a/app/javascript/views/people/PersonCard.jsx
+++ b/app/javascript/views/people/PersonCard.jsx
@@ -8,7 +8,7 @@ import {setHash} from 'utils/navigation'
 class PersonCard extends React.PureComponent {
   componentDidUpdate(prevProps) {
     if (this.props.mode === SHOW_MODE && prevProps.mode !== SHOW_MODE) {
-      setHash(`#participants-card-${this.props.personId}`)
+      setHash(`#participants-card-${this.props.personId}-anchor`)
     }
   }
 
@@ -60,9 +60,12 @@ class PersonCard extends React.PureComponent {
     const id = `participants-card-${personId}`
 
     return (
-      <div className={className} id={id}>
-        {this.renderHeader()}
-        {this.renderBody()}
+      <div>
+        <a className='anchor' id={`${id}-anchor`}/>
+        <div className={className} id={id}>
+          {this.renderHeader()}
+          {this.renderBody()}
+        </div>
       </div>
     )
   }

--- a/spec/javascripts/views/SideBarPeopleSpec.jsx
+++ b/spec/javascripts/views/SideBarPeopleSpec.jsx
@@ -33,11 +33,11 @@ describe('SideBarPeople', () => {
     it('renders a link to the People selected/created based on search', () => {
       expect(component.find('NavLink[text="Scooby Doo, Esq"]').exists()).toBe(true)
       expect(component.find('NavLink[text="Scooby Doo, Esq"]').props().href)
-        .toBe('#participants-card-1')
+        .toBe('#participants-card-1-anchor')
 
       expect(component.find('NavLink[text="Ultra Goku"]').exists()).toBe(true)
       expect(component.find('NavLink[text="Ultra Goku"]').props().href)
-        .toBe('#participants-card-2')
+        .toBe('#participants-card-2-anchor')
     })
   })
 })

--- a/spec/javascripts/views/people/PersonCardSpec.jsx
+++ b/spec/javascripts/views/people/PersonCardSpec.jsx
@@ -76,6 +76,16 @@ describe('PersonCard', () => {
       )
       expect(component.find('.card-body').children('p').at(0).text()).toEqual('Showing')
     })
+
+    it('renders an anchor to itself', () => {
+      const component = renderPersonCard({
+        mode: SHOW_MODE,
+        personId: '42',
+      })
+      const anchor = component.find('.anchor')
+      expect(anchor.props().id).toEqual(`participants-card-42-anchor`)
+    })
+
     it('does not render a card action row', () => {
       const component = renderPersonCard({mode: 'show'})
       expect(component.find('CardActionRow').exists()).toEqual(false)
@@ -83,6 +93,7 @@ describe('PersonCard', () => {
       expect(component.find('button.btn-default').exists()).toEqual(false)
     })
   })
+
   describe('mode is edit', () => {
     it('displays a card header', () => {
       const onDelete = jasmine.createSpy('onDelete')
@@ -136,6 +147,15 @@ describe('PersonCard', () => {
       const component = renderPersonCard({mode: EDIT_MODE})
       expect(component.find('CardActionRow').exists()).toEqual(true)
       expect(component.find('CardActionRow').props().isSaving).not.toBeTruthy()
+    })
+
+    it('renders an anchor to itself', () => {
+      const component = renderPersonCard({
+        mode: EDIT_MODE,
+        personId: '42',
+      })
+      const anchor = component.find('.anchor')
+      expect(anchor.props().id).toEqual(`participants-card-42-anchor`)
     })
 
     it('canceling edit calls onCancel', () => {
@@ -215,6 +235,15 @@ describe('PersonCard', () => {
       const component = renderPersonCard({mode: SAVING_MODE})
       expect(component.find('CardActionRow').exists()).toEqual(true)
       expect(component.find('CardActionRow').props().isSaving).toEqual(true)
+    })
+
+    it('renders an anchor to itself', () => {
+      const component = renderPersonCard({
+        mode: SAVING_MODE,
+        personId: '42',
+      })
+      const anchor = component.find('.anchor')
+      expect(anchor.props().id).toEqual(`participants-card-42-anchor`)
     })
 
     it('navigates to itself when transitioning to show mode', () => {

--- a/spec/javascripts/views/people/PersonCardSpec.jsx
+++ b/spec/javascripts/views/people/PersonCardSpec.jsx
@@ -159,7 +159,7 @@ describe('PersonCard', () => {
       expect(Navigation.setHash).not.toHaveBeenCalled()
 
       component.setProps({mode: SHOW_MODE})
-      expect(Navigation.setHash).toHaveBeenCalledWith(`#participants-card-${id}`)
+      expect(Navigation.setHash).toHaveBeenCalledWith(`#participants-card-${id}-anchor`)
     })
   })
   describe('mode is saving', () => {
@@ -224,7 +224,7 @@ describe('PersonCard', () => {
       expect(Navigation.setHash).not.toHaveBeenCalled()
 
       component.setProps({mode: SHOW_MODE})
-      expect(Navigation.setHash).toHaveBeenCalledWith(`#participants-card-${id}`)
+      expect(Navigation.setHash).toHaveBeenCalledWith(`#participants-card-${id}-anchor`)
     })
   })
 })


### PR DESCRIPTION
HOT-2278

### Jira Story

- [Page and Global level header must stick to the top when user scroll down HOT-2278](https://osi-cwds.atlassian.net/browse/HOT-2278)

## Description
The participant card headers were stuck underneath the sticky headers when using nav and saving the cards

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

