### PR TITLE
Remove: Authorization to Ferb API

### DIFF
--- a/app/repositories/participant_repository.rb
+++ b/app/repositories/participant_repository.rb
@@ -6,10 +6,7 @@ class ParticipantRepository
   class AuthorizationError < StandardError; end
 
   def self.create(security_token, participant)
-    legacy_id = participant.dig(:legacy_descriptor, :legacy_id)
     screening_id = participant[:screening_id]
-
-    authorize security_token, legacy_id
 
     response = FerbAPI.make_api_call(
       security_token,
@@ -30,6 +27,7 @@ class ParticipantRepository
 
   def self.update(security_token, participant)
     raise 'Error updating participant: id is required' unless participant[:id]
+
     response = FerbAPI.make_api_call(
       security_token,
       FerbRoutes.screening_participant_path(participant[:screening_id], participant[:id]),
@@ -52,6 +50,7 @@ class ParticipantRepository
       FerbAPI.make_api_call(security_token, route, :get)
     rescue ApiError => e
       raise AuthorizationError if e.api_error[:http_code] == 403
+
       raise e
     end
   end

--- a/spec/controllers/api/v1/participants_controller_spec.rb
+++ b/spec/controllers/api/v1/participants_controller_spec.rb
@@ -80,10 +80,7 @@ describe Api::V1::ParticipantsController do
         .with(security_token, participant_params)
         .and_raise(ParticipantRepository::AuthorizationError)
 
-      process :create,
-        method: :post,
-        params: { participant: participant_params },
-        session: session
+      post :create, params: { participant: participant_params }, session: session
       expect(response.status).to eq(403)
       expect(JSON.parse(response.body)).to eq({
         status: 403

--- a/spec/features/screening/participant/create_participant_spec.rb
+++ b/spec/features/screening/participant/create_participant_spec.rb
@@ -255,12 +255,6 @@ feature 'Create participant' do
     within '#search-card', text: 'Search' do
       find('strong', text: 'Homer Simpson').click
     end
-    expect(a_request(:get,
-      ferb_api_url(
-        FerbRoutes.client_authorization_path(
-          created_participant_homer.legacy_descriptor.legacy_id
-        )
-      ))).to have_been_made
     expect(a_request(:post,
       ferb_api_url(
         FerbRoutes.screening_participant_path(existing_screening[:id])

--- a/spec/repositories/participant_repository_spec.rb
+++ b/spec/repositories/participant_repository_spec.rb
@@ -77,9 +77,6 @@ describe ParticipantRepository do
 
       it 'should return a participant when authorization succeeds' do
         expect(FerbAPI).to receive(:make_api_call)
-          .with(security_token, "/authorize/client/#{participant_id}", :get)
-          .and_return(status: 200)
-        expect(FerbAPI).to receive(:make_api_call)
           .with(
             security_token,
             FerbRoutes.screening_participant_path(screening_id),
@@ -89,57 +86,6 @@ describe ParticipantRepository do
         created_participant = described_class.create(security_token, payload)
         expect(created_participant['id']).to eq(participant_id)
         expect(created_participant['first_name']).to eq('New Participant')
-      end
-
-      it 'should raise an error when authorization fails' do
-        url = "/authorize/client/#{participant_id}"
-        expect(FerbAPI).to receive(:make_api_call)
-          .with(security_token, url, :get)
-          .and_raise(
-            ApiError.new(
-              message: 'Forbidden',
-              sent_attributes: '',
-              url: url,
-              method: :get,
-              response: OpenStruct.new(
-                status: 403,
-                body: 'Forbidden'
-              )
-            )
-          )
-
-        expect(FerbAPI).not_to receive(:make_api_call)
-          .with(security_token, FerbRoutes.screening_participant_path(screening_id), :post)
-
-        expect do
-          described_class.create(security_token, payload)
-        end.to raise_error(described_class::AuthorizationError)
-      end
-
-      it 'should reraise unexpected API errors' do
-        url = "/authorize/client/#{participant_id}"
-
-        exception = ApiError.new(
-          message: 'I am a teapot',
-          sent_attributes: '',
-          url: url,
-          method: :get,
-          response: OpenStruct.new(
-            status: 418,
-            body: 'I am a teapot'
-          )
-        )
-
-        expect(FerbAPI).to receive(:make_api_call)
-          .with(security_token, url, :get)
-          .and_raise(exception)
-
-        expect(FerbAPI).not_to receive(:make_api_call)
-          .with(security_token, FerbRoutes.screening_participant_path(screening_id), :post)
-
-        expect do
-          described_class.create(security_token, payload)
-        end.to raise_error(exception)
       end
     end
   end


### PR DESCRIPTION
### Jira Story

- [Remove the Separate Ruby call to Authorize the client for Participant POST](https://osi-cwds.atlassian.net/browse/HOT-2207)

## Description
Remove extra ruby call to authorize the client.

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
Removing code.

## Types of changes
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
