### PR TITLE
SNAP-661 Check searchable when toggling off address search

### DIFF
--- a/app/javascript/common/search/Autocompleter.jsx
+++ b/app/javascript/common/search/Autocompleter.jsx
@@ -60,7 +60,7 @@ export default class Autocompleter extends Component {
     const {onClear, searchTerm, onToggleAddressSearch} = this.props
 
     onClear()
-    if (!event.target.checked) { this.searchAndFocus(searchTerm) }
+    if (!event.target.checked && this.isSearchable(this.props.searchTerm)) { this.searchAndFocus(searchTerm) }
     onToggleAddressSearch(event)
   }
 
@@ -69,9 +69,7 @@ export default class Autocompleter extends Component {
   }
 
   hideMenu() {
-    if (this.inputRef) {
-      this.inputRef.setAttribute('aria-activedescendant', '')
-    }
+    if (this.inputRef) { this.inputRef.setAttribute('aria-activedescendant', '') }
     this.setState({menuVisible: false})
   }
 

--- a/app/javascript/reducers/peopleSearchReducer.js
+++ b/app/javascript/reducers/peopleSearchReducer.js
@@ -25,6 +25,13 @@ const initialState = fromJS({
   searchCounty: '',
   defaultCounty: null,
 })
+
+const resetAddressSearch = (state) => state
+  .set('searchCounty', state.get('defaultCounty') || '')
+  .set('searchCity', '')
+  .set('searchAddress', '')
+  .set('isAddressIncluded', false)
+
 export default createReducer(initialState, {
   [PEOPLE_SEARCH_FETCH](state, {payload: {searchTerm}}) {
     return state.set('searchTerm', searchTerm)
@@ -75,13 +82,9 @@ export default createReducer(initialState, {
     }
   },
   [TOGGLE_ADDRESS_SEARCH](state) {
-    return state.set('isAddressIncluded', !state.get('isAddressIncluded'))
+    return state.get('isAddressIncluded') ?
+      resetAddressSearch(state) :
+      state.set('isAddressIncluded', true)
   },
-  [RESET_ADDRESS_SEARCH](state) {
-    return state
-      .set('searchCounty', state.get('defaultCounty') || '')
-      .set('searchCity', '')
-      .set('searchAddress', '')
-      .set('isAddressIncluded', false)
-  },
+  [RESET_ADDRESS_SEARCH]: resetAddressSearch,
 })

--- a/spec/javascripts/components/common/search/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/search/AutocompleterSpec.jsx
@@ -442,6 +442,39 @@ describe('<Autocompleter />', () => {
     })
   })
 
+  describe('when address search is toggled off', () => {
+    let onSearch
+    const isAddressIncluded = true
+
+    beforeEach(() => {
+      onSearch = jasmine.createSpy('onSearch')
+    })
+
+    it('returns to autocomplete by searching immediately', () => {
+      const autocompleter = renderAutocompleter({
+        onSearch,
+        isAddressIncluded,
+        searchTerm: 'ABC',
+      })
+      autocompleter.find('SearchByAddress').props().toggleAddressSearch({target: {checked: false}})
+
+      expect(onSearch).toHaveBeenCalled()
+      expect(autocompleter.state().menuVisible).toEqual(true)
+    })
+
+    it('does not search when the query not searchable', () => {
+      const autocompleter = renderAutocompleter({
+        onSearch,
+        isAddressIncluded,
+        searchTerm: '',
+      })
+      autocompleter.find('SearchByAddress').props().toggleAddressSearch({target: {checked: false}})
+
+      expect(onSearch).not.toHaveBeenCalled()
+      expect(autocompleter.state().menuVisible).toEqual(false)
+    })
+  })
+
   describe('renderInput', () => {
     it('renders an input element', () => {
       const autocompleter = renderAutocompleter({})

--- a/spec/javascripts/reducers/peopleSearchReducerSpec.js
+++ b/spec/javascripts/reducers/peopleSearchReducerSpec.js
@@ -194,19 +194,38 @@ describe('peopleSearchReducer', () => {
     const action = toggleAddressSearch()
     it('toggle isAddressIncluded flag from false to true', () => {
       const initialState = fromJS({isAddressIncluded: false})
-      expect(peopleSearchReducer(initialState, action)).toEqualImmutable(
-        fromJS({
-          isAddressIncluded: true,
-        })
-      )
+      const newState = peopleSearchReducer(initialState, action)
+      expect(newState.get('isAddressIncluded')).toEqual(true)
     })
     it('toggle isAddressIncluded flag from true to false', () => {
       const initialState = fromJS({isAddressIncluded: true})
-      expect(peopleSearchReducer(initialState, action)).toEqualImmutable(
-        fromJS({
-          isAddressIncluded: false,
-        })
-      )
+      const newState = peopleSearchReducer(initialState, action)
+      expect(newState.get('isAddressIncluded')).toEqual(false)
+    })
+    it('clears everything and sets county to default', () => {
+      const action = resetAddressSearch()
+      const initialState = fromJS({
+        searchCounty: 'Yolo',
+        searchCity: 'Davis',
+        searchAddress: '123 Main St',
+        isAddressIncluded: true,
+        defaultCounty: 'Sacramento',
+      })
+      const newState = peopleSearchReducer(initialState, action)
+      expect(newState).toEqualImmutable(fromJS({
+        searchCounty: 'Sacramento',
+        searchCity: '',
+        searchAddress: '',
+        isAddressIncluded: false,
+        defaultCounty: 'Sacramento',
+      }))
+    })
+    it('sets county to empty if there is no default', () => {
+      const action = resetAddressSearch()
+      const initialState = fromJS({defaultCounty: null})
+      const newState = peopleSearchReducer(initialState, action)
+      expect(newState.get('searchCounty')).toEqual('')
+      expect(newState.get('defaultCounty')).toEqual(null)
     })
   })
 


### PR DESCRIPTION
### Jira Story

- [Search with Address SNAP-661](https://osi-cwds.atlassian.net/browse/SNAP-661)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
When we toggle off address search, we want to return to autocomplete behavior, and we were doing this by immediately triggering a search. If there is no search term, however, this queries a lot of generic results. Instead, we check to see if the term is searchable first, and we also clear the address fields while we are at it.

There is a known issue with this, where if there is no search term, you do not end up focused on the input field. Focusing on the input field is difficult in this situation, because it really really wants to open the results menu (includesAddressSearch has not yet had the time to clear in Redux). Fixing this would require a large refactor, so I think we need to live with it for now. (But if you have any ideas, let me know.)

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

