### PR TITLE
FIT-498: Bug in chromedriver helper pulls only latest version, this is a temp fix

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -13,5 +13,8 @@ RUN chmod +x /usr/local/bin/build.sh
 
 COPY . ./
 RUN bundle install -j8 --retry=3
+RUN CHROME_VERSION=$(google-chrome --version | sed -r 's/[^0-9]+([0-9]+\.[0-9]+\.[0-9]+).*/\1/g') && \
+    CHROMEDRIVER_VERSION=$(curl -s https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION) && \
+    bundle exec chromedriver-update $CHROMEDRIVER_VERSION
 RUN yarn
 RUN bin/webpack


### PR DESCRIPTION
This is the bug: 

- https://github.com/flavorjones/chromedriver-helper/issues/79

This fix should work, but eventually can be updated when this bug is fixed with the correct version of chromedriver-helper.

### Jira Story

- [Intake Application Pipeline Deployments are Unsuccessful FIT-498](https://osi-cwds.atlassian.net/browse/FIT-498)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.