### PR TITLE
Lock down chrome driver version for test builds

### DIFF
--- a/docker/test/docker-compose.yml
+++ b/docker/test/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - ../../reports:/reports
       - ../../tmp:/ca_intake/tmp/capybara
+      - .chromedriver-helper:/root/.chromedriver-helper
     environment:
       FERB_API_URL: "https://ferbapi.preint.cwds.io"
       DORA_API_URL: "https://doraapi.preint.cwds.io"


### PR DESCRIPTION
### Jira Story

No Story: fix PR builds

## Description
PR Builds and possibly other builds are failing because chrome driver version is not locked down to 2.38

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

