### PR TITLE
FIT-498: Add ability to rerun a failed master build with a increment version i…

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,10 @@ def buildMaster() {
     triggerProperties = pullRequestMergedTriggerProperties('intake-master')
     properties([
       pipelineTriggers([triggerProperties]),
-      buildDiscarderDefaults('master')
+      buildDiscarderDefaults('master'),
+      parameters([
+        string(name: 'INCREMENT_VERSION', defaultValue: '', description: 'major, minor, or patch')
+      ])
     ])
 
     try {
@@ -153,7 +156,7 @@ def rspecTestsSnapshot() {
     sh 'EXCLUDE_PATTERN="features/screening" ./scripts/ci/rspec_test.rb'
   }
 }
-      
+
 def build() {
   stage('Build') {
     curStage = 'Build'
@@ -164,7 +167,7 @@ def build() {
 def incrementTag() {
   stage('Increment Tag') {
     curStage = 'Increment Tag'
-    VERSION = newSemVer()
+    VERSION = newSemVer(env.INCREMENT_VERSION)
     VCS_REF = sh(
       script: 'git rev-parse --short HEAD', returnStdout: true
     )


### PR DESCRIPTION
Adding this because currently you can't rerun a failed master build without having admin access and redelivering the webhook payload because incrementing requires a JSON payload to find the label.

Adds a single param that is defaulted to nothing, but can be set to patch, minor, or major.

### Jira Story

- [FIT-498](https://osi-cwds.atlassian.net/browse/FIT-498)

## Description
<!--- Provide a description with context for those that don't know what this pull request is about. -->

## Tests
- [ ] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [x] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

