### PR TITLE
SNAP-1100 250 Search Results Bug: on page size change

### DIFF
--- a/app/javascript/actions/peopleSearchActions.js
+++ b/app/javascript/actions/peopleSearchActions.js
@@ -17,9 +17,9 @@ export const search = (isClientOnly, isAdvancedSearchOn, personSearchFields, tot
   type: PEOPLE_SEARCH_FETCH,
   payload: {isClientOnly, isAdvancedSearchOn, personSearchFields, totalResultsReceived},
 })
-export const loadMoreResults = (isClientOnly, isAdvancedSearchOn, personSearchFields, totalResultsReceived) => ({
+export const loadMoreResults = (isClientOnly, isAdvancedSearchOn, personSearchFields, totalResultsReceived, totalResultsRequested) => ({
   type: LOAD_MORE_RESULTS,
-  payload: {isClientOnly, isAdvancedSearchOn, personSearchFields, totalResultsReceived},
+  payload: {isClientOnly, isAdvancedSearchOn, personSearchFields, totalResultsReceived, totalResultsRequested},
 })
 export const loadMoreResultsFailure = (error) => ({
   type: LOAD_MORE_RESULTS_COMPLETE,

--- a/app/javascript/common/search/Autocompleter.jsx
+++ b/app/javascript/common/search/Autocompleter.jsx
@@ -209,7 +209,7 @@ export default class Autocompleter extends Component {
   }
 
   renderPersonSearchFields() {
-    const {states, counties, onChange, onCancel, onBlur, onFocus, personSearchFields, isAdvancedSearchOn, clientIdError, ssnErrors, dobErrors, canSearch} = this.props
+    const {onChange, onCancel, onBlur, onFocus, personSearchFields, isAdvancedSearchOn, clientIdError, ssnErrors, dobErrors, canSearch} = this.props
     const searchWithEnter = (e) => {
       const enterKeyCode = 13
       if ((canSearch && e.charCode === enterKeyCode)) { this.handleSubmit() }
@@ -222,8 +222,6 @@ export default class Autocompleter extends Component {
         onCancel={onCancel}
         onSubmit={this.handleSubmit}
         personSearchFields={personSearchFields}
-        states={states}
-        counties={counties}
         isAdvancedSearchOn={isAdvancedSearchOn}
         clientIdError={clientIdError}
         ssnErrors={ssnErrors}
@@ -244,10 +242,6 @@ Autocompleter.propTypes = {
   canCreateNewPerson: PropTypes.bool,
   canSearch: PropTypes.bool,
   clientIdError: PropTypes.array,
-  counties: PropTypes.arrayOf(PropTypes.shape({
-    code: PropTypes.string,
-    value: PropTypes.string,
-  })),
   dobErrors: PropTypes.array,
   id: PropTypes.string,
   isAdvancedSearchOn: PropTypes.bool,
@@ -265,12 +259,6 @@ Autocompleter.propTypes = {
   ssnErrors: PropTypes.array,
   staffId: PropTypes.string,
   startTime: PropTypes.string,
-  states: PropTypes.arrayOf(
-    PropTypes.shape({
-      code: PropTypes.string,
-      value: PropTypes.string,
-    })
-  ),
   total: PropTypes.number,
 }
 

--- a/app/javascript/common/search/Autocompleter.jsx
+++ b/app/javascript/common/search/Autocompleter.jsx
@@ -24,7 +24,10 @@ const itemClassName = (isHighlighted) => `search-item${isHighlighted ? ' highlig
 export default class Autocompleter extends Component {
   constructor(props) {
     super(props)
-    this.state = {menuVisible: false}
+    this.state = {
+      menuVisible: false,
+      currentPageNumber: 1,
+    }
     this.hideMenu = this.hideMenu.bind(this)
     this.onItemSelect = this.onItemSelect.bind(this)
     this.renderMenu = this.renderMenu.bind(this)
@@ -69,10 +72,15 @@ export default class Autocompleter extends Component {
 
   loadMoreResults() {
     const {onLoadMoreResults, isAdvancedSearchOn, personSearchFields, results} = this.props
+    const pageSize = 25
+    const {currentPageNumber} = this.state
+    const nextPageNumber = currentPageNumber + 1
     const totalResultsReceived = results.length
-    onLoadMoreResults(isAdvancedSearchOn, personSearchFields, totalResultsReceived)
+    const totalResultsRequested = pageSize * nextPageNumber
+    onLoadMoreResults(isAdvancedSearchOn, personSearchFields, totalResultsReceived, totalResultsRequested)
     this.element_ref.setIgnoreBlur(true)
     if (this.inputRef) { this.inputRef.focus() }
+    this.setState({currentPageNumber: nextPageNumber})
   }
 
   onSelect(item) {

--- a/app/javascript/common/search/SearchResultsTable.jsx
+++ b/app/javascript/common/search/SearchResultsTable.jsx
@@ -99,10 +99,11 @@ class SearchResultsTable extends React.Component {
     },
   ]
 
-  fetchData() {
+  fetchData(currentPageNumber, currentPageSize) {
     const {onLoadMoreResults, personSearchFields, results} = this.props
     const totalResultsReceived = results.length
-    onLoadMoreResults(personSearchFields, totalResultsReceived)
+    const totalResultsRequested = currentPageNumber * currentPageSize
+    onLoadMoreResults(personSearchFields, totalResultsReceived, totalResultsRequested)
   }
 
   calculateNumberOfPages(total, currentRow) {
@@ -115,8 +116,8 @@ class SearchResultsTable extends React.Component {
   haveResults(currentPageNumber, currentPageSize) {
     const {results} = this.props
     const totalResultsReceived = results.length
-    const numberOfResultsRequested = currentPageNumber * currentPageSize
-    const haveResults = totalResultsReceived >= numberOfResultsRequested
+    const totalResultsRequested = currentPageNumber * currentPageSize
+    const haveResults = totalResultsReceived >= totalResultsRequested
     return haveResults
   }
 
@@ -128,7 +129,7 @@ class SearchResultsTable extends React.Component {
     const requestResults = !this.haveResults(currentPageNumber, currentRow) && nextPageRequested
     setCurrentPageNumber(currentPageNumber)
     if (requestResults) {
-      this.fetchData()
+      this.fetchData(currentPageNumber, currentRow)
     }
     this.setState({previousPageNumber: pageIndex})
   }
@@ -141,7 +142,7 @@ class SearchResultsTable extends React.Component {
     setCurrentPageNumber(currentPageNumber)
     setCurrentRowNumber(pageSize)
     if (requestResults) {
-      this.fetchData()
+      this.fetchData(currentPageNumber, pageSize)
     }
   }
 

--- a/app/javascript/common/search/SearchResultsTable.jsx
+++ b/app/javascript/common/search/SearchResultsTable.jsx
@@ -14,9 +14,7 @@ const commonStyle = {headerClassName: 'search-results-header'}
 class SearchResultsTable extends React.Component {
   constructor() {
     super()
-    this.state = {
-      previousPageNumber: -1,
-    }
+    this.state = {previousPageNumber: -1}
     this.fetchData = this.fetchData.bind(this)
   }
 
@@ -101,23 +99,9 @@ class SearchResultsTable extends React.Component {
     },
   ]
 
-  fetchData(totalResultsReceived) {
-    const {onLoadMoreResults, personSearchFields} = this.props
-    onLoadMoreResults(personSearchFields, totalResultsReceived)
-  }
-
-  setRowAndFetchData(pageSize, pageIndex) {
-    const {
-      setCurrentRowNumber,
-      setCurrentPageNumber,
-      onLoadMoreResults,
-      personSearchFields,
-      results,
-    } = this.props
-    const currentPageNumber = pageIndex + 1
+  fetchData() {
+    const {onLoadMoreResults, personSearchFields, results} = this.props
     const totalResultsReceived = results.length
-    setCurrentRowNumber(pageSize)
-    setCurrentPageNumber(currentPageNumber)
     onLoadMoreResults(personSearchFields, totalResultsReceived)
   }
 
@@ -128,8 +112,9 @@ class SearchResultsTable extends React.Component {
     return Math.ceil(pageCount)
   }
 
-  shouldRequestResults(currentPageNumber, previousPageNumber) {
+  shouldRequestResults(currentPageNumber) {
     const {currentRow, results} = this.props
+    const {previousPageNumber} = this.state
     const totalResultsReceived = results.length
     const nextPageRequested = currentPageNumber > previousPageNumber
     const haveResults = totalResultsReceived >= currentRow * currentPageNumber
@@ -138,16 +123,25 @@ class SearchResultsTable extends React.Component {
   }
 
   handlePageChange(pageIndex) {
-    const {setCurrentPageNumber, results} = this.props
-    const {previousPageNumber} = this.state
+    const {setCurrentPageNumber} = this.props
     const currentPageNumber = ++pageIndex
-    const totalResultsReceived = results.length
-    const requestResults = this.shouldRequestResults(currentPageNumber, previousPageNumber)
+    const requestResults = this.shouldRequestResults(currentPageNumber)
     setCurrentPageNumber(currentPageNumber)
     if (requestResults) {
-      this.fetchData(totalResultsReceived)
+      this.fetchData()
     }
     this.setState({previousPageNumber: pageIndex})
+  }
+
+  handlePageSizeChange(pageSize, pageIndex) {
+    const {setCurrentRowNumber, setCurrentPageNumber} = this.props
+    const currentPageNumber = pageIndex + 1
+    const requestResults = this.shouldRequestResults(currentPageNumber)
+    setCurrentRowNumber(pageSize)
+    setCurrentPageNumber(currentPageNumber)
+    if (requestResults) {
+      this.fetchData()
+    }
   }
 
   render() {
@@ -162,9 +156,9 @@ class SearchResultsTable extends React.Component {
           data={resultsSubset}
           minRows={0}
           pages={this.calculateNumberOfPages(total, currentRow)}
-          onPageChange={(pageIndex) => this.handlePageChange(pageIndex)}
           defaultPageSize={currentRow}
-          onPageSizeChange={(pageSize, pageIndex) => this.setRowAndFetchData(pageSize, pageIndex)}
+          onPageChange={(pageIndex) => this.handlePageChange(pageIndex)}
+          onPageSizeChange={(pageSize, pageIndex) => this.handlePageSizeChange(pageSize, pageIndex)}
         />
       </Fragment>
     )

--- a/app/javascript/common/search/SearchResultsTable.jsx
+++ b/app/javascript/common/search/SearchResultsTable.jsx
@@ -112,20 +112,20 @@ class SearchResultsTable extends React.Component {
     return Math.ceil(pageCount)
   }
 
-  shouldRequestResults(currentPageNumber) {
-    const {currentRow, results} = this.props
-    const {previousPageNumber} = this.state
+  haveResults(currentPageNumber, currentPageSize) {
+    const {results} = this.props
     const totalResultsReceived = results.length
-    const nextPageRequested = currentPageNumber > previousPageNumber
-    const haveResults = totalResultsReceived >= currentRow * currentPageNumber
-    const requestResults = nextPageRequested && !haveResults
-    return requestResults
+    const numberOfResultsRequested = currentPageNumber * currentPageSize
+    const haveResults = totalResultsReceived >= numberOfResultsRequested
+    return haveResults
   }
 
   handlePageChange(pageIndex) {
-    const {setCurrentPageNumber} = this.props
+    const {currentRow, setCurrentPageNumber} = this.props
+    const {previousPageNumber} = this.state
     const currentPageNumber = ++pageIndex
-    const requestResults = this.shouldRequestResults(currentPageNumber)
+    const nextPageRequested = currentPageNumber > previousPageNumber
+    const requestResults = !this.haveResults(currentPageNumber, currentRow) && nextPageRequested
     setCurrentPageNumber(currentPageNumber)
     if (requestResults) {
       this.fetchData()
@@ -134,11 +134,12 @@ class SearchResultsTable extends React.Component {
   }
 
   handlePageSizeChange(pageSize, pageIndex) {
-    const {setCurrentRowNumber, setCurrentPageNumber} = this.props
-    const currentPageNumber = pageIndex + 1
-    const requestResults = this.shouldRequestResults(currentPageNumber)
-    setCurrentRowNumber(pageSize)
+    const {currentRow, setCurrentRowNumber, setCurrentPageNumber} = this.props
+    const currentPageNumber = ++pageIndex
+    const pageSizeIncreased = pageSize > currentRow
+    const requestResults = !this.haveResults(currentPageNumber, pageSize) && pageSizeIncreased
     setCurrentPageNumber(currentPageNumber)
+    setCurrentRowNumber(pageSize)
     if (requestResults) {
       this.fetchData()
     }

--- a/app/javascript/containers/common/PersonSearchFormContainer.js
+++ b/app/javascript/containers/common/PersonSearchFormContainer.js
@@ -56,8 +56,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   const onCancel = () => { dispatch(onClear('results')); dispatch(resetPersonSearch()) }
   const onSearch = (isAvancedSearchOn, personSearchFields, totalResultsReceived) =>
     dispatch(search(ownProps.isClientOnly, isAvancedSearchOn, personSearchFields, totalResultsReceived))
-  const onLoadMoreResults = (isAvancedSearchOn, personSearchFields, totalResultsReceived) =>
-    dispatch(loadMoreResults(ownProps.isClientOnly, isAvancedSearchOn, personSearchFields, totalResultsReceived))
+  const onLoadMoreResults = (isAvancedSearchOn, personSearchFields, totalResultsReceived, totalResultsRequested) =>
+    dispatch(loadMoreResults(ownProps.isClientOnly, isAvancedSearchOn, personSearchFields, totalResultsReceived, totalResultsRequested))
   return {onBlur, onSearch, onClear, onChange, onCancel, onFocus, onLoadMoreResults, dispatch}
 }
 

--- a/app/javascript/containers/snapshot/PersonSearchResultsContainer.js
+++ b/app/javascript/containers/snapshot/PersonSearchResultsContainer.js
@@ -25,15 +25,11 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-  const onLoadMoreResults = (personSearchFields, totalResultsReceived) => {
-    dispatch(loadMoreResults(true, true, personSearchFields, totalResultsReceived))
+  const onLoadMoreResults = (personSearchFields, totalResultsReceived, totalResultsRequested) => {
+    dispatch(loadMoreResults(true, true, personSearchFields, totalResultsReceived, totalResultsRequested))
   }
-  const setCurrentPageNumber = (pageNumber) => {
-    dispatch(setSearchCurrentPage(pageNumber))
-  }
-  const setCurrentRowNumber = (pageNumber) => {
-    dispatch(setSearchCurrentRow(pageNumber))
-  }
+  const setCurrentPageNumber = (pageNumber) => dispatch(setSearchCurrentPage(pageNumber))
+  const setCurrentRowNumber = (pageNumber) => dispatch(setSearchCurrentRow(pageNumber))
   const onAuthorize = (id) => dispatch(authorizeSnapshotPerson(id))
   return {onLoadMoreResults, setCurrentPageNumber, setCurrentRowNumber, onAuthorize, dispatch}
 }

--- a/app/javascript/sagas/loadMorePeopleSearchResultsSaga.js
+++ b/app/javascript/sagas/loadMorePeopleSearchResultsSaga.js
@@ -1,15 +1,16 @@
 import {takeEvery, put, select} from 'redux-saga/effects'
 import {getPeopleEffect} from 'sagas/fetchPeopleSearchSaga'
-import {selectLastResultsSortValue, selectSearchResultsCurrentRow} from 'selectors/peopleSearchSelectors'
+import {selectLastResultsSortValue} from 'selectors/peopleSearchSelectors'
 import {
   LOAD_MORE_RESULTS,
   loadMoreResultsSuccess,
   loadMoreResultsFailure,
 } from 'actions/peopleSearchActions'
 
-export function* loadMorePeopleSearch({payload: {isClientOnly, isAdvancedSearchOn, personSearchFields, totalResultsReceived}}) {
+export function* loadMorePeopleSearch({payload}) {
   try {
-    const size = yield select(selectSearchResultsCurrentRow)
+    const {isClientOnly, isAdvancedSearchOn, personSearchFields, totalResultsReceived, totalResultsRequested} = payload
+    const size = totalResultsRequested - totalResultsReceived
     const sort = yield select(selectLastResultsSortValue)
     const response = yield getPeopleEffect({isClientOnly, isAdvancedSearchOn, personSearchFields, size, totalResultsReceived, sort})
     yield put(loadMoreResultsSuccess(response))

--- a/spec/javascripts/actions/peopleSearchActionsSpec.js
+++ b/spec/javascripts/actions/peopleSearchActionsSpec.js
@@ -44,7 +44,7 @@ describe('peopleSearchActions', () => {
     const action = loadMoreResults(true, {
       firstName: 'Nikola',
       lastName: 'Tesla',
-    }, 250)
+    }, 200, 300)
     expect(isFSA(action)).toEqual(true)
   })
 

--- a/spec/javascripts/components/common/search/AutocompleterSpec.jsx
+++ b/spec/javascripts/components/common/search/AutocompleterSpec.jsx
@@ -300,6 +300,9 @@ describe('<Autocompleter />', () => {
       })
 
       describe('isAdvancedSearchOn feature toggle is On', () => {
+        const totalResultsReceived = results.length
+        const pageSize = 25
+
         it('calls onLoadMoreResults', () => {
           const autocompleter = mountAutocompleter({
             results,
@@ -309,35 +312,18 @@ describe('<Autocompleter />', () => {
             isAdvancedSearchOn: true,
             dobErrors: [],
           })
+          const currentPageNumber = autocompleter.state().currentPageNumber
+          const nextPageNumber = currentPageNumber + 1
+          const totalResultsRequested = pageSize * nextPageNumber
           autocompleter
             .find('Autocomplete')
             .props()
             .onSelect('_value', {showMoreResults: true})
-          expect(onLoadMoreResults).toHaveBeenCalledWith(true, defaultPersonSearchFields, 3)
+          expect(onLoadMoreResults).toHaveBeenCalledWith(true, defaultPersonSearchFields, totalResultsReceived, totalResultsRequested)
         })
 
         it('calls onLoadMoreResults with an address', () => {
-          const autocompleter = mountAutocompleter({
-            results,
-            onSelect,
-            onLoadMoreResults,
-            total,
-            personSearchFields: {
-              ssn: '',
-              clientId: '',
-              state: '',
-              county: 'Colusa',
-              city: 'Central City',
-              address: 'Star Labs',
-              approximateAgeUnits: '',
-            },
-            isAdvancedSearchOn: true,
-          })
-          autocompleter
-            .find('Autocomplete')
-            .props()
-            .onSelect('_value', {showMoreResults: true})
-          expect(onLoadMoreResults).toHaveBeenCalledWith(true, {
+          const personSearchFields = {
             ssn: '',
             clientId: '',
             state: '',
@@ -345,7 +331,23 @@ describe('<Autocompleter />', () => {
             city: 'Central City',
             address: 'Star Labs',
             approximateAgeUnits: '',
-          }, 3)
+          }
+          const autocompleter = mountAutocompleter({
+            results,
+            onSelect,
+            onLoadMoreResults,
+            total,
+            personSearchFields,
+            isAdvancedSearchOn: true,
+          })
+          const currentPageNumber = autocompleter.state().currentPageNumber
+          const nextPageNumber = currentPageNumber + 1
+          const totalResultsRequested = pageSize * nextPageNumber
+          autocompleter
+            .find('Autocomplete')
+            .props()
+            .onSelect('_value', {showMoreResults: true})
+          expect(onLoadMoreResults).toHaveBeenCalledWith(true, personSearchFields, totalResultsReceived, totalResultsRequested)
         })
       })
     })

--- a/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
+++ b/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
@@ -300,15 +300,15 @@ describe('SearchResultsTable', () => {
           })
         })
       })
-    })
 
-    describe('when the previous page is requested', () => {
-      it('onLoadMoreResults is not called', () => {
-        const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-        const component = render({onLoadMoreResults})
-        const searchResultsTable = component.find('ReactTable')
-        searchResultsTable.props().onPageChange(-2)
-        expect(onLoadMoreResults).not.toHaveBeenCalled()
+      describe('when the previous page is requested', () => {
+        it('onLoadMoreResults is not called', () => {
+          const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
+          const component = render({onLoadMoreResults})
+          const searchResultsTable = component.find('ReactTable')
+          searchResultsTable.props().onPageChange(-2)
+          expect(onLoadMoreResults).not.toHaveBeenCalled()
+        })
       })
     })
   })

--- a/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
+++ b/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
@@ -276,18 +276,22 @@ describe('SearchResultsTable', () => {
       describe('when the next page is requested', () => {
         describe('and we have not requested the results for the next page', () => {
           it('onLoadMoreResults is called with personSearchFields and totalResultsReceived', () => {
+            const nextPageNumber = 2
+            const pageSize = 25
             const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
             const personSearchFields = {lastName: 'laure'}
             const results = generateMockResults(25)
             const totalResultsReceived = results.length
+            const totalResultsRequested = nextPageNumber * pageSize
             const component = render({
+              currentRow: pageSize,
               results,
               onLoadMoreResults,
               personSearchFields,
             })
             const searchResultsTable = component.find('ReactTable')
             searchResultsTable.props().onPageChange(1)
-            expect(onLoadMoreResults).toHaveBeenCalledWith({lastName: 'laure'}, totalResultsReceived)
+            expect(onLoadMoreResults).toHaveBeenCalledWith(personSearchFields, totalResultsReceived, totalResultsRequested)
           })
         })
 
@@ -339,18 +343,21 @@ describe('SearchResultsTable', () => {
       describe('when the page size is increased', () => {
         describe('and we have do not have all the results to display', () => {
           it('onLoadMoreResults is called', () => {
+            const currentPageNumber = 1
+            const pageSize = 50
             const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
             const personSearchFields = {lastName: 'Bravo'}
             const results = generateMockResults(25)
             const totalResultsReceived = results.length
+            const totalResultsRequested = currentPageNumber * pageSize
             const component = render({
               results,
               onLoadMoreResults,
               personSearchFields,
             })
             const searchResultsTable = component.find('ReactTable')
-            searchResultsTable.props().onPageSizeChange(50, 0)
-            expect(onLoadMoreResults).toHaveBeenCalledWith(personSearchFields, totalResultsReceived)
+            searchResultsTable.props().onPageSizeChange(pageSize, 0)
+            expect(onLoadMoreResults).toHaveBeenCalledWith(personSearchFields, totalResultsReceived, totalResultsRequested)
           })
         })
 

--- a/spec/javascripts/sagas/loadMorePeopleSearchResultsSagaSpec.js
+++ b/spec/javascripts/sagas/loadMorePeopleSearchResultsSagaSpec.js
@@ -4,10 +4,7 @@ import {
   loadMorePeopleSearchResultsSaga,
   loadMorePeopleSearch,
 } from 'sagas/loadMorePeopleSearchResultsSaga'
-import {
-  selectLastResultsSortValue,
-  selectSearchResultsCurrentRow,
-} from 'selectors/peopleSearchSelectors'
+import {selectLastResultsSortValue} from 'selectors/peopleSearchSelectors'
 import {
   LOAD_MORE_RESULTS,
   loadMoreResults,
@@ -28,26 +25,24 @@ describe('loadMorePeopleSearch', () => {
   const isClientOnly = true
   const isAdvancedSearchOn = true
   const personSearchFields = {lastName: 'Doe'}
-  const totalResultsReceived = 250
-  const action = loadMoreResults(isClientOnly, isAdvancedSearchOn, personSearchFields, totalResultsReceived)
+  const totalResultsReceived = 200
+  const totalResultsRequested = 250
+  const size = totalResultsRequested - totalResultsReceived
+  const action = loadMoreResults(isClientOnly, isAdvancedSearchOn, personSearchFields, totalResultsReceived, totalResultsRequested)
   const lastResultSort = ['last_result_sort']
 
-  it('finds some error during the process', () => {
+  it('catches errors during the process', () => {
     const error = 'Something went wrong'
     const peopleSeachGenerator = loadMorePeopleSearch(action)
-    const size = 25
     const searchParams = {
       is_client_only: true,
       is_advanced_search_on: true,
       total_results_received: totalResultsReceived,
       person_search_fields: {last_name: 'doe'},
-      size: size,
+      size,
       search_after: lastResultSort,
     }
-    expect(peopleSeachGenerator.next().value).toEqual(
-      select(selectSearchResultsCurrentRow)
-    )
-    expect(peopleSeachGenerator.next(size).value).toEqual(select(selectLastResultsSortValue))
+    expect(peopleSeachGenerator.next().value).toEqual(select(selectLastResultsSortValue))
     expect(peopleSeachGenerator.next(lastResultSort).value).toEqual(call(get, '/api/v1/people', searchParams))
     expect(peopleSeachGenerator.throw(error).value).toEqual(put(loadMoreResultsFailure('Something went wrong')))
   })
@@ -58,18 +53,14 @@ describe('loadMorePeopleSearch', () => {
         hits: [],
       },
     }
-    const size = 25
     const peopleSeachGenerator = loadMorePeopleSearch(action)
-    expect(peopleSeachGenerator.next().value).toEqual(
-      select(selectSearchResultsCurrentRow)
-    )
-    expect(peopleSeachGenerator.next(size).value).toEqual(select(selectLastResultsSortValue))
+    expect(peopleSeachGenerator.next().value).toEqual(select(selectLastResultsSortValue))
     expect(peopleSeachGenerator.next(lastResultSort).value).toEqual(call(get, '/api/v1/people', {
       is_client_only: true,
       is_advanced_search_on: true,
       total_results_received: totalResultsReceived,
       person_search_fields: {last_name: 'doe'},
-      size: size,
+      size,
       search_after: lastResultSort,
     }))
     expect(peopleSeachGenerator.next(searchResults).value).toEqual(put(loadMoreResultsSuccess(searchResults)))


### PR DESCRIPTION
### Jira Story

https://osi-cwds.atlassian.net/browse/SNAP-1100

## Description
This PR fixes a bug in the search results table caused by the page size control. 

When a user changes the page size within the drop-down control, it is possible to request duplicate results. 

This can cause issues retrieving the first 250 results, because there would be duplicates within the 250 displayed in the results table. Once 250 results has been requested (even if they are duplicates), the ruby logic will not send any more results to the front-end.

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

