### PR TITLE
Fix County Filter Bug - Partial Match on County Field

### DIFF
--- a/app/services/person_search_by_county_query_builder.rb
+++ b/app/services/person_search_by_county_query_builder.rb
@@ -17,7 +17,8 @@ module PersonSearchByCountyQueryBuilder
 
   def must
     [
-      match_query(field: 'sp_county', query: formatted_query(county), name: 'q_county')
+      match_query(field: 'sp_county', query: formatted_query(county), name: 'q_county',
+                  min_s_m: '100%')
     ].flatten.compact
   end
 end

--- a/spec/support/helpers/person_search_by_county_query_builder_helper.rb
+++ b/spec/support/helpers/person_search_by_county_query_builder_helper.rb
@@ -9,7 +9,8 @@ module PersonSearchByCountyQueryBuilderHelper
             "match": {
               "sp_county": {
                 "query": 'yolo',
-                "_name": 'q_county'
+                "_name": 'q_county',
+                "minimum_should_match": '100%'
               }
             }
           }

--- a/spec/support/helpers/person_search_by_name_query_builder_helper.rb
+++ b/spec/support/helpers/person_search_by_name_query_builder_helper.rb
@@ -282,7 +282,8 @@ module PersonSearchByNameQueryBuilderHelper
                 "match": {
                   "sp_county": {
                     "query": 'yolo',
-                    "_name": 'q_county'
+                    "_name": 'q_county',
+                    "minimum_should_match": '100%'
                   }
                 }
               }


### PR DESCRIPTION
### Jira Story

https://osi-cwds.atlassian.net/browse/SNAP-1105

## Description
This fixes a bug in Snapshot search that filters records based on partial matches on the county selected.

For example, searching for "San Francisco" might display results for "San Diego" because of a partial match on "San."

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [ ] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

