### PR TITLE
Snap 656 show csec data and tag

### DIFF
--- a/app/javascript/selectors/screening/personCSECFormSelectors.js
+++ b/app/javascript/selectors/screening/personCSECFormSelectors.js
@@ -18,10 +18,10 @@ export const getPersonCSECDetailsSelector = (state, personId) => {
 }
 
 export const getCSECRequireValidationSelector = (state, personId) => {
-  const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value'])
-  const roles = state.getIn(['peopleForm', personId, 'roles', 'value'], List()).toJS()
-  const csecDetails = selectCsec(state).get(personId)
-  if ((roles && screeningReportType && roles.includes('Victim') && screeningReportType === 'csec') || (csecDetails && csecDetails.size > 0)) {
+  const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value']) || ''
+  const roles = state.getIn(['peopleForm', personId, 'roles', 'value']) || List()
+  const csecDetails = selectCsec(state).get(personId) || List()
+  if ((roles.includes('Victim') && screeningReportType === 'csec') || csecDetails.size > 0) {
     return true
   }
   return false

--- a/app/javascript/selectors/screening/personCSECFormSelectors.js
+++ b/app/javascript/selectors/screening/personCSECFormSelectors.js
@@ -6,6 +6,7 @@ import {
   combineCompact,
   hasRequiredValuesCreate,
 } from 'utils/validator'
+import {selectCsec} from 'selectors/screening/personCardSelectors'
 
 export const getPersonCSECDetailsSelector = (state, personId) => {
   const person = state.getIn(['peopleForm', personId], Map())
@@ -19,7 +20,8 @@ export const getPersonCSECDetailsSelector = (state, personId) => {
 export const getCSECRequireValidationSelector = (state, personId) => {
   const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value'])
   const roles = state.getIn(['peopleForm', personId, 'roles', 'value'], List()).toJS()
-  if (roles && screeningReportType && roles.includes('Victim') && screeningReportType === 'csec') {
+  const csecDetails = selectCsec(state).get(personId)
+  if ((roles && screeningReportType && roles.includes('Victim') && screeningReportType === 'csec') || (csecDetails && csecDetails.size > 0)) {
     return true
   }
   return false

--- a/app/javascript/selectors/screening/personCardSelectors.js
+++ b/app/javascript/selectors/screening/personCardSelectors.js
@@ -4,6 +4,7 @@ import {SHOW_MODE} from 'actions/screeningPageActions'
 import {selectParticipants} from 'selectors/participantSelectors'
 import {participantFlag} from 'utils/accessIndicator'
 import nameFormatter from 'utils/nameFormatter'
+import {Maybe} from 'utils/maybe'
 
 export const getPersonNamesSelector = createSelector(
   selectParticipants,
@@ -44,6 +45,9 @@ export const getModeValueSelector = (state, personId) => {
   return screeningPage.getIn(['peopleCards', personId], SHOW_MODE)
 }
 
+const hasNoCsecEndate = (csecInfo) =>
+  csecInfo.some((value) => Maybe.of(value.get('end_date')).isNothing())
+
 export const selectInformationalMessage = (state, personId) => {
   const probationYouthInfo = selectProbationYouth(state).get(personId)
   const deceasedInfo = selectDeceased(state).get(personId)
@@ -52,7 +56,7 @@ export const selectInformationalMessage = (state, personId) => {
     return 'Deceased'
   } else if (probationYouthInfo) {
     return 'Probation Youth'
-  } else if (csecInfo && csecInfo.size > 0) {
+  } else if (csecInfo && csecInfo.size > 0 && hasNoCsecEndate(csecInfo)) {
     return 'CSEC'
   }
   return null

--- a/app/javascript/selectors/screening/personCardSelectors.js
+++ b/app/javascript/selectors/screening/personCardSelectors.js
@@ -45,7 +45,7 @@ export const getModeValueSelector = (state, personId) => {
   return screeningPage.getIn(['peopleCards', personId], SHOW_MODE)
 }
 
-const hasNoCsecEndate = (csecInfo) =>
+const hasNoCsecEndDate = (csecInfo) =>
   csecInfo.some((value) => Maybe.of(value.get('end_date')).isNothing())
 
 export const selectInformationalMessage = (state, personId) => {
@@ -56,7 +56,7 @@ export const selectInformationalMessage = (state, personId) => {
     return 'Deceased'
   } else if (probationYouthInfo) {
     return 'Probation Youth'
-  } else if (csecInfo && csecInfo.size > 0 && hasNoCsecEndate(csecInfo)) {
+  } else if (csecInfo && csecInfo.size > 0 && hasNoCsecEndDate(csecInfo)) {
     return 'CSEC'
   }
   return null

--- a/app/javascript/selectors/screening/personShowSelectors.js
+++ b/app/javascript/selectors/screening/personShowSelectors.js
@@ -19,6 +19,7 @@ import {getSSNErrors} from 'utils/ssnValidator'
 import {getZIPErrors} from 'utils/zipValidator'
 import moment from 'moment'
 import {systemCodeDisplayValue, selectCsecTypes} from 'selectors/systemCodeSelectors'
+import {selectCsec} from 'selectors/screening/personCardSelectors'
 
 const selectPersonOrEmpty = (state, personId) =>
   selectParticipant(state, personId).valueOrElse(Map())
@@ -181,7 +182,10 @@ export const getFormattedPersonInformationSelector = (state, personId) => {
   const approximateAge = personApproximateAge(person)
   const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value'])
   const roles = state.getIn(['peopleForm', personId, 'roles', 'value'], List()).toJS()
-  const showCSEC = roles && screeningReportType && roles.includes('Victim') && screeningReportType === 'csec'
+  const csecDetails = selectCsec(state).get(personId)
+  const showCSEC = (
+    roles && screeningReportType && roles.includes('Victim') && screeningReportType === 'csec') || (csecDetails && csecDetails.size > 0
+    )
   return fromJS({
     approximateAge: approximateAge,
     CSECTypes: {value: csecTypesSelector(state, personId), errors: []},

--- a/app/javascript/selectors/screening/personShowSelectors.js
+++ b/app/javascript/selectors/screening/personShowSelectors.js
@@ -176,14 +176,20 @@ const personApproximateAge = (person) => {
   }
 }
 
+const showCSEC = (state, personId) => {
+  const roles = state.getIn(['peopleForm', personId, 'roles', 'value']) || List()
+  const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value'])
+  const csecDetails = selectCsec(state).get(personId) || List()
+  if ((roles.includes('Victim') && screeningReportType === 'csec') || csecDetails.size > 0) {
+    return true
+  }
+  return false
+}
+
 export const getFormattedPersonInformationSelector = (state, personId) => {
   const person = selectPersonOrEmpty(state, personId)
   const legacyDescriptor = person.get('legacy_descriptor')
   const approximateAge = personApproximateAge(person)
-  const roles = state.getIn(['peopleForm', personId, 'roles', 'value']) || List()
-  const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value'])
-  const csecDetails = selectCsec(state).get(personId) || List()
-  const showCSEC = (roles.includes('Victim') && screeningReportType === 'csec') || csecDetails.size > 0
   return fromJS({
     approximateAge: approximateAge,
     CSECTypes: {value: csecTypesSelector(state, personId), errors: []},
@@ -199,7 +205,7 @@ export const getFormattedPersonInformationSelector = (state, personId) => {
     roles: {value: person.get('roles', List()), errors: []},
     ssn: {value: ssnFormatter(person.get('ssn')), errors: []},
     alertErrorMessage: getPersonAlertErrorMessageSelector(state, personId),
-    showCSEC: showCSEC,
+    showCSEC: showCSEC(state, personId),
   })
 }
 

--- a/app/javascript/selectors/screening/personShowSelectors.js
+++ b/app/javascript/selectors/screening/personShowSelectors.js
@@ -183,9 +183,7 @@ export const getFormattedPersonInformationSelector = (state, personId) => {
   const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value'])
   const roles = state.getIn(['peopleForm', personId, 'roles', 'value'], List()).toJS()
   const csecDetails = selectCsec(state).get(personId)
-  const showCSEC = (
-    roles && screeningReportType && roles.includes('Victim') && screeningReportType === 'csec') || (csecDetails && csecDetails.size > 0
-    )
+  const showCSEC = (roles && screeningReportType && roles.includes('Victim') && screeningReportType === 'csec') || (csecDetails && csecDetails.size > 0)
   return fromJS({
     approximateAge: approximateAge,
     CSECTypes: {value: csecTypesSelector(state, personId), errors: []},

--- a/app/javascript/selectors/screening/personShowSelectors.js
+++ b/app/javascript/selectors/screening/personShowSelectors.js
@@ -180,10 +180,10 @@ export const getFormattedPersonInformationSelector = (state, personId) => {
   const person = selectPersonOrEmpty(state, personId)
   const legacyDescriptor = person.get('legacy_descriptor')
   const approximateAge = personApproximateAge(person)
-  const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value'])
-  const roles = state.getIn(['peopleForm', personId, 'roles', 'value'], List()).toJS()
-  const csecDetails = selectCsec(state).get(personId)
-  const showCSEC = (roles && screeningReportType && roles.includes('Victim') && screeningReportType === 'csec') || (csecDetails && csecDetails.size > 0)
+  const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value']) || ''
+  const roles = state.getIn(['peopleForm', personId, 'roles', 'value']) || List()
+  const csecDetails = selectCsec(state).get(personId) || List()
+  const showCSEC = (roles.includes('Victim') && screeningReportType === 'csec') || csecDetails.size > 0
   return fromJS({
     approximateAge: approximateAge,
     CSECTypes: {value: csecTypesSelector(state, personId), errors: []},

--- a/app/javascript/selectors/screening/personShowSelectors.js
+++ b/app/javascript/selectors/screening/personShowSelectors.js
@@ -180,8 +180,8 @@ export const getFormattedPersonInformationSelector = (state, personId) => {
   const person = selectPersonOrEmpty(state, personId)
   const legacyDescriptor = person.get('legacy_descriptor')
   const approximateAge = personApproximateAge(person)
-  const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value']) || ''
   const roles = state.getIn(['peopleForm', personId, 'roles', 'value']) || List()
+  const screeningReportType = state.getIn(['screeningInformationForm', 'report_type', 'value'])
   const csecDetails = selectCsec(state).get(personId) || List()
   const showCSEC = (roles.includes('Victim') && screeningReportType === 'csec') || csecDetails.size > 0
   return fromJS({

--- a/spec/javascripts/containers/screenings/PersonShowContainerSpec.jsx
+++ b/spec/javascripts/containers/screenings/PersonShowContainerSpec.jsx
@@ -63,7 +63,7 @@ describe('PersonShowContainer', () => {
         errors: [],
       },
       ssn: {value: '123-45-6789', errors: []},
-      showCSEC: undefined,
+      showCSEC: true,
     })
   })
 })

--- a/spec/javascripts/selectors/screening/personCSECFormSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/personCSECFormSelectorsSpec.js
@@ -79,6 +79,31 @@ describe('personCSECFormSelectors', () => {
       const state = fromJS({peopleForm, screeningInformationForm})
       expect(getCSECRequireValidationSelector(state, 'one')).toEqual(true)
     })
+
+    it('returns false if csec details are empty', () => {
+      const participants = [
+        {
+          id: '1',
+          csec: [],
+        },
+      ]
+      const state = fromJS({participants})
+      expect(getCSECRequireValidationSelector(state, '1')).toEqual(false)
+    })
+
+    it('returns true if csec details are not empty', () => {
+      const participants = [
+        {
+          id: '1',
+          csec: [{
+            csec_code_id: '1',
+            start_date: '1/1/1111',
+          }],
+        },
+      ]
+      const state = fromJS({participants})
+      expect(getCSECRequireValidationSelector(state, '1')).toEqual(true)
+    })
   })
 
   describe('getVisibleErrorsSelector', () => {

--- a/spec/javascripts/selectors/screening/personCardSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/personCardSelectorsSpec.js
@@ -158,6 +158,18 @@ describe('personCardSelectors', () => {
           participant_id: undefined,
           csec_code_id: '1',
           start_date: '1/1/1111',
+        }],
+      },
+      {
+        id: '129',
+        first_name: 'Jane',
+        middle_name: '',
+        last_name: 'Public',
+        csec: [{
+          id: undefined,
+          participant_id: undefined,
+          csec_code_id: '1',
+          start_date: '1/1/1111',
           end_date: '1/1/1111',
         }],
       },
@@ -173,9 +185,14 @@ describe('personCardSelectors', () => {
         expect(selectInformationalMessage(state, '127')).toEqual(null)
       })
     })
-    describe('when a person has any csec details ', () => {
+    describe('when a person has csec details but no end date', () => {
       it('returns message: CSEC', () => {
         expect(selectInformationalMessage(state, '128')).toEqual('CSEC')
+      })
+    })
+    describe('when a person has csec details and end date', () => {
+      it('returns no message', () => {
+        expect(selectInformationalMessage(state, '129')).toEqual(null)
       })
     })
     describe('when a person has date_of_death', () => {

--- a/spec/javascripts/selectors/screening/personShowSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/personShowSelectorsSpec.js
@@ -33,7 +33,7 @@ describe('personShowSelectors', () => {
         races: undefined,
         ethnicity: undefined,
         alertErrorMessage: undefined,
-        showCSEC: undefined,
+        showCSEC: false,
       }))
     })
 

--- a/spec/javascripts/selectors/screening/personShowSelectorsSpec.js
+++ b/spec/javascripts/selectors/screening/personShowSelectorsSpec.js
@@ -46,6 +46,27 @@ describe('personShowSelectors', () => {
         .toEqual('Client ID 1-4 in CWS-CMS')
     })
 
+    it('includes the csec details for the given person', () => {
+      const participants = [
+        {id: '1', csec: [{csec_code_id: '14', start_date: '1111-11-11'}]},
+      ]
+      const state = fromJS({participants})
+      expect(getFormattedPersonInformationSelector(state, '1').get('csecStartedAt'))
+        .toEqual(fromJS({
+          value: '11/11/1111',
+          errors: [],
+        }))
+    })
+
+    it('does not include the csec details not  provided for the given person', () => {
+      const participants = [
+        {id: '1', csec: [{csec_code_id: '14'}]},
+      ]
+      const state = fromJS({participants})
+      expect(getFormattedPersonInformationSelector(state, '1').get('csecEndedAt'))
+        .toEqual(undefined)
+    })
+
     it('includes the display name for the given person', () => {
       const participants = [{id: '1', first_name: 'John', middle_name: 'Q', last_name: 'Public'}]
       const state = fromJS({participants})


### PR DESCRIPTION

### Jira Story

- [Show CSEC data in appropriate fields](https://osi-cwds.atlassian.net/browse/SNAP-656)

## Description
As per PO request the changes made in this PR changes will allow us to

- Show the CSEC tag on if it is active (don't show if end_date exists)
- Show the CSEC details regardless of active or inactive


## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

_**Before fix in Integration even it has end_date tag is shown and no details are displayed in person card.**_
![screen shot 2018-10-01 at 2 34 43 pm](https://user-images.githubusercontent.com/30534102/46318091-2b744900-c58a-11e8-91cc-70ecf55e59f6.png)

_**After the fix in local when it has end_date tag is not shown and details are displayed in person card.**_
![screen shot 2018-10-01 at 2 34 58 pm](https://user-images.githubusercontent.com/30534102/46318092-2b744900-c58a-11e8-968a-b0aa8b55e347.png)