### PR TITLE
FIT-434: Updates parallel testing gem so we can exclude directories

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ group :development, :test do
     ref: '488863b3211572ba5488b6f3956aa365d847a48b'
   gem 'haml_lint', '0.27.0'
   gem 'i18n-tasks'
-  gem 'parallel_tests', '2.21.2'
+  gem 'parallel_tests', '2.28.0'
   gem 'pry'
   gem 'pry-byebug'
   gem 'pry-doc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -224,8 +224,8 @@ GEM
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
-    parallel (1.12.1)
-    parallel_tests (2.21.2)
+    parallel (1.13.0)
+    parallel_tests (2.28.0)
       parallel
     parser (2.5.3.0)
       ast (~> 2.4.0)
@@ -453,7 +453,7 @@ DEPENDENCIES
   logstash-logger (~> 0.26.1)
   newrelic_rpm
   nokogiri (~> 1.8.1)
-  parallel_tests (= 2.21.2)
+  parallel_tests (= 2.28.0)
   pry
   pry-byebug
   pry-doc


### PR DESCRIPTION
This allows us to exclude directories since we're moving the feature specs
for screening to be informational in Jenkins runs.


- [FIT-434](https://osi-cwds.atlassian.net/browse/FIT-434)

<!--- Provide a description with context for those that don't know what this pull request is about. -->

- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->
N/A

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.