### PR TITLE
SNAP-685 - Default csec to empty list in mapDoraPerson

### DIFF
--- a/app/javascript/utils/peopleSearchHelper.js
+++ b/app/javascript/utils/peopleSearchHelper.js
@@ -96,7 +96,7 @@ export const mapPhoneNumber = (result) =>
     .valueOrElse(List())
 
 export const mapDoraPersonToParticipant = (state, person) => Map({
-  csec: person.get('csec'),
+  csec: person.get('csec') || List(),
   date_of_birth: person.get('date_of_birth'),
   date_of_death: person.get('date_of_death'),
   approximate_age: null,

--- a/spec/javascripts/utils/peopleSearchHelperSpec.js
+++ b/spec/javascripts/utils/peopleSearchHelperSpec.js
@@ -163,6 +163,63 @@ describe('peopleSearchHelper', () => {
       )
       expect(result).toEqualImmutable(fromJS(participant))
     })
+
+    it('defaults csec to an empty list', () => {
+      const doraPerson = {
+        race_ethnicity: {
+          hispanic_origin_code: 'N',
+          unable_to_determine_code: '',
+          race_codes: [{id: '1'}],
+          hispanic_codes: [],
+          hispanic_unable_to_determine_code: '',
+        },
+        addresses: [{
+          zip: '99999',
+          city: 'Al Haad',
+          type: {id: RESIDENCE_TYPE},
+          street_name: 'Canary Alley',
+          state_name: 'California',
+          street_number: '15',
+          effective_start_date: '1997-09-04',
+          id: 'NuzhtHm083',
+          state: {id: '1828'},
+          state_code: 'CA',
+          zip_4: '1111',
+          phone_numbers: [{number: '9660007290'}],
+        }],
+        gender: 'male',
+        languages: [{
+          id: '2',
+          primary: true,
+        }, {
+          id: '1',
+          primary: false,
+        }],
+        date_of_birth: '1994-09-29',
+        date_of_death: '1996-09-21',
+        legacy_descriptor: {
+          legacy_id: 'OkMXEhe083',
+          legacy_ui_id: '1673-3395-1268-0001926',
+          legacy_last_updated: '2004-11-16T17:25:53.407-0800',
+          legacy_table_name: 'PLC_HM_T',
+          legacy_table_description: 'Placement Home',
+        },
+        last_name: 'John',
+        middle_name: '',
+        name_suffix: 'jr',
+        ssn: '996005129',
+        phone_numbers: [{number: '9660007290'}],
+        id: 'OkMXEhe083',
+        first_name: 'Mohammed',
+        sensitivity_indicator: 'N',
+        // No csec data
+      }
+      const state = fromJS({systemCodes})
+
+      const result = mapDoraPersonToParticipant(state, fromJS(doraPerson))
+
+      expect(result.get('csec')).toEqualImmutable(fromJS([]))
+    })
   })
 
   describe('mapLanguages', () => {


### PR DESCRIPTION
### Jira Story

- [Intake App: Update Rails Query for CSEC SNAP-685](https://osi-cwds.atlassian.net/browse/SNAP-685)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->
This patches a bug where participants with no CSEC information caused a crash in Snapshot. This slipped through our testing crash because:
1. Fake data in Preint caused every person in the search to have some CSEC data.
2. With end of sprint approaching, we got impatient waiting for real data and felt we had to merge to make the deadline.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

