### PR TITLE
SNAP-661 - Clear old results when hitting search submit

### DIFF
--- a/app/javascript/common/search/Autocompleter.jsx
+++ b/app/javascript/common/search/Autocompleter.jsx
@@ -51,7 +51,8 @@ export default class Autocompleter extends Component {
   }
 
   handleSubmit() {
-    const {searchTerm} = this.props
+    const {onClear, searchTerm} = this.props
+    onClear()
     this.searchAndFocus(searchTerm, this.constructAddress())
   }
 

--- a/spec/javascripts/components/common/search/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/search/AutocompleterSpec.jsx
@@ -421,6 +421,24 @@ describe('<Autocompleter />', () => {
 
         expect(autocompleter.state().menuVisible).toEqual(true)
       })
+
+      it('clears old results when button is submitted', () => {
+        const isAddressIncluded = true
+        const onClear = jasmine.createSpy('onClear')
+        const autocompleter = renderAutocompleter({
+          onClear,
+          isAddressIncluded,
+          searchTerm: '',
+          searchAddress: '123 Main St',
+          searchCity: 'Sac Town',
+          searchCounty: 'Sacramento',
+        })
+        const searchByAddress = autocompleter.find('SearchByAddress')
+
+        searchByAddress.props().onSubmit()
+
+        expect(onClear).toHaveBeenCalled()
+      })
     })
   })
 


### PR DESCRIPTION
### Jira Story

- [Search with Address SNAP-661](https://osi-cwds.atlassian.net/browse/SNAP-661)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This is a small UX tweak on top of the existing search with address behavior. When you click the search submit button, we clear old results. This helps avoid confusion, especially when the new query has no matches.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

