### PR TITLE
Specifically add chromedriver version 2.38

### DIFF
--- a/docker/base_images/Dockerfile.intake_testing
+++ b/docker/base_images/Dockerfile.intake_testing
@@ -26,10 +26,24 @@ RUN  apt-get install -y \
     libfontconfig1-dev \
     yarn \
     bzip2 \
+    unzip \
     man
 
 RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo -E bash -
 RUN apt-get install -y nodejs
+
+# Credits to https://github.com/elgalu/docker-selenium
+ENV CHROME_DRIVER_VERSION="2.38" \
+  CHROME_DRIVER_BASE="chromedriver.storage.googleapis.com" \
+  CPU_ARCH="64"
+ENV CHROME_DRIVER_FILE="chromedriver_linux${CPU_ARCH}.zip"
+ENV CHROME_DRIVER_URL="https://${CHROME_DRIVER_BASE}/${CHROME_DRIVER_VERSION}/${CHROME_DRIVER_FILE}"
+RUN  wget -nv -O chromedriver_linux${CPU_ARCH}.zip ${CHROME_DRIVER_URL} \
+  && unzip chromedriver_linux${CPU_ARCH}.zip \
+  && rm chromedriver_linux${CPU_ARCH}.zip \
+  && chmod 755 chromedriver \
+  && mv chromedriver /usr/local/bin/ \
+  && chromedriver --version
 
 ARG GECKODRIVER_VERSION=0.18.0
 RUN wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM cwds/intake_testing_base_image:2.3
+FROM cwds/intake_testing_base_image:2.4
 LABEL application=intake_accelerator
 
 ENV APP_HOME /ca_intake


### PR DESCRIPTION
No Story. Updating base_image with chromedriver specified to 2.38 to fix the pipeline tests.

https://cloud.docker.com/u/cwds/repository/docker/cwds/intake_testing_base_image