### PR TITLE
HOT-2167: Center the dropdown values in multiselect and highlight correctly

### DIFF
--- a/app/assets/stylesheets/multi-select.scss
+++ b/app/assets/stylesheets/multi-select.scss
@@ -31,6 +31,13 @@
   }
 }
 
+.Select-option {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+}
+
 .Select--multi .Select-value-label {
   font-size: 1.7rem;
   margin: 0;


### PR DESCRIPTION
### Jira Story

- [Inconsistent Spacing in Allegation Drop Down Menu HOT-2167](https://osi-cwds.atlassian.net/browse/HOT-2167)

## Description
The multi-select dropdown for allegations was highlighting the options inconsistently when they spanned more than one line.
## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
CSS change, no functional code changes

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

