### PR TITLE
SNAP-661 - Clear address search when leaving Hotline

### DIFF
--- a/app/javascript/actions/peopleSearchActions.js
+++ b/app/javascript/actions/peopleSearchActions.js
@@ -8,6 +8,8 @@ export const SET_SEARCH_COUNTY = 'PEOPLE_SEARCH/SET_SEARCH_COUNTY'
 export const LOAD_MORE_RESULTS = 'PEOPLE_SEARCH/LOAD_MORE_RESULTS'
 export const LOAD_MORE_RESULTS_COMPLETE = 'PEOPLE_SEARCH/LOAD_MORE_RESULTS_COMPLETE'
 export const TOGGLE_ADDRESS_SEARCH = 'TOGGLE_ADDRESS_SEARCH'
+export const RESET_ADDRESS_SEARCH = 'RESET_ADDRESS_SEARCH'
+
 export const setSearchTerm = (searchTerm) => ({
   type: SET_SEARCH_TERM,
   payload: {searchTerm},
@@ -55,4 +57,7 @@ export const clear = () => ({
 })
 export const toggleAddressSearch = () => ({
   type: TOGGLE_ADDRESS_SEARCH,
+})
+export const resetAddressSearch = () => ({
+  type: RESET_ADDRESS_SEARCH,
 })

--- a/app/javascript/containers/common/PersonSearchFormContainer.js
+++ b/app/javascript/containers/common/PersonSearchFormContainer.js
@@ -20,6 +20,7 @@ import {
   clear,
   loadMoreResults,
   toggleAddressSearch,
+  resetAddressSearch,
 } from 'actions/peopleSearchActions'
 import {canUserAddClient} from 'utils/authorization'
 import {getStaffIdSelector} from 'selectors/userInfoSelectors'
@@ -51,6 +52,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   const onChangeAddress = (value) => dispatch(setSearchAddress(value))
   const onChangeCity = (value) => dispatch(setSearchCity(value))
   const onChangeCounty = (value) => dispatch(setSearchCounty(value))
+  const onResetAddressSearch = () => dispatch(resetAddressSearch())
   const onSearch = (value, address) => dispatch(search(value, ownProps.isClientOnly, address))
   const onLoadMoreResults = (address) => dispatch(loadMoreResults(ownProps.isClientOnly, address))
   const onToggleAddressSearch = () => dispatch(toggleAddressSearch())
@@ -63,6 +65,7 @@ const mapDispatchToProps = (dispatch, ownProps) => {
     onChangeCounty,
     onLoadMoreResults,
     onToggleAddressSearch,
+    onResetAddressSearch,
     dispatch,
   }
 }

--- a/app/javascript/reducers/peopleSearchReducer.js
+++ b/app/javascript/reducers/peopleSearchReducer.js
@@ -5,6 +5,7 @@ import {
   PEOPLE_SEARCH_CLEAR,
   PEOPLE_SEARCH_FETCH,
   PEOPLE_SEARCH_FETCH_COMPLETE,
+  RESET_ADDRESS_SEARCH,
   SET_SEARCH_TERM,
   SET_SEARCH_ADDRESS,
   SET_SEARCH_CITY,
@@ -22,6 +23,7 @@ const initialState = fromJS({
   searchAddress: '',
   searchCity: '',
   searchCounty: '',
+  defaultCounty: null,
 })
 export default createReducer(initialState, {
   [PEOPLE_SEARCH_FETCH](state, {payload: {searchTerm}}) {
@@ -62,7 +64,8 @@ export default createReducer(initialState, {
     return state.set('searchCounty', county)
   },
   [FETCH_USER_INFO_COMPLETE](state, {payload: {userInfo: {county}}}) {
-    return state.get('searchCounty') === '' ? state.set('searchCounty', county) : state
+    const newState = state.set('defaultCounty', county)
+    return newState.get('searchCounty') === '' ? newState.set('searchCounty', county) : newState
   },
   [LOAD_MORE_RESULTS_COMPLETE](state, {payload: {results}, error}) {
     if (error) {
@@ -73,5 +76,12 @@ export default createReducer(initialState, {
   },
   [TOGGLE_ADDRESS_SEARCH](state) {
     return state.set('isAddressIncluded', !state.get('isAddressIncluded'))
+  },
+  [RESET_ADDRESS_SEARCH](state) {
+    return state
+      .set('searchCounty', state.get('defaultCounty') || '')
+      .set('searchCity', '')
+      .set('searchAddress', '')
+      .set('isAddressIncluded', false)
   },
 })

--- a/app/javascript/views/people/PersonSearchForm.jsx
+++ b/app/javascript/views/people/PersonSearchForm.jsx
@@ -8,6 +8,7 @@ class PersonSearchForm extends React.Component {
   componentWillUnmount() {
     this.props.onClear()
     this.props.onChange('')
+    this.props.onResetAddressSearch()
   }
 
   render() {
@@ -52,6 +53,7 @@ PersonSearchForm.propTypes = {
   onChangeCounty: PropTypes.func.isRequired,
   onClear: PropTypes.func.isRequired,
   onLoadMoreResults: PropTypes.func,
+  onResetAddressSearch: PropTypes.func,
   onSearch: PropTypes.func,
   onSelect: PropTypes.func,
   results: PropTypes.array,

--- a/spec/javascripts/reducers/peopleSearchReducerSpec.js
+++ b/spec/javascripts/reducers/peopleSearchReducerSpec.js
@@ -4,6 +4,7 @@ import {
   fetchFailure,
   fetchSuccess,
   toggleAddressSearch,
+  resetAddressSearch,
   search,
   setSearchTerm,
   setSearchAddress,
@@ -213,16 +214,37 @@ describe('peopleSearchReducer', () => {
     it('defaults the search county to the county of the user', () => {
       const action = fetchUserInfoSuccess({county: 'Los Angeles'})
       const initialState = fromJS({searchCounty: ''})
-      expect(
-        peopleSearchReducer(initialState, action).get('searchCounty')
-      ).toEqual('Los Angeles')
+      const newState = peopleSearchReducer(initialState, action)
+      expect(newState.get('searchCounty')).toEqual('Los Angeles')
+      expect(newState.get('defaultCounty')).toEqual('Los Angeles')
     })
     it('does not override an explicit user selection', () => {
       const action = fetchUserInfoSuccess({county: 'Los Angeles'})
       const initialState = fromJS({searchCounty: 'Sutter'})
-      expect(
-        peopleSearchReducer(initialState, action).get('searchCounty')
-      ).toEqual('Sutter')
+      const newState = peopleSearchReducer(initialState, action)
+      expect(newState.get('searchCounty')).toEqual('Sutter')
+      expect(newState.get('defaultCounty')).toEqual('Los Angeles')
+    })
+  })
+
+  describe('on RESET_ADDRESS_SEARCH', () => {
+    it('clears everything and sets county to default', () => {
+      const action = resetAddressSearch()
+      const initialState = fromJS({
+        searchCounty: 'Yolo',
+        searchCity: 'Davis',
+        searchAddress: '123 Main St',
+        isAddressIncluded: true,
+        defaultCounty: 'Sacramento',
+      })
+      const newState = peopleSearchReducer(initialState, action)
+      expect(newState).toEqualImmutable(fromJS({
+        searchCounty: 'Sacramento',
+        searchCity: '',
+        searchAddress: '',
+        isAddressIncluded: false,
+        defaultCounty: 'Sacramento',
+      }))
     })
   })
 })

--- a/spec/javascripts/reducers/peopleSearchReducerSpec.js
+++ b/spec/javascripts/reducers/peopleSearchReducerSpec.js
@@ -246,5 +246,12 @@ describe('peopleSearchReducer', () => {
         defaultCounty: 'Sacramento',
       }))
     })
+    it('sets county to empty if there is no default', () => {
+      const action = resetAddressSearch()
+      const initialState = fromJS({defaultCounty: null})
+      const newState = peopleSearchReducer(initialState, action)
+      expect(newState.get('searchCounty')).toEqual('')
+      expect(newState.get('defaultCounty')).toEqual(null)
+    })
   })
 })

--- a/spec/javascripts/store/storeSpec.js
+++ b/spec/javascripts/store/storeSpec.js
@@ -36,6 +36,7 @@ describe('Store', () => {
         searchCounty: '',
         searchCity: '',
         searchAddress: '',
+        defaultCounty: null,
       },
       relationshipForm: {},
       relationships: [],

--- a/spec/javascripts/views/people/PersonSearchFormSpec.jsx
+++ b/spec/javascripts/views/people/PersonSearchFormSpec.jsx
@@ -17,6 +17,7 @@ describe('PersonSearchForm', () => {
     onChangeCity = () => null,
     onChangeCounty = () => null,
     onClear = () => null,
+    onResetAddressSearch = () => null,
     onSearch = () => null,
     searchPrompt = '',
     canCreateNewPerson = false,
@@ -30,6 +31,7 @@ describe('PersonSearchForm', () => {
       onChangeCity,
       onChangeCounty,
       onClear,
+      onResetAddressSearch,
       onSearch,
       searchPrompt,
       canCreateNewPerson,
@@ -41,10 +43,12 @@ describe('PersonSearchForm', () => {
   it('componentWillUnmount', () => {
     const onClear = jasmine.createSpy('onClear')
     const onChange = jasmine.createSpy('onChange')
-    const component = renderPersonSearchForm({onClear, onChange})
+    const onResetAddressSearch = jasmine.createSpy('onResetAddressSearch')
+    const component = renderPersonSearchForm({onClear, onChange, onResetAddressSearch})
     component.unmount()
     expect(onClear).toHaveBeenCalled()
     expect(onChange).toHaveBeenCalled()
+    expect(onResetAddressSearch).toHaveBeenCalled()
   })
 
   it('renders a card anchor', () => {


### PR DESCRIPTION
### Jira Story

- [Search with Address SNAP-661](https://osi-cwds.atlassian.net/browse/SNAP-661)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This is another UX tweak which resets the address search state when the user leaves Hotline. This fixes an issue where the user could start a screening, check Include Address, fill out fields, return to their Case Load dashboard, and start a new screening without clearing the address search fields.

Now, every new screening has a fresh start.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

