### PR TITLE
Remove address information from API call to Query Builder;

### DIFF
--- a/app/javascript/data/personSearch.js
+++ b/app/javascript/data/personSearch.js
@@ -9,23 +9,17 @@ const mapObject = (obj, f) => {
 }
 
 const SEARCH_PARAMS = Object.freeze({
-  searchAddress: 'street',
   searchApproximateAge: 'approximate_age',
   searchApproximateAgeUnits: 'approximate_age_units',
-  searchCity: 'city',
   searchClientId: 'client_id',
-  searchCountry: 'country',
-  searchCounty: 'county',
   searchDateOfBirth: 'date_of_birth',
   searchFirstName: 'first_name',
   searchSexAtBirth: 'sex_at_birth',
   searchLastName: 'last_name',
   searchMiddleName: 'middle_name',
   searchSsn: 'ssn',
-  searchState: 'state',
   searchSuffix: 'suffix',
   searchTerm: 'search_term',
-  searchZipCode: 'zip_code',
 })
 
 export const toAPIParams = fields => {

--- a/spec/javascripts/sagas/fetchPeopleSearchSagaSpec.js
+++ b/spec/javascripts/sagas/fetchPeopleSearchSagaSpec.js
@@ -54,7 +54,7 @@ describe('getPeopleEffect', () => {
     expect(getPeopleEffect({
       isClientOnly: true,
       isAdvancedSearchOn: true,
-      personSearchFields: {searchFirstName: 'John'},
+      personSearchFields: {searchFirstName: 'John', searchCounty: 'Yolo'},
     })).toEqual(call(get, '/api/v1/people', {
       is_client_only: true,
       is_advanced_search_on: true,
@@ -65,12 +65,12 @@ describe('getPeopleEffect', () => {
     expect(getPeopleEffect({
       isClientOnly: true,
       isAdvancedSearchOn: false,
-      personSearchFields: {searchAddress: '123 Main St', searchCity: 'Anywhereville', searchCounty: 'Oz'},
+      personSearchFields: {searchFirstName: 'John', searchLastName: 'Doe', searchCounty: 'Yolo'},
       sort: 'What even goes here?',
     })).toEqual(call(get, '/api/v1/people', {
       is_client_only: true,
       is_advanced_search_on: false,
-      person_search_fields: {street: '123 Main St', city: 'Anywhereville', county: 'Oz'},
+      person_search_fields: {first_name: 'John', last_name: 'Doe'},
       search_after: 'What even goes here?',
     }))
   })


### PR DESCRIPTION
## Description
This will remove address information from the API call to the Query Builder.

We need to remove the address information because we removed address fields in the Search UI, and county is automatically set in Redux.

Since they are not able to change the county (because the fields were removed in the latest update to the Snapshot Search UI), we should remove address information from the API call and ES Query.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

