### PR TITLE
Snap-692 rails session not expiring fix 

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -7,9 +7,9 @@ Feature.with(:centralized_sessions) do
     port: ENV.fetch('REDIS_PORT', '6379'),
     db: 0,
     namespace: 'session'
-  }, expires_in: 4.hours
+  }, expire_after: 4.hours
 end
 
 Feature.without(:centralized_sessions) do
-  Rails.application.config.session_store :cookie_store, key: '_ca_intake_session'
+  Rails.application.config.session_store :cookie_store, key: '_ca_intake_session', expire_after: 4.hours
 end


### PR DESCRIPTION


### Intake Rails session not expiring after 4 hours

- [SNAP-692](https://osi-cwds.atlassian.net/browse/SNAP-692)

## Description
As a CARES Architect, I need the application to be secure so that users data is protected, including for the Intake application to time out after 4 hours of inactivity. 

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
This is part of the Rails config that isn't covered by tests.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

