### PR TITLE
Hot-1758-inconsistent-labelling

### DIFF
--- a/app/javascript/screenings/ScreeningsTable.jsx
+++ b/app/javascript/screenings/ScreeningsTable.jsx
@@ -51,9 +51,9 @@ class ScreeningsTable extends React.Component {
           <TableHeaderColumn headerTitle={false} dataField='screening_decision' dataFormat={decisionType} dataSort={false} tdStyle={textWrap}>
           Type/Decision</TableHeaderColumn>
           <TableHeaderColumn headerTitle={false} dataField='screening_status' dataSort={true}>Status</TableHeaderColumn>
-          <TableHeaderColumn headerTitle={false} dataField='assignee' tdStyle= {textWrap} dataSort={false}>Assignee</TableHeaderColumn>
+          <TableHeaderColumn headerTitle={false} dataField='assignee' tdStyle= {textWrap} dataSort={false}>Assigned Social Worker</TableHeaderColumn>
           <TableHeaderColumn headerTitle={false} dataField='started_at' dataFormat={reportDateAndTime} dataSort={true} tdStyle={textWrap}>
-          Report Date and Time</TableHeaderColumn>
+          Screening Start Date/Time</TableHeaderColumn>
         </BootstrapTable>
       </div>
     )

--- a/spec/features/home_page_spec.rb
+++ b/spec/features/home_page_spec.rb
@@ -117,7 +117,7 @@ feature 'home page' do
         visit root_path(accessCode: access_code)
       end
 
-      it 'screenings can be sorted by clickable name, status, and report date and time' do
+      it 'screenings can be sorted by clickable name, status, and Screening Start Date/Time' do
         expect(page).to have_title 'Intake'
         expect(page).to have_button 'Start Screening'
 
@@ -125,13 +125,13 @@ feature 'home page' do
           expect(page).to have_css('th', text: 'Screening Name')
           expect(page).to have_css('th', text: 'Type/Decision')
           expect(page).to have_css('th', text: 'Status')
-          expect(page).to have_css('th', text: 'Assignee')
-          expect(page).to have_css('th', text: 'Report Date and Time')
+          expect(page).to have_css('th', text: 'Assigned Social Worker')
+          expect(page).to have_css('th', text: 'Screening Start Date/Time')
         end
 
         rows = all('tr')
         within 'tbody' do
-          # 'default ordered by "Report Date and Time", in descending order'
+          # 'default ordered by "Screening Start Date/Time", in descending order'
           within rows[1] do
             expect(page).to have_content('Other submitted', normalize_ws: true)
             expect(find_all('td').last).to have_content('')
@@ -177,12 +177,12 @@ feature 'home page' do
         end
 
         within 'thead' do
-          find('th', text: 'Report Date and Time').find('.order').click
+          find('th', text: 'Screening Start Date/Time').find('.order').click
         end
 
         rows = all('tr')
         within 'tbody' do
-          # 'ordered list by "Report Date and Time", ascending order'
+          # 'ordered list by "Screening Start Date/Times", ascending order'
           within rows[1] do
             expect(find_all('td').last).to have_text('08/17/2018')
           end


### PR DESCRIPTION
### Inconsistent labeling between Screening card and Landing Page Index

- [Name of Story HOT-1758](https://osi-cwds.atlassian.net/browse/HOT-1758)

## Description
<!--- Landing page and screening info card labels should show Assigned Social Worker and Screening Start Date/Time. -->

## Tests
- [ ] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ X] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [X ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [X ] My code follows the code style of this project.
- [ X] I have ran all tests for the project.
- [ X] I have ran lint/rubocop check for the changed/new files.
- [ X] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ X] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

