### PR TITLE
HOT-1546 - Remove State of California from some address dropdowns

### DIFF
--- a/app/javascript/common/county/CountiesInjector.jsx
+++ b/app/javascript/common/county/CountiesInjector.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
-import {selectCounties} from 'selectors/systemCodeSelectors'
+import {selectCountiesWithoutStateOfCalifornia} from 'selectors/systemCodeSelectors'
 
 const mapStateToProps = (state, ownProps) => ({
-  counties: selectCounties(state).toJS(),
+  counties: selectCountiesWithoutStateOfCalifornia(state).toJS(),
   ...ownProps,
 })
 

--- a/app/javascript/containers/screenings/CrossReportFormContainer.jsx
+++ b/app/javascript/containers/screenings/CrossReportFormContainer.jsx
@@ -37,7 +37,7 @@ import {
   getCommunityCareLicensingFormSelector,
   getUserCountySelector,
 } from 'selectors/screening/crossReportFormSelectors'
-import {selectCounties} from 'selectors/systemCodeSelectors'
+import {selectCountiesWithoutStateOfCalifornia} from 'selectors/systemCodeSelectors'
 
 export const cardName = 'cross-report-card'
 
@@ -46,7 +46,7 @@ const mapStateToProps = (state, {onShow}) => ({
   areCrossReportsRequired: getAllegationsRequireCrossReportsValueSelector(state),
   cardName: cardName,
   communityCareLicensing: getCommunityCareLicensingFormSelector(state).toJS(),
-  counties: selectCounties(state).toJS(),
+  counties: selectCountiesWithoutStateOfCalifornia(state).toJS(),
   county_id: state.getIn(['crossReportForm', 'county_id', 'value']) || '',
   countyAgencies: {
     [DISTRICT_ATTORNEY]: getDistrictAttorneyAgenciesSelector(state).toJS(),

--- a/app/javascript/reducers/peopleSearchReducer.js
+++ b/app/javascript/reducers/peopleSearchReducer.js
@@ -71,6 +71,7 @@ export default createReducer(initialState, {
     return state.set('searchCounty', county)
   },
   [FETCH_USER_INFO_COMPLETE](state, {payload: {userInfo: {county}}}) {
+    if (county === 'State of California') { return state }
     const newState = state.set('defaultCounty', county)
     return newState.get('searchCounty') === '' ? newState.set('searchCounty', county) : newState
   },

--- a/app/javascript/selectors/systemCodeSelectors.js
+++ b/app/javascript/selectors/systemCodeSelectors.js
@@ -23,3 +23,6 @@ export const selectScreenResponseTimes = selectCodes('screenResponseTimes')
 export const selectUnableToDetermineCodes = selectCodes('unableToDetermineCodes')
 export const selectCsecTypes = selectCodes('csecTypes')
 export const selectCommunicationMethods = selectCodes('communicationMethods')
+
+export const selectCountiesWithoutStateOfCalifornia = (state) =>
+  selectCounties(state).filter((code) => code.get('value') !== 'State of California')

--- a/spec/features/screening/allegations_cross_reports_spec.rb
+++ b/spec/features/screening/allegations_cross_reports_spec.rb
@@ -162,7 +162,7 @@ feature 'show cross reports' do
 
     within '#cross-report-card.edit' do
       expect(page).to have_content('must be cross-reported to law enforcement')
-      select 'State of California', from: 'County'
+      select 'Fresno', from: 'County'
       find('label', text: /\ADistrict Attorney\z/).click
       expect(page).to have_content('must be cross-reported to law enforcement')
       select 'LA District Attorney - Criminal Division', from: 'District Attorney Agency Name'

--- a/spec/features/screening/cross_reports_spec.rb
+++ b/spec/features/screening/cross_reports_spec.rb
@@ -221,7 +221,7 @@ feature 'cross reports' do
     communication_method = 'Child Abuse Form'
 
     within '#cross-report-card' do
-      select 'State of California', from: 'County'
+      select 'Fresno', from: 'County'
       find('label', text: /\ACounty Licensing\z/).click
       fill_in_datepicker 'Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p')
       select communication_method, from: 'Communication Method'
@@ -277,7 +277,7 @@ feature 'cross reports' do
       expect(page).to \
         have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p'))
       expect(page).to have_field('Communication Method', with: communication_method)
-      select 'State of California', from: 'County'
+      select 'Fresno', from: 'County'
       find('label', text: /\ALaw Enforcement\z/).click
       expect(page).to_not \
         have_field('Cross Reported on Date', with: reported_on.strftime('%m/%d/%Y %l:%M %p'))
@@ -320,7 +320,7 @@ feature 'cross reports' do
     communication_method = 'Child Abuse Form'
 
     within '#cross-report-card' do
-      select 'State of California', from: 'County'
+      select 'Fresno', from: 'County'
       find('label', text: /\ACounty Licensing\z/).click
       fill_in_datepicker 'Cross Reported on Date', with: reported_on
       select communication_method, from: 'Communication Method'
@@ -331,7 +331,7 @@ feature 'cross reports' do
     click_link 'Edit cross report'
 
     within '#cross-report-card' do
-      select 'State of California', from: 'County'
+      select 'Fresno', from: 'County'
       find('label', text: /\ACounty Licensing\z/).click
       expect(page).to have_field('Cross Reported on Date', with: '')
       expect(page).to have_field('Communication Method', with: '')

--- a/spec/features/screening/edit_screening_spec.rb
+++ b/spec/features/screening/edit_screening_spec.rb
@@ -396,7 +396,7 @@ feature 'individual card save' do
     stub_empty_history_for_screening(existing_screening)
 
     within '#cross-report-card' do
-      select 'State of California', from: 'County'
+      select 'Fresno', from: 'County'
       find('label', text: 'District Attorney').click
       select 'LA District Attorney - Criminal Division', from: 'District Attorney Agency Name'
       click_button 'Save'

--- a/spec/javascripts/components/common/county/CountiesInjectorSpec.jsx
+++ b/spec/javascripts/components/common/county/CountiesInjectorSpec.jsx
@@ -20,6 +20,7 @@ describe('CountiesInjector', () => {
       {code: '232', value: 'Alpine'},
       {code: '233', value: 'Amador'},
       {code: '234', value: 'Butte'},
+      {code: '1234', value: 'State of California'},
     ]
     const state = fromJS({systemCodes: {counties}})
 
@@ -28,9 +29,14 @@ describe('CountiesInjector', () => {
       expect(component.find('MyComponent').text()).toEqual('Hello World')
     })
 
-    it('adds list of counties to the child', () => {
+    it('adds list of counties without State of California to the child', () => {
       const component = render(<MyComponent />, state)
-      expect(component.find('MyComponent').props().counties).toEqual(counties)
+      expect(component.find('MyComponent').props().counties).toEqual([
+        {code: '231', value: 'Alameda'},
+        {code: '232', value: 'Alpine'},
+        {code: '233', value: 'Amador'},
+        {code: '234', value: 'Butte'},
+      ])
     })
   })
 

--- a/spec/javascripts/reducers/peopleSearchReducerSpec.js
+++ b/spec/javascripts/reducers/peopleSearchReducerSpec.js
@@ -244,6 +244,13 @@ describe('peopleSearchReducer', () => {
       expect(newState.get('searchCounty')).toEqual('Sutter')
       expect(newState.get('defaultCounty')).toEqual('Los Angeles')
     })
+    it('does not set the default if user is State of California', () => {
+      const action = fetchUserInfoSuccess({county: 'State of California'})
+      const initialState = fromJS({searchCounty: '', defaultCounty: null})
+      const newState = peopleSearchReducer(initialState, action)
+      expect(newState.get('searchCounty')).toEqual('')
+      expect(newState.get('defaultCounty')).toEqual(null)
+    })
   })
 
   describe('on RESET_ADDRESS_SEARCH', () => {

--- a/spec/javascripts/selectors/systemCodeSelectorsSpec.js
+++ b/spec/javascripts/selectors/systemCodeSelectorsSpec.js
@@ -2,6 +2,7 @@ import {
   selectAddressCounties,
   selectAddressTypes,
   selectCounties,
+  selectCountiesWithoutStateOfCalifornia,
   selectCountyAgencies,
   selectEthnicityTypes,
   selectHispanicOriginCodes,
@@ -65,7 +66,10 @@ describe('systemCodeSelectors', () => {
 
   describe('selectCounties', () => {
     it('returns a list of counties', () => {
-      const counties = [{code: '1', value: 'ABC'}]
+      const counties = [
+        {code: '1', value: 'ABC'},
+        {code: '99', value: 'State of California'},
+      ]
       const otherSystemCodes = [{code: '2', value: 'invalid'}]
       const state = fromJS({systemCodes: {counties, otherSystemCodes}})
       expect(selectCounties(state).toJS()).toEqual(counties)
@@ -196,6 +200,32 @@ describe('systemCodeSelectors', () => {
       const unableToDetermineCodes = []
       const state = fromJS({systemCodes: {unableToDetermineCodes}})
       expect(selectUnableToDetermineCodes(state).toJS()).toEqual([])
+    })
+  })
+
+  describe('selectCountiesWithoutStateOfCalifornia', () => {
+    it('returns a list of counties', () => {
+      const counties = [{code: '1', value: 'ABC'}]
+      const otherSystemCodes = [{code: '2', value: 'invalid'}]
+      const state = fromJS({systemCodes: {counties, otherSystemCodes}})
+      expect(selectCountiesWithoutStateOfCalifornia(state).toJS()).toEqual(counties)
+    })
+
+    it('removes State of California from the list', () => {
+      const counties = [
+        {code: '1', value: 'ABC'},
+        {code: '99', value: 'State of California'},
+      ]
+      const otherSystemCodes = [{code: '2', value: 'invalid'}]
+      const state = fromJS({systemCodes: {counties, otherSystemCodes}})
+      expect(selectCountiesWithoutStateOfCalifornia(state).toJS()).toEqual([counties[0]])
+    })
+
+    it('returns an empty list when counties are empty', () => {
+      const counties = []
+      const otherSystemCodes = [{code: '2', value: 'invalid'}]
+      const state = fromJS({systemCodes: {counties, otherSystemCodes}})
+      expect(selectCountiesWithoutStateOfCalifornia(state).toJS()).toEqual([])
     })
   })
 })

--- a/spec/support/helpers/system_code_helpers.rb
+++ b/spec/support/helpers/system_code_helpers.rb
@@ -68,7 +68,7 @@ module SystemCodeHelpers
   def county_type_codes
     [
       { code: 'c40', value: 'San Francisco', category: 'county_type', sub_category: nil },
-      { code: 'c41', value: 'State of California', category: 'county_type', sub_category: nil },
+      { code: 'c41', value: 'Fresno', category: 'county_type', sub_category: nil },
       { code: 'c42', value: 'Sacramento', category: 'county_type', sub_category: nil }
     ]
   end


### PR DESCRIPTION
### Jira Story

- [Test for DocTool rule 02366 Gov't Entity Type cannot be "State of CA" for addresses HOT-1546](https://osi-cwds.atlassian.net/browse/HOT-1546)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
State of California is a special value that should not be included in many cases. This achieves that by manually removing it from the LOV list. This requires inspecting the contents of the LOV results, which should be considered tech debt.

Users with State of California as their county will default to blank options for Address Search and Cross Report.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
Kinda a little of both?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

