### PR TITLE
HOT-2485 - Show search results when street search only

### DIFF
--- a/app/javascript/common/search/Autocompleter.jsx
+++ b/app/javascript/common/search/Autocompleter.jsx
@@ -123,7 +123,7 @@ export default class Autocompleter extends Component {
   }
 
   onFocus() {
-    if (this.isSearchable(this.props.searchTerm)) {
+    if (this.isSearchable(this.props.searchTerm) || this.props.searchAddress) {
       this.setState({menuVisible: true})
     } else {
       this.hideMenu()

--- a/spec/javascripts/components/common/search/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/search/AutocompleterSpec.jsx
@@ -402,6 +402,25 @@ describe('<Autocompleter />', () => {
           county: 'Sacramento',
         })
       })
+
+      it('displays search results when button is submitted', () => {
+        const isAddressIncluded = true
+        const autocompleter = renderAutocompleter({
+          onSearch,
+          onChange,
+          isAddressIncluded,
+          searchTerm: '',
+          searchAddress: '123 Main St',
+          searchCity: 'Sac Town',
+          searchCounty: 'Sacramento',
+        })
+        const searchByAddress = autocompleter.find('SearchByAddress')
+        expect(autocompleter.state().menuVisible).toEqual(false)
+
+        searchByAddress.props().onSubmit()
+
+        expect(autocompleter.state().menuVisible).toEqual(true)
+      })
     })
   })
 


### PR DESCRIPTION
### Jira Story

- [Search with Address HOT-2485](https://osi-cwds.atlassian.net/browse/HOT-2485)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
There is a bug where if you search by street address alone (with no characters entered into the main autocomplete search bar), the search results would never be displayed. With this, the results are displayed after you click Search. In that situation, the search button sends your focus to the main search input, and onFocus handles displaying of results.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

