### PR TITLE
HOT 2530 Blank Screen on Person Save

### DIFF
--- a/app/javascript/reducers/errorsReducer.js
+++ b/app/javascript/reducers/errorsReducer.js
@@ -3,18 +3,26 @@ import {CLEAR_ERRORS} from 'actions/clearErrors'
 
 const initialState = fromJS({})
 
+export const PROCESS_ERROR = 'The application encountered an error and could not process it'
+export const PROCESS_TYPE = 'PROCESS_TYPE'
+
 export default function errorsReducer(state = initialState, action) {
-  const {payload, error, type} = action
+  try {
+    const {payload, error, type} = action
 
-  if (error) {
-    const {error: {responseJSON = {}} = {}} = payload
-    const {api_response_body: {issue_details} = {}} = responseJSON
-    return state.set(type, fromJS(issue_details || payload))
+    if (error) {
+      const {error: errorPayload} = payload
+      const {responseJSON} = errorPayload
+      const {api_response_body: {issue_details} = {}} = responseJSON || errorPayload
+      return state.set(type, fromJS(issue_details))
+    }
+
+    if (type === CLEAR_ERRORS) {
+      return initialState
+    }
+
+    return state.delete(type)
+  } catch (error) {
+    return state.set(PROCESS_TYPE, fromJS({error: [PROCESS_ERROR]}))
   }
-
-  if (type === CLEAR_ERRORS) {
-    return initialState
-  }
-
-  return state.delete(type)
 }

--- a/spec/features/screening/participant/editing_participant_spec.rb
+++ b/spec/features/screening/participant/editing_participant_spec.rb
@@ -116,6 +116,26 @@ feature 'Edit Person' do
         )
       ).to have_been_made
     end
+
+    context 'when there is an error' do
+      scenario 'displays the error banner without completely crashing the page' do
+        stub_request(:put,
+          ferb_api_url(FerbRoutes.screening_participant_path(screening[:id], marge.id)))
+          .and_return(proc {
+            sleep 2
+            { status: 500 }
+          })
+        visit edit_screening_path(id: screening[:id])
+        within edit_participant_card_selector(marge.id) do
+          click_button 'Save'
+          expect(page).to have_button('Saving', disabled: true)
+        end
+        expect(page).to have_text(
+          /Something went wrong, sorry! Please try your last action again. \(Ref #:.*\)/
+        )
+        expect(page).to have_css(participant_card_selector(marge.id))
+      end
+    end
   end
 
   context 'editing and saving person phone numbers' do

--- a/spec/javascripts/reducers/errorsReducerSpec.js
+++ b/spec/javascripts/reducers/errorsReducerSpec.js
@@ -2,9 +2,78 @@ import {fromJS} from 'immutable'
 import * as matchers from 'jasmine-immutable-matchers'
 import errorsReducer from 'reducers/errorsReducer'
 import {SUBMIT_SCREENING_COMPLETE} from 'actions/actionTypes'
+import {PROCESS_TYPE} from 'reducers/errorsReducer'
 
 describe('errorsReducer', () => {
   beforeEach(() => jasmine.addMatchers(matchers))
+
+  describe('on error', () => {
+    it('sets errors when there is a response JSON', () => {
+      const state = fromJS({})
+      const action = {
+        payload: {error: {responseJSON: {api_response_body: {issue_details: {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'a user message',
+          property: 'approvalStatus',
+          invalid_value: 0,
+        }}}}},
+        type: SUBMIT_SCREENING_COMPLETE,
+        error: true,
+      }
+      expect(errorsReducer(state, action)).toEqualImmutable(
+        fromJS({
+          [SUBMIT_SCREENING_COMPLETE]: {
+            incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+            type: 'constraint_validation',
+            user_message: 'a user message',
+            property: 'approvalStatus',
+            invalid_value: 0,
+          },
+        })
+      )
+    })
+    it('sets errors when there is no response JSON', () => {
+      const state = fromJS({})
+      const action = {
+        payload: {error: {api_response_body: {issue_details: {
+          incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+          type: 'constraint_validation',
+          user_message: 'a user message',
+          property: 'approvalStatus',
+          invalid_value: 0,
+        }}}},
+        type: SUBMIT_SCREENING_COMPLETE,
+        error: true,
+      }
+      expect(errorsReducer(state, action)).toEqualImmutable(
+        fromJS({
+          [SUBMIT_SCREENING_COMPLETE]: {
+            incident_id: '0de2aea9-04f9-4fc4-bc16-75b6495839e0',
+            type: 'constraint_validation',
+            user_message: 'a user message',
+            property: 'approvalStatus',
+            invalid_value: 0,
+          },
+        })
+      )
+    })
+
+    it('sets an anonymous error in the store when it cannot process the error message', () => {
+      const state = fromJS({})
+      const action = {
+        payload: {asdf: 'asdf'},
+        error: true,
+      }
+      expect(errorsReducer(state, action)).toEqualImmutable(
+        fromJS({
+          [PROCESS_TYPE]: {
+            error: ['The application encountered an error and could not process it'],
+          },
+        })
+      )
+    })
+  })
 
   describe('on errors for SUBMIT_SCREENING_COMPLETE', () => {
     it('stores the list of issue_details', () => {
@@ -73,7 +142,7 @@ describe('errorsReducer', () => {
         expect(errorsReducer(state, action)).toEqualImmutable(
           fromJS({
             ACTION_TYPE: 'Did not have a plan',
-            GENERIC_ACTION_COMPLETE: 'Did not have a plan',
+            PROCESS_TYPE: {error: ['The application encountered an error and could not process it']},
           })
         )
       })

--- a/spec/support/helpers/screening_helpers.rb
+++ b/spec/support/helpers/screening_helpers.rb
@@ -2,11 +2,15 @@
 
 module ScreeningHelpers
   def edit_participant_card_selector(participant_id)
-    "#participants-card-#{participant_id}.edit"
+    "#{participant_card_selector(participant_id)}.edit"
   end
 
   def show_participant_card_selector(participant_id)
-    "#participants-card-#{participant_id}.show"
+    "#{participant_card_selector(participant_id)}.show"
+  end
+
+  def participant_card_selector(participant_id)
+    "#participants-card-#{participant_id}"
   end
 
   def save_card(card_name)


### PR DESCRIPTION
### Jira Story

- [Saving a person when there is an error causes a blank screen HOT-2530](https://osi-cwds.atlassian.net/browse/HOT-2530)

## Description
The problem in the bug is when a user adds a person to a screening and then tries to save them when there is an error saving, a blank screen occurs because the errors reducer cannot process the error. The errors reducer should expect the error to be dispatched with a certain format. If it fails to parse the error, it should report its failure and not cause the application to crash.

I did some cleanup of how we handle errors such that we can handle error payloads with responseJSON keys and also without them. The larger change though, was to catch any errors thrown in the errors reducer and set the store to have an error marked as a processing problem. The errors reducer is always evaluated no matter what action is dispatched, so we need to ensure that it succeeds or reports that it failed to report the error (which itself is an error). An alternative would be just be returning current state, but that would hide the problem and potentially hide other errors too.

## Tests
- [x] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

