### PR TITLE
Hot 2434 enable disable create relationship button in modal

### DIFF
--- a/app/javascript/containers/screenings/ScreeningCreateRelationshipContainer.jsx
+++ b/app/javascript/containers/screenings/ScreeningCreateRelationshipContainer.jsx
@@ -2,7 +2,7 @@ import {connect} from 'react-redux'
 import ScreeningCreateRelationship from 'views/ScreeningCreateRelationship'
 import {
   selectCandidates,
-  selectisDisabledForm,
+  selectIsDisabledForm,
 } from 'selectors/screening/candidateSelectors'
 import {
   batchCreateRelationships,
@@ -12,7 +12,7 @@ import {
 
 const mapStateToProps = (state, {personId}) => ({
   candidates: selectCandidates(state, personId).toJS(),
-  isDisabled: selectisDisabledForm(state),
+  isDisabled: selectIsDisabledForm(state),
 })
 
 export const mapDispatchToProps = (dispatch) => ({

--- a/app/javascript/containers/screenings/ScreeningCreateRelationshipContainer.jsx
+++ b/app/javascript/containers/screenings/ScreeningCreateRelationshipContainer.jsx
@@ -1,6 +1,9 @@
 import {connect} from 'react-redux'
 import ScreeningCreateRelationship from 'views/ScreeningCreateRelationship'
-import {selectCandidates} from 'selectors/screening/candidateSelectors'
+import {
+  selectCandidates,
+  selectisDisabledForm,
+} from 'selectors/screening/candidateSelectors'
 import {
   batchCreateRelationships,
   setFieldCandidate,
@@ -9,6 +12,7 @@ import {
 
 const mapStateToProps = (state, {personId}) => ({
   candidates: selectCandidates(state, personId).toJS(),
+  isDisabled: selectisDisabledForm(state),
 })
 
 export const mapDispatchToProps = (dispatch) => ({

--- a/app/javascript/reducers/candidatesFormReducer.js
+++ b/app/javascript/reducers/candidatesFormReducer.js
@@ -55,7 +55,7 @@ const loadCandidates = (state, {payload: {relationships}, error}) => {
     return state
   } else {
     const candidates = buildCandidates(fromJS((relationships)))
-    return candidates.set('isDisabled', true)
+    return candidates
   }
 }
 

--- a/app/javascript/reducers/candidatesFormReducer.js
+++ b/app/javascript/reducers/candidatesFormReducer.js
@@ -64,13 +64,13 @@ const removeRelationshipType = (candidates) => (
 )
 
 const resetCandidates = (state, {payload: {id}}) =>
-  state.update(id, removeRelationshipType)
+  state.update(id, removeRelationshipType).delete('isActive')
 
 const updateCandidateForm = (state, {payload: {personId, candidateId, value}}) => {
   const index = state.get(personId).findIndex(
     (relatee) => relatee.getIn(['candidate', 'id']) === candidateId
   )
-  return state.setIn([personId, index, 'candidate', 'relationshipType'], value)
+  return state.setIn([personId, index, 'candidate', 'relationshipType'], value).set('isActive', false)
 }
 
 export default createReducer(Map(), {

--- a/app/javascript/reducers/candidatesFormReducer.js
+++ b/app/javascript/reducers/candidatesFormReducer.js
@@ -53,7 +53,8 @@ const loadCandidates = (state, {payload: {relationships}, error}) => {
   if (error) {
     return state
   } else {
-    return buildCandidates(fromJS((relationships)))
+    const candidates = buildCandidates(fromJS((relationships)))
+    return candidates.set('isDisabled', true)
   }
 }
 
@@ -64,13 +65,13 @@ const removeRelationshipType = (candidates) => (
 )
 
 const resetCandidates = (state, {payload: {id}}) =>
-  state.update(id, removeRelationshipType).delete('isActive')
+  state.update(id, removeRelationshipType).delete('isDisabled')
 
 const updateCandidateForm = (state, {payload: {personId, candidateId, value}}) => {
   const index = state.get(personId).findIndex(
     (relatee) => relatee.getIn(['candidate', 'id']) === candidateId
   )
-  return state.setIn([personId, index, 'candidate', 'relationshipType'], value).set('isActive', false)
+  return state.setIn([personId, index, 'candidate', 'relationshipType'], value).set('isDisabled', false)
 }
 
 export default createReducer(Map(), {

--- a/app/javascript/reducers/candidatesFormReducer.js
+++ b/app/javascript/reducers/candidatesFormReducer.js
@@ -78,7 +78,6 @@ const updateCandidateForm = (state, {payload: {personId, candidateId, fieldSet, 
   )
   const updatedForm = state.setIn([personId, index, 'candidate', fieldSet], value)
   const relationshipTypeExists = updatedForm.getIn([personId]).some(checkRelationshipType)
-  console.log(value)
   return (relationshipTypeExists) ? updatedForm.set('isDisabled', false) : updatedForm.set('isDisabled', true)
 }
 

--- a/app/javascript/reducers/candidatesFormReducer.js
+++ b/app/javascript/reducers/candidatesFormReducer.js
@@ -9,6 +9,7 @@ import {
   SET_CANDIDATE_FORM_FIELD,
 } from 'actions/relationshipsActions'
 import nameFormatter from 'utils/nameFormatter'
+import {Maybe} from 'utils/maybe'
 
 const selectPerson = (person) => (Map({
   age: ageFormatter({
@@ -67,11 +68,18 @@ const removeRelationshipType = (candidates) => (
 const resetCandidates = (state, {payload: {id}}) =>
   state.update(id, removeRelationshipType).delete('isDisabled')
 
-const updateCandidateForm = (state, {payload: {personId, candidateId, value}}) => {
+const checkRelationshipType = (candidate) =>
+  Maybe.of(candidate.getIn(['candidate', 'relationshipType'])).isSomething() &&
+  candidate.getIn(['candidate', 'relationshipType']) !== ''
+
+const updateCandidateForm = (state, {payload: {personId, candidateId, fieldSet, value}}) => {
   const index = state.get(personId).findIndex(
     (relatee) => relatee.getIn(['candidate', 'id']) === candidateId
   )
-  return state.setIn([personId, index, 'candidate', 'relationshipType'], value).set('isDisabled', false)
+  const updatedForm = state.setIn([personId, index, 'candidate', fieldSet], value)
+  const relationshipTypeExists = updatedForm.getIn([personId]).some(checkRelationshipType)
+  console.log(value)
+  return (relationshipTypeExists) ? updatedForm.set('isDisabled', false) : updatedForm.set('isDisabled', true)
 }
 
 export default createReducer(Map(), {

--- a/app/javascript/selectors/screening/candidateSelectors.js
+++ b/app/javascript/selectors/screening/candidateSelectors.js
@@ -12,3 +12,5 @@ export const selectCandidatesWithEdits = (state, id) => (Map({
     same_home_status: 'N',
   })),
 }))
+
+export const selectisDisabledForm = (state) => state.getIn(['candidatesForm', 'isDisabled'])

--- a/app/javascript/selectors/screening/candidateSelectors.js
+++ b/app/javascript/selectors/screening/candidateSelectors.js
@@ -13,4 +13,4 @@ export const selectCandidatesWithEdits = (state, id) => (Map({
   })),
 }))
 
-export const selectisDisabledForm = (state) => state.getIn(['candidatesForm', 'isDisabled'])
+export const selectIsDisabledForm = (state) => state.getIn(['candidatesForm', 'isDisabled'])

--- a/app/javascript/views/ScreeningCreateRelationship.jsx
+++ b/app/javascript/views/ScreeningCreateRelationship.jsx
@@ -31,6 +31,7 @@ export default class ScreeningCreateRelationship extends React.Component {
   }
 
   modalFooter() {
+    const {isDisabled = true} = this.props
     return (
       <div>
         <button
@@ -43,6 +44,7 @@ export default class ScreeningCreateRelationship extends React.Component {
         <button
           aria-label='Create Relationship'
           className='btn btn-primary'
+          disabled={isDisabled}
           onClick={this.saveCreateRelationship}
         >
           Create Relationship
@@ -96,6 +98,7 @@ ScreeningCreateRelationship.propTypes = {
       name: PropTypes.string,
     }),
   })),
+  isDisabled: PropTypes.bool,
   onCancel: PropTypes.func,
   onChange: PropTypes.func,
   onSave: PropTypes.func,

--- a/spec/javascripts/reducers/candidatesFormReducerSpec.js
+++ b/spec/javascripts/reducers/candidatesFormReducerSpec.js
@@ -171,6 +171,7 @@ describe('candidatesFormReducer', () => {
               name: 'Walter A White, Sr',
             },
           }],
+          isActive: false,
         })
       )
     })

--- a/spec/javascripts/reducers/candidatesFormReducerSpec.js
+++ b/spec/javascripts/reducers/candidatesFormReducerSpec.js
@@ -178,8 +178,8 @@ describe('candidatesFormReducer', () => {
     })
   })
 
-  describe('on SET_CANDIDATE_FORM_FIELD1', () => {
-    it('returns isDisabled to true', () => {
+  describe('SET_CANDIDATE_FORM_FIELD', () => {
+    it('sets isDisabled to true if relationshipType is set to empty value', () => {
       const personId = '1'
       const candidateId = '4157'
       const fieldSet = 'relationshipType'

--- a/spec/javascripts/reducers/candidatesFormReducerSpec.js
+++ b/spec/javascripts/reducers/candidatesFormReducerSpec.js
@@ -46,7 +46,7 @@ describe('candidatesFormReducer', () => {
     it('returns only isDisabled field', () => {
       expect(
         candidatesReducer(Map(), fetchRelationshipsSuccess([]))
-      ).toEqualImmutable(Map({isDisabled: true}))
+      ).toEqualImmutable(Map({}))
     })
 
     it('returns candidates for relationships', () => {
@@ -87,7 +87,6 @@ describe('candidatesFormReducer', () => {
               name: 'Walter A White, Sr',
             },
           }],
-          isDisabled: true,
         })
       )
     })

--- a/spec/javascripts/reducers/candidatesFormReducerSpec.js
+++ b/spec/javascripts/reducers/candidatesFormReducerSpec.js
@@ -98,7 +98,7 @@ describe('candidatesFormReducer', () => {
       const personId = '1'
       const candidateId = '4157'
       const fieldSet = 'relationshipType'
-      const value = '191'
+      const value = '190'
       const candidateForm = {
         1: [{
           person: {
@@ -153,7 +153,7 @@ describe('candidatesFormReducer', () => {
               id: '4157',
               gender: 'Male',
               name: 'New York C Pechan, Sr',
-              relationshipType: '191',
+              relationshipType: '190',
             },
           }, {
             person: {
@@ -173,6 +173,93 @@ describe('candidatesFormReducer', () => {
             },
           }],
           isDisabled: false,
+        })
+      )
+    })
+  })
+
+  describe('on SET_CANDIDATE_FORM_FIELD1', () => {
+    it('returns isDisabled to true', () => {
+      const personId = '1'
+      const candidateId = '4157'
+      const fieldSet = 'relationshipType'
+      const value = ''
+      const candidateForm = {
+        1: [{
+          person: {
+            age: '20 yrs',
+            dateOfBirth: '01/15/1986',
+            id: '1',
+            gender: 'Male',
+            legacyId: '3',
+            name: 'Ricky Robinson',
+          },
+          candidate: {
+            age: '30 yrs',
+            dateOfBirth: '11/11/1958',
+            id: '4157',
+            gender: 'Male',
+            name: 'New York C Pechan, Sr',
+            relationshipType: '200',
+          },
+        }, {
+          person: {
+            age: '20 yrs',
+            dateOfBirth: '01/15/1986',
+            id: '1',
+            gender: 'Male',
+            legacyId: '3',
+            name: 'Ricky Robinson',
+          },
+          candidate: {
+            age: '40 yrs',
+            dateOfBirth: '11/11/1968',
+            id: '4158',
+            gender: 'Male',
+            name: 'Walter A White, Sr',
+          },
+        }],
+        isDisabled: false,
+      }
+      const action = setFieldCandidate(personId, candidateId, fieldSet, value)
+      const state = fromJS(candidateForm)
+      expect(candidatesReducer(state, action)).toEqualImmutable(
+        fromJS({
+          1: [{
+            person: {
+              age: '20 yrs',
+              dateOfBirth: '01/15/1986',
+              id: '1',
+              gender: 'Male',
+              legacyId: '3',
+              name: 'Ricky Robinson',
+            },
+            candidate: {
+              age: '30 yrs',
+              dateOfBirth: '11/11/1958',
+              id: '4157',
+              gender: 'Male',
+              name: 'New York C Pechan, Sr',
+              relationshipType: '',
+            },
+          }, {
+            person: {
+              age: '20 yrs',
+              dateOfBirth: '01/15/1986',
+              id: '1',
+              gender: 'Male',
+              legacyId: '3',
+              name: 'Ricky Robinson',
+            },
+            candidate: {
+              age: '40 yrs',
+              dateOfBirth: '11/11/1968',
+              id: '4158',
+              gender: 'Male',
+              name: 'Walter A White, Sr',
+            },
+          }],
+          isDisabled: true,
         })
       )
     })

--- a/spec/javascripts/reducers/candidatesFormReducerSpec.js
+++ b/spec/javascripts/reducers/candidatesFormReducerSpec.js
@@ -43,10 +43,10 @@ describe('candidatesFormReducer', () => {
   }]
 
   describe('on FETCH_RELATIONSHIPS_COMPLETE', () => {
-    it('returns an empty immutable map', () => {
+    it('returns only isDisabled field', () => {
       expect(
         candidatesReducer(Map(), fetchRelationshipsSuccess([]))
-      ).toEqualImmutable(Map())
+      ).toEqualImmutable(Map({isDisabled: true}))
     })
 
     it('returns candidates for relationships', () => {
@@ -87,6 +87,7 @@ describe('candidatesFormReducer', () => {
               name: 'Walter A White, Sr',
             },
           }],
+          isDisabled: true,
         })
       )
     })
@@ -171,7 +172,7 @@ describe('candidatesFormReducer', () => {
               name: 'Walter A White, Sr',
             },
           }],
-          isActive: false,
+          isDisabled: false,
         })
       )
     })

--- a/spec/javascripts/selectors/screening/candidateSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/candidateSelectorsSpec.js
@@ -2,7 +2,7 @@ import {fromJS} from 'immutable'
 import {
   selectCandidates,
   selectCandidatesWithEdits,
-  selectisDisabledForm,
+  selectIsDisabledForm,
 } from 'selectors/screening/candidateSelectors'
 import * as matchers from 'jasmine-immutable-matchers'
 
@@ -155,10 +155,10 @@ describe('candidateSelectors', () => {
     })
   })
 
-  describe('selectisDisabledForm', () => {
+  describe('selectIsDisabledForm', () => {
     it('returns a list of candidates with isDisabled field', () => {
       const state = fromJS({candidatesForm})
-      expect(selectisDisabledForm(state)).toBe(true)
+      expect(selectIsDisabledForm(state)).toBe(true)
     })
   })
 })

--- a/spec/javascripts/selectors/screening/candidateSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/candidateSelectorsSpec.js
@@ -2,6 +2,7 @@ import {fromJS} from 'immutable'
 import {
   selectCandidates,
   selectCandidatesWithEdits,
+  selectisDisabledForm,
 } from 'selectors/screening/candidateSelectors'
 import * as matchers from 'jasmine-immutable-matchers'
 
@@ -9,6 +10,7 @@ describe('candidateSelectors', () => {
   beforeEach(() => jasmine.addMatchers(matchers))
 
   const candidatesForm = {
+    isDisabled: true,
     1: [{
       person: {
         age: '20 yrs',
@@ -150,6 +152,13 @@ describe('candidateSelectors', () => {
       expect(
         selectCandidatesWithEdits(state, id)).toEqualImmutable(fromJS({relationships: []})
       )
+    })
+  })
+
+  describe('selectisDisabledForm', () => {
+    it('returns a list of candidates with isDisabled field', () => {
+      const state = fromJS({candidatesForm})
+      expect(selectisDisabledForm(state)).toBe(true)
     })
   })
 })

--- a/spec/javascripts/views/ScreeningCreateRelationshipSpec.jsx
+++ b/spec/javascripts/views/ScreeningCreateRelationshipSpec.jsx
@@ -109,4 +109,10 @@ describe('ScreeningCreateRelationship', () => {
       expect(onSave).toHaveBeenCalledWith('805')
     })
   })
+  it('SaveRelationship Button is disabled when the modal is popped up initially', () => {
+    wrapper.setState({show: true})
+    const footer = wrapper.find('ModalComponent').props().modalFooter
+    const save = footer.props.children[1]
+    expect(save.props.disabled).toEqual(true)
+  })
 })


### PR DESCRIPTION
### Jira Story

- [Hot 2434 enable disable create relationship button in modal](Implement 'Enable Create Relationship Button' Business Rule)

## Description
As a Hotline Worker, I want the Create RelationshipButton to be Enabled only if any of the fields are touched, else disable Create Relationship button, so that, I know I have to Create the relationship before saving.

**AC**
The button is disabled on the initial pop-up. 
If the fields are touched, the button is enabled.
The button is disabled if the empty Relationship field is selected.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

