### PR TITLE
Fix on filtering pending participants.

### DIFF
--- a/app/javascript/reducers/pendingParticipantsReducer.js
+++ b/app/javascript/reducers/pendingParticipantsReducer.js
@@ -6,6 +6,20 @@ import {
 } from 'actions/personCardActions'
 import {createReducer} from 'utils/createReducer'
 import {List} from 'immutable'
+import {Maybe} from 'utils/maybe'
+
+const getLegacyDescriptor = (person) => Maybe.of(person.legacy_descriptor)
+
+const getLegacyId = (legacyDescriptor) => Maybe.of(legacyDescriptor.legacy_id)
+
+const isParticipant = (person) => (id) =>
+  getLegacyDescriptor(person)
+    .chain(getLegacyId)
+    .map((legacyId) => legacyId === id)
+    .valueOrElse(false)
+
+const isParticipantLegacy = (person) => (id) =>
+  Maybe.of(person.legacy_id).map((legacyId) => legacyId === id).valueOrElse(false)
 
 export default createReducer(List(), {
   [CREATE_SNAPSHOT_PERSON](state, {payload: {id}}) {
@@ -20,6 +34,8 @@ export default createReducer(List(), {
       return List()
     } else {
       return state.filter((id) => id !== person.id)
+        .filterNot(isParticipant(person))
+        .filterNot(isParticipantLegacy(person))
     }
   },
   [CLEAR_PEOPLE]() {

--- a/spec/javascripts/reducers/pendingParticipantsReducerSpec.js
+++ b/spec/javascripts/reducers/pendingParticipantsReducerSpec.js
@@ -29,6 +29,42 @@ describe('pendingParticipantsReducer', () => {
       const expectedState = fromJS([firstId])
       expect(pendingParticipantsReducer(oldState, action)).toEqualImmutable(expectedState)
     })
+    it('returns the pending particpants without the completed participant using legacy descriptor', () => {
+      const firstId = '2'
+      const secondId = '3'
+      const legacyId = '9GAG'
+      const oldState = fromJS([firstId, secondId, legacyId])
+      const action = createPersonSuccess({id: '4', legacy_descriptor: {legacy_id: '9GAG'}})
+      const expectedState = fromJS([firstId, secondId])
+      expect(pendingParticipantsReducer(oldState, action)).toEqualImmutable(expectedState)
+    })
+    it('returns the pending participant even with legacy_id is undefined', () => {
+      const firstId = '2'
+      const secondId = '3'
+      const legacyId = '9GAG'
+      const oldState = fromJS([firstId, secondId, legacyId])
+      const action = createPersonSuccess({id: '5', legacy_descriptor: {hello: '9GAG'}})
+      const expectedState = fromJS([firstId, secondId, legacyId])
+      expect(pendingParticipantsReducer(oldState, action)).toEqualImmutable(expectedState)
+    })
+    it('returns all the pending participant even with legacy_id defined', () => {
+      const firstId = '2'
+      const secondId = '3'
+      const legacyId = '9GAG'
+      const oldState = fromJS([firstId, secondId, legacyId])
+      const action = createPersonSuccess({id: '5', legacy_descriptor: {legacy_id: 'DBZ'}})
+      const expectedState = fromJS([firstId, secondId, legacyId])
+      expect(pendingParticipantsReducer(oldState, action)).toEqualImmutable(expectedState)
+    })
+    it('returns all the pending participants without the complete participant using legacy_id field', () => {
+      const firstId = '2'
+      const secondId = '3'
+      const legacyId = 'DBZ'
+      const oldState = fromJS([firstId, secondId, legacyId])
+      const action = createPersonSuccess({id: '5', legacy_id: 'DBZ'})
+      const expectedState = fromJS([firstId, secondId])
+      expect(pendingParticipantsReducer(oldState, action)).toEqualImmutable(expectedState)
+    })
     it('returns the last state on failure', () => {
       const action = createPersonFailure()
       expect(pendingParticipantsReducer(List(), action)).toEqual(List())


### PR DESCRIPTION
### Jira Story

- [Fix the Attach link in Relationship card HOT-2575](https://osi-cwds.atlassian.net/browse/HOT-2575)
- This also relate to [Inconsistent responses from Ferb POST participant(s) endpoints HOT-2577](https://osi-cwds.atlassian.net/browse/HOT-2577)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This fixes the filtering of pending participants in pendingParticipants reducer
when create person completed. The snapshot uses legacy_id as person id while
the screening used participant id as person id. To fix this bug, legacy_descriptor field is used to filter
the pending participants so as to not break snapshot and it would fix the screening page when a
participant is remove so the Attach button will be visible. Added also a fallback for legacy_id field since there is still a bug in API Responses. (FYI - I Attached pictures on JIRA). 

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
