### PR TITLE
SNAP-1105 Fix County Filter in Search

### DIFF
--- a/app/javascript/reducers/peopleSearchReducer.js
+++ b/app/javascript/reducers/peopleSearchReducer.js
@@ -74,8 +74,7 @@ const setPersonSearchFieldErrorCheck = (state, {payload}) => {
 }
 
 const resetPersonSearchFields = state => {
-  const defaultCounty = state.get('defaultCounty') || ''
-  const searchFields = fromJS({...defaultSearchFieldsState, county: defaultCounty})
+  const searchFields = fromJS(defaultSearchFieldsState)
   return state.set('searchFields', searchFields)
 }
 
@@ -136,7 +135,7 @@ export default createReducer(initialState, {
     const searchFields = state.get('searchFields')
     const isCountyEmpty = searchFields.get('county') === ''
     const newState = state.set('defaultCounty', county)
-    const newSearchFields = searchFields.set('county', county)
+    const newSearchFields = searchFields.set('county', '')
     const newStateWithCounty = newState.set('searchFields', newSearchFields)
 
     return isCountyEmpty ? newStateWithCounty : newState

--- a/app/services/person_search_by_county_query_builder.rb
+++ b/app/services/person_search_by_county_query_builder.rb
@@ -8,7 +8,7 @@ module PersonSearchByCountyQueryBuilder
   include QueryBuilderHelper
 
   def build_query(builder)
-    builder.payload[:query][:function_score][:query][:bool][:must].concat(must)
+    builder.payload[:query][:function_score][:query][:bool][:filter] = must
   end
 
   def query
@@ -16,6 +16,8 @@ module PersonSearchByCountyQueryBuilder
   end
 
   def must
-    [match_query(field: 'sp_county', query: formatted_query(county))].flatten.compact
+    [
+      match_query(field: 'sp_county', query: formatted_query(county), name: 'q_county')
+    ].flatten.compact
   end
 end

--- a/spec/javascripts/reducers/peopleSearchReducerSpec.js
+++ b/spec/javascripts/reducers/peopleSearchReducerSpec.js
@@ -521,11 +521,11 @@ describe('peopleSearchReducer', () => {
   })
 
   describe('on FETCH_USER_INFO_COMPLETE', () => {
-    it('defaults the search county to the county of the user', () => {
+    it('defaults the search county to empty string', () => {
       const action = fetchUserInfoSuccess({county: 'Los Angeles'})
       const initialState = fromJS({searchFields: {county: ''}})
       const newState = peopleSearchReducer(initialState, action)
-      expect(newState.get('searchFields').get('county')).toEqual('Los Angeles')
+      expect(newState.get('searchFields').get('county')).toEqual('')
       expect(newState.get('defaultCounty')).toEqual('Los Angeles')
     })
     it('does not override an explicit user selection', () => {
@@ -548,7 +548,7 @@ describe('peopleSearchReducer', () => {
   })
 
   describe('on RESET_PERSON_SEARCH', () => {
-    it('clears everything and sets county to default', () => {
+    it('clears everything and sets county to empty string', () => {
       const action = resetPersonSearch()
       const initialState = fromJS({
         searchFields: {
@@ -591,7 +591,7 @@ describe('peopleSearchReducer', () => {
             sexAtBirth: '',
             address: '',
             city: '',
-            county: 'Sacramento',
+            county: '',
             state: '',
             country: '',
             zipCode: '',

--- a/spec/support/helpers/person_search_by_county_query_builder_helper.rb
+++ b/spec/support/helpers/person_search_by_county_query_builder_helper.rb
@@ -8,7 +8,8 @@ module PersonSearchByCountyQueryBuilderHelper
           {
             "match": {
               "sp_county": {
-                "query": 'yolo'
+                "query": 'yolo',
+                "_name": 'q_county'
               }
             }
           }

--- a/spec/support/helpers/person_search_by_name_query_builder_helper.rb
+++ b/spec/support/helpers/person_search_by_name_query_builder_helper.rb
@@ -275,11 +275,14 @@ module PersonSearchByNameQueryBuilderHelper
                     "_name": 'q_cli'
                   }
                 }
-              },
+              }
+            ],
+            "filter": [
               {
                 "match": {
                   "sp_county": {
-                    "query": 'yolo'
+                    "query": 'yolo',
+                    "_name": 'q_county'
                   }
                 }
               }


### PR DESCRIPTION
### Jira Story

https://osi-cwds.atlassian.net/browse/SNAP-1105

## Description
This fixes a bug in the search by county query builder that matched results based on county, instead of filtering results by county.

Also, we no longer default the county in the county drop-down, and leave it empty for the user to make a county selection.

![Screen Shot 2019-06-25 at 4 51 57 PM](https://user-images.githubusercontent.com/37000915/60141273-9ba2aa80-9769-11e9-90f7-8fa60b48eca7.png)

![Screen Shot 2019-06-25 at 4 52 13 PM](https://user-images.githubusercontent.com/37000915/60141280-a2312200-9769-11e9-9aff-fd5511860f70.png)


## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

