### PR TITLE
Fix for blank options on Edit Relationship DropDown.

### DIFF
--- a/app/javascript/common/relationship/EditRelationshipForm.jsx
+++ b/app/javascript/common/relationship/EditRelationshipForm.jsx
@@ -62,7 +62,7 @@ const EditRelationshipForm = ({
                 value={editFormRelationship.relationship_type}
                 aria-label='Relationship Type'
                 onChange={({target}) => {
-                  onChange('relationship_type', parseInt(target.value, 10))
+                  onChange('relationship_type', target.value)
                   if (!isAbsentParentDisabled(type.secondary)) {
                     onChange('absent_parent_indicator', false)
                   }

--- a/app/javascript/reducers/relationshipFormReducer.js
+++ b/app/javascript/reducers/relationshipFormReducer.js
@@ -37,8 +37,15 @@ const buildRelationship = (state, {payload: {person, relationship}}) => {
   })
 }
 
-const setRelationshipForm = (state, {payload: {field, value}}) =>
-  state.setIn(['relationship', field], value)
+const setRelationshipForm = (state, {payload: {field, value}}) => {
+  if (field === 'relationship_type') {
+    if (value === '') {
+      return state
+    }
+    return state.setIn(['relationship', field], parseInt(value, 10))
+  }
+  return state.setIn(['relationship', field], value)
+}
 
 const updateRelationship = (state, {payload: {relationship}, error}) => {
   if (error) {

--- a/spec/javascripts/components/common/relationship/EditRelationshipFormSpec.jsx
+++ b/spec/javascripts/components/common/relationship/EditRelationshipFormSpec.jsx
@@ -92,7 +92,7 @@ describe('EditRelationshipForm', () => {
       render({onChange, ...props})
         .find('#edit_relationship')
         .simulate('change', {target: {value: '808'}})
-      expect(onChange).toHaveBeenCalledWith('relationship_type', 808)
+      expect(onChange).toHaveBeenCalledWith('relationship_type', '808')
     })
     it('expects same home status to change', () => {
       render({onChange, ...props})

--- a/spec/javascripts/reducers/relationshipFormReducerSpec.js
+++ b/spec/javascripts/reducers/relationshipFormReducerSpec.js
@@ -104,6 +104,24 @@ describe('relationshipFormReducer', () => {
           }})
       )
     })
+    it('sets relationshipType to previous state if empty option selected', () => {
+      const lastState = fromJS(relationshipForm)
+      const actionRelationshipTye = setRelationshipForm('relationship_type', '')
+      expect(relationshipFormReducer(lastState, actionRelationshipTye)).toEqualImmutable(
+        fromJS({
+          relationship: {
+            absent_parent_indicator: true,
+            client_id: 'ZXY123',
+            end_date: '2010-10-01',
+            id: '12345',
+            relationship_type: 190,
+            relative_id: 'ABC987',
+            reversed: false,
+            same_home_status: 'Y',
+            start_date: '1999-10-01',
+          }})
+      )
+    })
   })
 
   describe('on UPDATE_RELATIONSHIP_COMPLETE', () => {


### PR DESCRIPTION
### Jira Story

- [Disable SaveRelationship Button in EditRelationship Modal if blank option is selected in the Relationship Dropdown. HOT-2525](https://osi-cwds.atlassian.net/browse/HOT-2525)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This fixes the edit relationship dropdown when a blank option is selected. Previously when a blank option is selected the Application would break which the screen would show blank. Now the blank option cannot be selected and the options remains the same.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
