### PR TITLE
HOT-2458 Keep existing cross report

### DIFF
--- a/app/javascript/selectors/screening/crossReportFormSelectors.js
+++ b/app/javascript/selectors/screening/crossReportFormSelectors.js
@@ -60,18 +60,25 @@ export const getScreeningWithEditsSelector = createSelector(
     agencies,
     participants
   ) => {
-    if (agencies.size) {
-      return screening
-        .setIn(['cross_reports', 0, 'county_id'], county_id)
-        .setIn(['cross_reports', 0, 'inform_date'], inform_date)
-        .setIn(['cross_reports', 0, 'method'], method)
-        .setIn(['cross_reports', 0, 'agencies'], agencies)
-        .set('participants', participants)
-    } else {
-      return screening
-        .set('cross_reports', List())
-        .set('participants', participants)
+    const hasFormData = county_id || inform_date || method || agencies && agencies.length > 0
+    let crossReports = screening.get('cross_reports')
+    const hasCrossReport = crossReports && crossReports.length > 0
+
+    if (!hasFormData && !hasCrossReport) {
+      return screening.set('participants', participants)
     }
+
+    if (hasFormData && !hasCrossReport) {
+      crossReports = new List()
+      crossReports.push({})
+      screening.set('cross_reports', crossReports)
+    }
+    return screening
+     .setIn(['cross_reports', 0, 'county_id'], county_id)
+     .setIn(['cross_reports', 0, 'inform_date'], inform_date)
+     .setIn(['cross_reports', 0, 'method'], method)
+     .setIn(['cross_reports', 0, 'agencies'], agencies)
+     .set('participants', participants)
   }
 )
 

--- a/app/javascript/selectors/screening/crossReportFormSelectors.js
+++ b/app/javascript/selectors/screening/crossReportFormSelectors.js
@@ -74,11 +74,11 @@ export const getScreeningWithEditsSelector = createSelector(
       screening.set('cross_reports', crossReports)
     }
     return screening
-     .setIn(['cross_reports', 0, 'county_id'], county_id)
-     .setIn(['cross_reports', 0, 'inform_date'], inform_date)
-     .setIn(['cross_reports', 0, 'method'], method)
-     .setIn(['cross_reports', 0, 'agencies'], agencies)
-     .set('participants', participants)
+      .setIn(['cross_reports', 0, 'county_id'], county_id)
+      .setIn(['cross_reports', 0, 'inform_date'], inform_date)
+      .setIn(['cross_reports', 0, 'method'], method)
+      .setIn(['cross_reports', 0, 'agencies'], agencies)
+      .set('participants', participants)
   }
 )
 

--- a/spec/javascripts/selectors/screening/crossReportFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/crossReportFormSelectorsSpec.js
@@ -702,10 +702,10 @@ describe('crossReportFormSelectors', () => {
       expect(getScreeningWithEditsSelector(state))
         .toEqualImmutable(fromJS({
           cross_reports: [{
-            "county_id": '-1',
-            "inform_date": null,
-            "method": null,
-            "agencies": [],
+            county_id: '-1',
+            inform_date: null,
+            method: null,
+            agencies: [],
           }],
           participants: [{
             id: '1',

--- a/spec/javascripts/selectors/screening/crossReportFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/crossReportFormSelectorsSpec.js
@@ -569,31 +569,46 @@ describe('crossReportFormSelectors', () => {
     })
   })
   describe('getScreeningWithEditsSelector', () => {
-    it('returns a screening with an empty cross reports if no data set', () => {
+    it('returns a screening for no form data and no existing cross report', () => {
+      const screening = {}
+      const crossReportForm = {}
+      const state = fromJS({screening, crossReportForm})
+      expect(getScreeningWithEditsSelector(state))
+        .toEqualImmutable(fromJS({
+          participants: [],
+        }))
+    })
+    it('returns a screening with with cross report if form data set', () => {
       const screening = {cross_reports: []}
       const crossReportForm = getCrossReportState({
         county_id: {
-          value: '',
+          value: '-1',
           touched: true,
         },
       })
       const state = fromJS({screening, crossReportForm})
       expect(getScreeningWithEditsSelector(state))
         .toEqualImmutable(fromJS({
-          cross_reports: [],
+          cross_reports: [{
+            county_id: '-1',
+            inform_date: null,
+            method: null,
+            agencies: [],
+          }],
           participants: [],
         }))
     })
     it('returns a screening with an updated cross_reports if the form has a value', () => {
-      const screening = {cross_reports: []}
+      const screening = {cross_reports: [{
+        county_id: '-1',
+        inform_date: '2017-02-20',
+        method: 'test method',
+        agencies: [{code: 'code 1', type: 'type 1'}],
+      }]}
       const crossReportForm = getCrossReportState({
         county_id: {
           value: '1234',
           touched: true,
-        },
-        inform_date: {
-          value: '2017-02-20',
-          touched: false,
         },
         method: {
           value: 'Child Abuse Form',
@@ -622,7 +637,7 @@ describe('crossReportFormSelectors', () => {
           cross_reports: [
             {
               county_id: '1234',
-              inform_date: '2017-02-20',
+              inform_date: null,
               method: 'Child Abuse Form',
               agencies: [
                 {type: 'DISTRICT_ATTORNEY', code: '1234'},
@@ -641,7 +656,7 @@ describe('crossReportFormSelectors', () => {
       }
       const crossReportForm = getCrossReportState({
         county_id: {
-          value: '',
+          value: '-1',
           touched: true,
         },
       })
@@ -649,7 +664,12 @@ describe('crossReportFormSelectors', () => {
       const state = fromJS({screening, crossReportForm, participants})
       expect(getScreeningWithEditsSelector(state))
         .toEqualImmutable(fromJS({
-          cross_reports: [],
+          cross_reports: [{
+            county_id: '-1',
+            inform_date: null,
+            method: null,
+            agencies: [],
+          }],
           participants,
         }))
     })
@@ -661,7 +681,7 @@ describe('crossReportFormSelectors', () => {
       }
       const crossReportForm = getCrossReportState({
         county_id: {
-          value: '',
+          value: '-1',
           touched: true,
         },
       })
@@ -681,7 +701,12 @@ describe('crossReportFormSelectors', () => {
       const state = fromJS({screening, crossReportForm, participants})
       expect(getScreeningWithEditsSelector(state))
         .toEqualImmutable(fromJS({
-          cross_reports: [],
+          cross_reports: [{
+            "county_id": '-1',
+            "inform_date": null,
+            "method": null,
+            "agencies": [],
+          }],
           participants: [{
             id: '1',
             first_name: 'Mario',


### PR DESCRIPTION
### Jira Story

- [Changes to Cross Report Card data incorrectly saved to postgres and to CWS HOT-2458] (https://osi-cwds.atlassian.net/browse/HOT-2458)

## Description
Keeping cross report once it is created. Update cross report every time if it exist. Triggering update not by agencies but any cross report field.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

