### PR TITLE
SNAP-830 search results menu should be visible

### DIFF
--- a/app/javascript/common/search/Autocompleter.jsx
+++ b/app/javascript/common/search/Autocompleter.jsx
@@ -208,7 +208,7 @@ export default class Autocompleter extends Component {
       <Autocomplete
         ref={(el) => (this.element_ref = el)}
         getItemValue={(_) => searchTerm}
-        inputProps={{id, onBlur: this.hideMenu, onFocus: this.onFocus}}
+        inputProps={{id, onFocus: this.onFocus}}
         items={newResults}
         onChange={this.onChangeInput}
         onSelect={this.onItemSelect}

--- a/spec/features/screening/participant/search_participant_spec.rb
+++ b/spec/features/screening/participant/search_participant_spec.rb
@@ -59,7 +59,7 @@ feature 'searching a participant in autocompleter' do
       end
     end
 
-    context 'closes search results' do
+    context 'search results' do
       before do
         legacy_descriptor = FactoryBot.create(:legacy_descriptor)
         search_response = PersonSearchResponseBuilder.build do |response|
@@ -97,7 +97,7 @@ feature 'searching a participant in autocompleter' do
         end
       end
 
-      scenario 'when clicking search result' do
+      scenario 'closes when clicking search result' do
         within '#search-card', text: 'Search' do
           page.find('strong', text: 'Marge').click
         end
@@ -107,11 +107,11 @@ feature 'searching a participant in autocompleter' do
         end
       end
 
-      scenario 'when clicking outside search result' do
+      scenario 'does not close when clicking outside search result' do
         page.find('#screening-information-card').click
 
         within '#search-card', text: 'Search' do
-          expect(page).to_not have_button('Create a new person')
+          expect(page).to have_button('Create a new person')
         end
       end
     end


### PR DESCRIPTION
### Jira Story

- [Search results to remain visible unless selected or search starts over](https://osi-cwds.atlassian.net/browse/SNAP-830)

## Description
Search results must remain visible UNLESS:
- a result thumbprint is clicked OR the start over button is clicked at the top of the page.

## Tests
- [ ] I have included unit tests 
- [x] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

