### PR TITLE
Turn on eager loading so that feature tests always have their constants

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -10,7 +10,8 @@ Rails.application.configure do
   # Do not eager load code on boot. This avoids loading your whole application
   # just for the purpose of running a single test. If you are using a tool that
   # preloads Rails for running tests, you may have to set it to true.
-  config.eager_load = false
+  config.eager_load = true
+  config.enable_dependency_loading = true
 
   # Configure static file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
### Jira Story

Pipeline Support -- no story

## Description
eager loading was turned off, so when rails could not load a constant it failed instead of retrying, this turns on autoloading in an effort to avoid that (which can cause tests to fail)

## Related Documentation
[Rails Guide (autoloading)](https://guides.rubyonrails.org/autoloading_and_reloading_constants.html#autoloading-in-the-test-environment)
[Rails 5 Spring Issue](https://github.com/rails/spring/issues/519
)
## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
Its just configuration

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

