### PR TITLE
HOT-2486 - Fix typo in CSEC types

### DIFF
--- a/app/javascript/enums/CSECTypes.js
+++ b/app/javascript/enums/CSECTypes.js
@@ -4,8 +4,7 @@ const CSEC_TYPES = Object.freeze([
   'Victim During Foster Care',
   'Victim in Open Case not in Foster Care',
   'Victim while Absent from Placement',
-  'Victim with Closed Case',
-  'Rcv ILP Svcs',
+  'Victim with Closed Case, Rcv ILP Svcs',
 ])
 
 export default CSEC_TYPES


### PR DESCRIPTION
### Jira Story

- [Cannot add more than 5 CSEC types HOT-2486](https://osi-cwds.atlassian.net/browse/HOT-2486)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This fixes a typo in our CSEC Type enum, where one of the types was accidentally split at a comma. More comments on how this could have been avoided are in the story, but for now, we are just patch the surface issue.

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->
The only way to test this would be with a feature test, which would not catch the mismatch between our Enum and actual LOV values anyway. I did manually test editing, saving, and displaying CSEC types on a Victim participant.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

