### PR TITLE
Approximate age bug fix

### DIFF
--- a/app/javascript/common/search/age/SearchByAgeMethodSelect.jsx
+++ b/app/javascript/common/search/age/SearchByAgeMethodSelect.jsx
@@ -8,6 +8,14 @@ class SearchByAgeMethodSelect extends React.Component {
     const {onChange} = this.props
     const isValidValue = value === 'dob' || value === 'approximate'
     onChange('searchByAgeMethod', isValidValue ? value : '')
+    if (value === 'approximate') { onChange('dateOfBirth', '') } else if (value === 'dob') {
+      onChange('approximateAge', '')
+      onChange('approximateAgeUnits', '')
+    } else if (value === '') {
+      onChange('dateOfBirth', '')
+      onChange('approximateAge', '')
+      onChange('approximateAgeUnits', '')
+    }
   }
 
   render() {

--- a/spec/javascripts/components/common/search/age/SearchByAgeMethodSelectSpec.jsx
+++ b/spec/javascripts/components/common/search/age/SearchByAgeMethodSelectSpec.jsx
@@ -57,6 +57,39 @@ describe('SearchByAgeMethodSelect', () => {
 
   describe('event handlers', () => {
     describe('onChange', () => {
+      describe('when approximate age is selected', () => {
+        it('clears the dob value', () => {
+          const onChange = jasmine.createSpy('onChange')
+          const selectField = render({onChange}).find('SelectField')
+          const event = {target: {value: 'approximate'}}
+          selectField.props().onChange(event)
+          expect(onChange).toHaveBeenCalledWith('dateOfBirth', '')
+        })
+      })
+
+      describe('when dob is selected', () => {
+        it('clears the approximate age value', () => {
+          const onChange = jasmine.createSpy('onChange')
+          const selectField = render({onChange}).find('SelectField')
+          const event = {target: {value: 'dob'}}
+          selectField.props().onChange(event)
+          expect(onChange).toHaveBeenCalledWith('approximateAge', '')
+          expect(onChange).toHaveBeenCalledWith('approximateAgeUnits', '')
+        })
+      })
+
+      describe('when empty value is selected', () => {
+        it('clears the dateOfBirth, approximateAge, approximateAgeUnits values', () => {
+          const onChange = jasmine.createSpy('onChange')
+          const selectField = render({onChange}).find('SelectField')
+          const event = {target: {value: ''}}
+          selectField.props().onChange(event)
+          expect(onChange).toHaveBeenCalledWith('dateOfBirth', '')
+          expect(onChange).toHaveBeenCalledWith('approximateAge', '')
+          expect(onChange).toHaveBeenCalledWith('approximateAgeUnits', '')
+        })
+      })
+
       describe('when the select field value is selected', () => {
         describe('to a valid value', () => {
           it('calls back with with the searchByAgeMethod', () => {


### PR DESCRIPTION
### Jira Story

No story

## Description
When selecting Approximate age, Search button was enabled because the `dateOfBirth` field value was not being cleared in the store. 
This PR will
1. clear the `dateOfBirth` value when Approximate age is selected.
2. clear the `approximateAge` and `approximateAgeUnits` value when Approximate age is selected.
3. clear the `dateOfBirth`, `approximateAge` and `approximateAgeUnits` value when blank is selected.
                    

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [ ] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [ ] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [ ] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

