### PR TITLE
SNAP-1099 Results Table: Fix Server Side Pagination

### DIFF
--- a/app/javascript/common/search/SearchResultsTable.jsx
+++ b/app/javascript/common/search/SearchResultsTable.jsx
@@ -97,16 +97,9 @@ class SearchResultsTable extends React.Component {
     },
   ]
 
-  fetchData(pageIndex) {
-    const {setCurrentPageNumber, onLoadMoreResults, personSearchFields, results} = this.props
-    const previousPage = this.state.previousPage
-    const currentPage = pageIndex + 1
-    const totalResultsReceived = results.length
-    setCurrentPageNumber(currentPage)
-    if (currentPage > previousPage) {
-      onLoadMoreResults(personSearchFields, totalResultsReceived)
-    }
-    this.setState({previousPage: pageIndex})
+  fetchData(totalResultsReceived) {
+    const {onLoadMoreResults, personSearchFields} = this.props
+    onLoadMoreResults(personSearchFields, totalResultsReceived)
   }
 
   setRowAndFetchData(pageSize, pageIndex) {
@@ -131,6 +124,18 @@ class SearchResultsTable extends React.Component {
     return Math.ceil(pageCount)
   }
 
+  handlePageChange(pageIndex) {
+    const {setCurrentPageNumber, results} = this.props
+    const {previousPage} = this.state
+    const currentPage = ++pageIndex
+    const totalResultsReceived = results.length
+    setCurrentPageNumber(currentPage)
+    if (currentPage > previousPage) {
+      this.fetchData(totalResultsReceived)
+    }
+    this.setState({previousPage: pageIndex})
+  }
+
   render() {
     const {resultsSubset, total, currentRow, onAuthorize} = this.props
     return (
@@ -142,7 +147,7 @@ class SearchResultsTable extends React.Component {
           data={resultsSubset}
           minRows={0}
           pages={this.calculateNumberOfPages(total, currentRow)}
-          onPageChange={(pageIndex) => this.fetchData(pageIndex)}
+          onPageChange={(pageIndex) => this.handlePageChange(pageIndex)}
           defaultPageSize={currentRow}
           onPageSizeChange={(pageSize, pageIndex) => this.setRowAndFetchData(pageSize, pageIndex)}
         />

--- a/app/javascript/common/search/SearchResultsTable.jsx
+++ b/app/javascript/common/search/SearchResultsTable.jsx
@@ -15,7 +15,7 @@ class SearchResultsTable extends React.Component {
   constructor() {
     super()
     this.state = {
-      previousPage: -1,
+      previousPageNumber: -1,
     }
     this.fetchData = this.fetchData.bind(this)
   }
@@ -110,10 +110,10 @@ class SearchResultsTable extends React.Component {
       personSearchFields,
       results,
     } = this.props
-    const currentPage = pageIndex + 1
+    const currentPageNumber = pageIndex + 1
     const totalResultsReceived = results.length
     setCurrentRowNumber(pageSize)
-    setCurrentPageNumber(currentPage)
+    setCurrentPageNumber(currentPageNumber)
     onLoadMoreResults(personSearchFields, totalResultsReceived)
   }
 
@@ -124,16 +124,26 @@ class SearchResultsTable extends React.Component {
     return Math.ceil(pageCount)
   }
 
+  shouldRequestResults(currentPageNumber, previousPageNumber) {
+    const {currentRow, results} = this.props
+    const totalResultsReceived = results.length
+    const nextPageRequested = currentPageNumber > previousPageNumber
+    const haveResults = totalResultsReceived >= currentRow * currentPageNumber
+    const requestResults = nextPageRequested && !haveResults
+    return requestResults
+  }
+
   handlePageChange(pageIndex) {
     const {setCurrentPageNumber, results} = this.props
-    const {previousPage} = this.state
-    const currentPage = ++pageIndex
+    const {previousPageNumber} = this.state
+    const currentPageNumber = ++pageIndex
     const totalResultsReceived = results.length
-    setCurrentPageNumber(currentPage)
-    if (currentPage > previousPage) {
+    const requestResults = this.shouldRequestResults(currentPageNumber, previousPageNumber)
+    setCurrentPageNumber(currentPageNumber)
+    if (requestResults) {
       this.fetchData(totalResultsReceived)
     }
-    this.setState({previousPage: pageIndex})
+    this.setState({previousPageNumber: pageIndex})
   }
 
   render() {

--- a/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
+++ b/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
@@ -243,46 +243,44 @@ describe('SearchResultsTable', () => {
   })
 
   describe('onPageChange', () => {
-    it('calls setCurrentPageNumber', () => {
-      const setCurrentPageNumber = jasmine.createSpy('setCurrentPageNumber')
-      const component = render({
-        results: defaultMockedResults,
-        resultsSubset: defaultMockedResults,
-        setCurrentPageNumber,
+    describe('setCurrentPageNumber', () => {
+      describe('when the page is changed', () => {
+        it('setCurrentPageNumber is called with the current page number', () => {
+          const setCurrentPageNumber = jasmine.createSpy('setCurrentPageNumber')
+          const component = render({setCurrentPageNumber})
+          const searchResultsTable = component.find('ReactTable')
+          searchResultsTable.props().onPageChange(1)
+          expect(setCurrentPageNumber).toHaveBeenCalledWith(2)
+        })
       })
-      const searchResultsTable = component.find('ReactTable')
-      searchResultsTable.props().onPageChange(1)
-      expect(setCurrentPageNumber).toHaveBeenCalledWith(2)
     })
 
-    it('calls onLoadMoreResults', () => {
-      const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-      const personSearchFields = {lastName: 'laure'}
-      const totalResultsReceived = defaultMockedResults.length
-      const component = render({
-        results: defaultMockedResults,
-        resultsSubset: defaultMockedResults,
-        onLoadMoreResults,
-        personSearchFields,
+    describe('onLoadMoreResults', () => {
+      describe('when the next page is requested', () => {
+        it('onLoadMoreResults is called with personSearchFields and totalResultsReceived', () => {
+          const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
+          const personSearchFields = {lastName: 'laure'}
+          const totalResultsReceived = defaultMockedResults.length
+          const component = render({
+            results: defaultMockedResults,
+            onLoadMoreResults,
+            personSearchFields,
+          })
+          const searchResultsTable = component.find('ReactTable')
+          searchResultsTable.props().onPageChange(1)
+          expect(onLoadMoreResults).toHaveBeenCalledWith({lastName: 'laure'}, totalResultsReceived)
+        })
       })
-      const searchResultsTable = component.find('ReactTable')
-      searchResultsTable.props().onPageChange(1)
-      expect(onLoadMoreResults).toHaveBeenCalledWith({lastName: 'laure'}, totalResultsReceived)
     })
 
-    it('does not call onLoadMoreResults when currentPage is less than previousPage', () => {
-      const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-      const personSearchFields = {lastName: 'laure'}
-      const totalResultsReceived = defaultMockedResults.length
-      const component = render({
-        results: defaultMockedResults,
-        resultsSubset: defaultMockedResults,
-        onLoadMoreResults,
-        personSearchFields,
+    describe('when the previous page is requested', () => {
+      it('onLoadMoreResults is not called', () => {
+        const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
+        const component = render({onLoadMoreResults})
+        const searchResultsTable = component.find('ReactTable')
+        searchResultsTable.props().onPageChange(-2)
+        expect(onLoadMoreResults).not.toHaveBeenCalled()
       })
-      const searchResultsTable = component.find('ReactTable')
-      searchResultsTable.props().onPageChange(-2)
-      expect(onLoadMoreResults).not.toHaveBeenCalledWith({lastName: 'laure'}, totalResultsReceived)
     })
   })
 

--- a/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
+++ b/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
@@ -96,7 +96,7 @@ const defaultMockedResults = [
     },
     'phoneNumber': null,
     'dateOfBirth': '1983-01-01',
-    'fullName': 'First Gimson',
+    'fullName': 'Second Gimson',
   },
 ]
 
@@ -257,18 +257,39 @@ describe('SearchResultsTable', () => {
 
     describe('onLoadMoreResults', () => {
       describe('when the next page is requested', () => {
-        it('onLoadMoreResults is called with personSearchFields and totalResultsReceived', () => {
-          const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-          const personSearchFields = {lastName: 'laure'}
-          const totalResultsReceived = defaultMockedResults.length
-          const component = render({
-            results: defaultMockedResults,
-            onLoadMoreResults,
-            personSearchFields,
+        describe('and we have not requested the results for the next page', () => {
+          it('onLoadMoreResults is called with personSearchFields and totalResultsReceived', () => {
+            const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
+            const personSearchFields = {lastName: 'laure'}
+            const totalResultsReceived = defaultMockedResults.length
+            const numberOfRowsPerPage = totalResultsReceived
+            const component = render({
+              currentRow: numberOfRowsPerPage,
+              results: defaultMockedResults,
+              onLoadMoreResults,
+              personSearchFields,
+            })
+            const searchResultsTable = component.find('ReactTable')
+            searchResultsTable.props().onPageChange(1)
+            expect(onLoadMoreResults).toHaveBeenCalledWith({lastName: 'laure'}, totalResultsReceived)
           })
-          const searchResultsTable = component.find('ReactTable')
-          searchResultsTable.props().onPageChange(1)
-          expect(onLoadMoreResults).toHaveBeenCalledWith({lastName: 'laure'}, totalResultsReceived)
+        })
+
+        describe('and we have requested the results for the next page', () => {
+          it('onLoadMoreResults is not called', () => {
+            const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
+            const totalResultsReceived = defaultMockedResults.length
+            const numberOfRowsPerPage = totalResultsReceived
+            const results = [...defaultMockedResults].concat(...defaultMockedResults)
+            const component = render({
+              currentRow: numberOfRowsPerPage,
+              results,
+              onLoadMoreResults,
+            })
+            const searchResultsTable = component.find('ReactTable')
+            searchResultsTable.props().onPageChange(1)
+            expect(onLoadMoreResults).not.toHaveBeenCalled()
+          })
         })
       })
     })


### PR DESCRIPTION
### Jira Story

https://osi-cwds.atlassian.net/browse/SNAP-1099

## Description
This fixes a pagination bug where data is requested for a page when it already exists in the front-end.

This currently happens when a users goes back to a page and the data was already requested. For example, navigating from page 1 to page 2, then from page 2 to page 1, and back to page 2. 

This would cause page 2 results to be requested twice. It should only be requested the first time we navigate from page 1 to 2. 

This can cause issues with requesting results up to 250.

This PR introduces logic to only request data when it is not present in the front-end.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

