### PR TITLE
Hot 2564 make breadcrumb link visible

### DIFF
--- a/app/javascript/common/config.js
+++ b/app/javascript/common/config.js
@@ -22,5 +22,5 @@ export function sdmPath() {
   return config().sdm_path
 }
 
-// Trigger page level error message on demand for tester to test error banner
+//Triggers page level error message on demand for tester to test error banner
 window.displayError = () => store.dispatch(fetchFailure({error: true}))

--- a/app/javascript/common/config.js
+++ b/app/javascript/common/config.js
@@ -1,3 +1,6 @@
+import {fetchFailure} from 'actions/systemCodesActions'
+import {store} from 'store/configureStore'
+
 export function config() {
   const {org: {intake: {config = {}} = {}} = {}} = window
   return config
@@ -18,3 +21,6 @@ export function jsClipboardSupported() {
 export function sdmPath() {
   return config().sdm_path
 }
+
+// Trigger page level error message on demand for tester to test error banner
+window.displayError = () => store.dispatch(fetchFailure({error: true}))

--- a/app/javascript/containers/HomePageContainer.jsx
+++ b/app/javascript/containers/HomePageContainer.jsx
@@ -4,11 +4,13 @@ import {bindActionCreators} from 'redux'
 import {connect} from 'react-redux'
 import {snapshotEnabledSelector, hotlineEnabledSelector} from 'selectors/homePageSelectors'
 import {HomePage} from 'views/homePage'
+import {getHasGenericErrorValueSelector} from 'selectors/errorsSelectors'
 
 function mapStateToProps(state, _ownProps) {
   return {
     snapshot: snapshotEnabledSelector(state),
     hotline: hotlineEnabledSelector(state),
+    hasError: getHasGenericErrorValueSelector(state),
   }
 }
 

--- a/app/javascript/containers/HomePageContainer.jsx
+++ b/app/javascript/containers/HomePageContainer.jsx
@@ -4,13 +4,11 @@ import {bindActionCreators} from 'redux'
 import {connect} from 'react-redux'
 import {snapshotEnabledSelector, hotlineEnabledSelector} from 'selectors/homePageSelectors'
 import {HomePage} from 'views/homePage'
-import {getHasGenericErrorValueSelector} from 'selectors/errorsSelectors'
 
 function mapStateToProps(state, _ownProps) {
   return {
     snapshot: snapshotEnabledSelector(state),
     hotline: hotlineEnabledSelector(state),
-    hasError: getHasGenericErrorValueSelector(state),
   }
 }
 

--- a/app/javascript/snapshots/SnapshotPage.jsx
+++ b/app/javascript/snapshots/SnapshotPage.jsx
@@ -16,7 +16,7 @@ import PageHeader from 'common/PageHeader'
 import SnapshotIntro from 'snapshots/SnapshotIntro'
 import SnapshotSideBar from 'snapshots/SnapshotSideBar'
 import {selectParticipants} from 'selectors/participantSelectors'
-import {BreadCrumb} from 'common/BreadCrumb'
+import BreadCrumb from 'containers/common/BreadCrumb'
 import {getHasGenericErrorValueSelector} from 'selectors/errorsSelectors'
 
 const isDuplicatePerson = (participants, id) => (
@@ -80,7 +80,7 @@ export class SnapshotPage extends React.Component {
       <div>
         <div>
           <PageHeader pageTitle='Snapshot' button={this.startOverButton()} />
-          <BreadCrumb hasError={hasGenericErrors} />
+          <BreadCrumb />
         </div>
         <div className={`container snapshot-container ${genericErrorClass}`}>
           <div className='row'>

--- a/app/javascript/snapshots/SnapshotPage.jsx
+++ b/app/javascript/snapshots/SnapshotPage.jsx
@@ -80,7 +80,7 @@ export class SnapshotPage extends React.Component {
       <div>
         <div>
           <PageHeader pageTitle='Snapshot' button={this.startOverButton()} />
-          <BreadCrumb />
+          <BreadCrumb hasError={hasGenericErrors} />
         </div>
         <div className={`container snapshot-container ${genericErrorClass}`}>
           <div className='row'>

--- a/app/javascript/views/homePage.jsx
+++ b/app/javascript/views/homePage.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import ScreeningsTable from 'screenings/ScreeningsTableContainer'
 import PageHeader from 'common/PageHeader'
-import {BreadCrumb} from 'common/BreadCrumb'
+import BreadCrumb from 'containers/common/BreadCrumb'
 
 const HomePageButtons = ({snapshot, hotline, createSnapshot, createScreening}) => (
   <div className='pull-right'>
@@ -36,7 +36,7 @@ HomePageButtons.propTypes = {
   snapshot: PropTypes.bool,
 }
 
-export const HomePage = ({snapshot, hotline, hasError, actions: {createSnapshot, createScreening}}) => (
+export const HomePage = ({snapshot, hotline, actions: {createSnapshot, createScreening}}) => (
   <div>
     <div>
       <PageHeader
@@ -50,7 +50,7 @@ export const HomePage = ({snapshot, hotline, hasError, actions: {createSnapshot,
           />
         }
       />
-      <BreadCrumb hasError={hasError}/>
+      <BreadCrumb />
     </div>
     <div className='shim'/>
     <div className='container'>
@@ -66,7 +66,6 @@ HomePage.propTypes = {
     createScreening: PropTypes.func,
     createSnapshot: PropTypes.func,
   }),
-  hasError: PropTypes.bool,
   hotline: PropTypes.bool,
   snapshot: PropTypes.bool,
 }

--- a/app/javascript/views/homePage.jsx
+++ b/app/javascript/views/homePage.jsx
@@ -36,7 +36,7 @@ HomePageButtons.propTypes = {
   snapshot: PropTypes.bool,
 }
 
-export const HomePage = ({snapshot, hotline, actions: {createSnapshot, createScreening}}) => (
+export const HomePage = ({snapshot, hotline, hasError, actions: {createSnapshot, createScreening}}) => (
   <div>
     <div>
       <PageHeader
@@ -50,7 +50,7 @@ export const HomePage = ({snapshot, hotline, actions: {createSnapshot, createScr
           />
         }
       />
-      <BreadCrumb />
+      <BreadCrumb hasError={hasError}/>
     </div>
     <div className='shim'/>
     <div className='container'>
@@ -66,6 +66,7 @@ HomePage.propTypes = {
     createScreening: PropTypes.func,
     createSnapshot: PropTypes.func,
   }),
+  hasError: PropTypes.bool,
   hotline: PropTypes.bool,
   snapshot: PropTypes.bool,
 }

--- a/spec/javascripts/components/SnapshotPageSpec.jsx
+++ b/spec/javascripts/components/SnapshotPageSpec.jsx
@@ -9,9 +9,21 @@ describe('SnapshotPage', () => {
     return shallow(<SnapshotPage {...props} />, {disableLifecycleMethods: true})
   }
 
-  it('renders a breadCrumb', () => {
-    const snapshotPage = renderSnapshotPage({})
-    expect(snapshotPage.find('BreadCrumb').exists()).toEqual(true)
+  describe('BreadCrumb', () => {
+    it('renders a BreadCrumb', () => {
+      const snapshotPage = renderSnapshotPage({})
+      expect(snapshotPage.find('BreadCrumb').exists()).toEqual(true)
+    })
+    it('renders a BreadCrumb with back-to-dashboard-error className, when hasGenericErrors is true ', () => {
+      const snapshotPage = renderSnapshotPage({hasGenericErrors: true})
+      expect(snapshotPage.find('BreadCrumb').props().hasError).toEqual(true)
+      expect(snapshotPage.find('BreadCrumb').html()).toContain('back-to-dashboard-error')
+    })
+    it('renders a BreadCrumb without back-to-dashboard-error className, when hasGenericErrors is false ', () => {
+      const snapshotPage = renderSnapshotPage({hasGenericErrors: false})
+      expect(snapshotPage.find('BreadCrumb').props().hasError).toEqual(false)
+      expect(snapshotPage.find('BreadCrumb').html()).not.toContain('back-to-dashboard-error')
+    })
   })
 
   it('renders a SnapshotIntro', () => {

--- a/spec/javascripts/components/SnapshotPageSpec.jsx
+++ b/spec/javascripts/components/SnapshotPageSpec.jsx
@@ -9,21 +9,9 @@ describe('SnapshotPage', () => {
     return shallow(<SnapshotPage {...props} />, {disableLifecycleMethods: true})
   }
 
-  describe('BreadCrumb', () => {
-    it('renders a BreadCrumb', () => {
-      const snapshotPage = renderSnapshotPage({})
-      expect(snapshotPage.find('BreadCrumb').exists()).toEqual(true)
-    })
-    it('renders a BreadCrumb with back-to-dashboard-error className, when hasGenericErrors is true ', () => {
-      const snapshotPage = renderSnapshotPage({hasGenericErrors: true})
-      expect(snapshotPage.find('BreadCrumb').props().hasError).toEqual(true)
-      expect(snapshotPage.find('BreadCrumb').html()).toContain('back-to-dashboard-error')
-    })
-    it('renders a BreadCrumb without back-to-dashboard-error className, when hasGenericErrors is false ', () => {
-      const snapshotPage = renderSnapshotPage({hasGenericErrors: false})
-      expect(snapshotPage.find('BreadCrumb').props().hasError).toEqual(false)
-      expect(snapshotPage.find('BreadCrumb').html()).not.toContain('back-to-dashboard-error')
-    })
+  it('renders a BreadCrumb', () => {
+    const snapshotPage = renderSnapshotPage({})
+    expect(snapshotPage.find('Connect(BreadCrumb)').exists()).toBe(true)
   })
 
   it('renders a SnapshotIntro', () => {

--- a/spec/javascripts/configSpec.js
+++ b/spec/javascripts/configSpec.js
@@ -87,3 +87,10 @@ describe('intake config', () => {
     })
   })
 })
+
+describe('displayError', () => {
+  it('return error as true', () => {
+    const callDisplayError = window.displayError()
+    expect(callDisplayError.error).toEqual(true)
+  })
+})

--- a/spec/javascripts/views/HomePageSpec.jsx
+++ b/spec/javascripts/views/HomePageSpec.jsx
@@ -66,9 +66,23 @@ describe('HomePage', () => {
       expect(homePage.find('Connect(ScreeningsTable)').length).toBe(1)
     })
   })
-  it('renders a breadCrumb', () => {
-    const props = {snapshot: true, hotline: true, actions: {}}
-    const homePage = shallow(<HomePage {...props}/>)
-    expect(homePage.find('BreadCrumb').exists()).toEqual(true)
+  describe('BreadCrumb', () => {
+    it('renders a BreadCrumb', () => {
+      const props = {snapshot: true, hotline: true, hasError: true, actions: {}}
+      const homePage = shallow(<HomePage {...props}/>)
+      expect(homePage.find('BreadCrumb').exists()).toEqual(true)
+    })
+    it('renders a BreadCrumb with back-to-dashboard-error className, when hasError is true ', () => {
+      const props = {snapshot: true, hotline: true, hasError: true, actions: {}}
+      const homePage = shallow(<HomePage {...props}/>)
+      expect(homePage.find('BreadCrumb').props().hasError).toEqual(true)
+      expect(homePage.find('BreadCrumb').html()).toContain('back-to-dashboard-error')
+    })
+    it('renders a BreadCrumb without back-to-dashboard-error className, when hasError is false ', () => {
+      const props = {snapshot: true, hotline: true, hasError: false, actions: {}}
+      const homePage = shallow(<HomePage {...props}/>)
+      expect(homePage.find('BreadCrumb').props().hasError).toEqual(false)
+      expect(homePage.find('BreadCrumb').html()).not.toContain('back-to-dashboard-error')
+    })
   })
 })

--- a/spec/javascripts/views/HomePageSpec.jsx
+++ b/spec/javascripts/views/HomePageSpec.jsx
@@ -66,23 +66,9 @@ describe('HomePage', () => {
       expect(homePage.find('Connect(ScreeningsTable)').length).toBe(1)
     })
   })
-  describe('BreadCrumb', () => {
-    it('renders a BreadCrumb', () => {
-      const props = {snapshot: true, hotline: true, hasError: true, actions: {}}
-      const homePage = shallow(<HomePage {...props}/>)
-      expect(homePage.find('BreadCrumb').exists()).toEqual(true)
-    })
-    it('renders a BreadCrumb with back-to-dashboard-error className, when hasError is true ', () => {
-      const props = {snapshot: true, hotline: true, hasError: true, actions: {}}
-      const homePage = shallow(<HomePage {...props}/>)
-      expect(homePage.find('BreadCrumb').props().hasError).toEqual(true)
-      expect(homePage.find('BreadCrumb').html()).toContain('back-to-dashboard-error')
-    })
-    it('renders a BreadCrumb without back-to-dashboard-error className, when hasError is false ', () => {
-      const props = {snapshot: true, hotline: true, hasError: false, actions: {}}
-      const homePage = shallow(<HomePage {...props}/>)
-      expect(homePage.find('BreadCrumb').props().hasError).toEqual(false)
-      expect(homePage.find('BreadCrumb').html()).not.toContain('back-to-dashboard-error')
-    })
+  it('renders a BreadCrumb', () => {
+    const props = {snapshot: true, hotline: true, actions: {}}
+    const homePage = shallow(<HomePage {...props}/>)
+    expect(homePage.find('Connect(BreadCrumb)').exists()).toBe(true)
   })
 })


### PR DESCRIPTION
### Jira Story

- [Make breadcrumb link visible](https://osi-cwds.atlassian.net/browse/HOT-2564)

## Description
Make breadcrumb link visible when error banner is displayed.  

Before Fix:
![screen shot 2018-09-25 at 3 02 36 pm](https://user-images.githubusercontent.com/24608948/46045933-0ee09880-c0d4-11e8-9519-fed26fc75c83.png)


After Fix:
![screen shot 2018-09-25 at 3 01 17 pm](https://user-images.githubusercontent.com/24608948/46045903-f3758d80-c0d3-11e8-99ff-061c461b7b18.png)
![screen shot 2018-09-25 at 3 00 55 pm](https://user-images.githubusercontent.com/24608948/46045904-f7091480-c0d3-11e8-9b79-92551ccfc9e7.png)
![screen shot 2018-09-25 at 3 00 35 pm](https://user-images.githubusercontent.com/24608948/46045907-fa040500-c0d3-11e8-911a-bc7744e4e213.png)

**Note**: Steps for tester to trigger error banner is documented in JIRA. 

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

