### PR TITLE
Bug: Strong params allow search_after

### DIFF
--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -36,7 +36,9 @@ module Api
       end
 
       def search_params
-        params.permit(:search_term, :is_client_only, search_after: [],
+        params.permit(:search_term,
+          :is_client_only,
+          search_after: [],
           search_address: %i[street city county])
       end
     end

--- a/app/controllers/api/v1/people_controller.rb
+++ b/app/controllers/api/v1/people_controller.rb
@@ -36,7 +36,7 @@ module Api
       end
 
       def search_params
-        params.permit(:search_term, :is_client_only, :search_after,
+        params.permit(:search_term, :is_client_only, search_after: [],
           search_address: %i[street city county])
       end
     end

--- a/spec/controllers/api/v1/people_controller_spec.rb
+++ b/spec/controllers/api/v1/people_controller_spec.rb
@@ -29,7 +29,7 @@ describe Api::V1::PeopleController do
 
     context 'when search_after is provied as a param' do
       before(:each) do
-        params[:search_after] = 'hello world'
+        params[:search_after] = ['hello world']
         allow(PersonSearchRepository).to receive(:search)
           .with(params.as_json, anything, security_token: security_token).and_return(people)
       end


### PR DESCRIPTION
### Jira Story

- [Snapshot Search duplicate 1-10 results](https://osi-cwds.atlassian.net/browse/SNAP-760)

## Description
Rails strong parameters was ignore search_after because it was expecting a string rather than what it is, an array.

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.
