### PR TITLE
SNAP-1128 Fix Microsoft Edge's phone number styling issue

### DIFF
--- a/app/javascript/common/search/SearchResultsTable.jsx
+++ b/app/javascript/common/search/SearchResultsTable.jsx
@@ -82,7 +82,10 @@ class SearchResultsTable extends React.Component {
     {
       Header: 'Service Provider Phone',
       accessor: 'spPhone',
-      Cell: (row) => phoneNumberFormatter(row.original.spPhone),
+      Cell: (row) =>
+        <div x-ms-format-detection="none">
+          {phoneNumberFormatter(row.original.spPhone)}
+        </div>,
       ...commonStyle,
     },
     {

--- a/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
+++ b/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
@@ -272,6 +272,7 @@ describe('SearchResultsTable', () => {
         expect(cell.at(3).text()).toEqual('Female')
         expect(cell.at(4).text()).toEqual('pokhara')
         expect(cell.at(5).text()).toEqual('(111) 111-1111')
+        expect(cell.at(5).find('div').at(1).props()['x-ms-format-detection']).toEqual('none')
         expect(cell.at(6).text()).toEqual('4451 Anniversary Parkway, Lake Elsinore, CA 92530')
         expect(cell.at(7).text()).toEqual('Closed')
       })


### PR DESCRIPTION
### Jira Story

- [Service provider phone number styling issue](https://osi-cwds.atlassian.net/browse/SNAP-1128)

## Description
Fix Microsoft Edge's phone number styling. 

Reference:
https://stackoverflow.com/questions/31978346/remove-microsoft-edges-phone-number-styling
https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/dev-guides/dn265018(v=vs.85)

Before:
<img width="901" alt="Screen Shot 2019-07-09 at 11 44 42 AM" src="https://user-images.githubusercontent.com/24608948/60914759-06121b00-a23f-11e9-90bb-c3a017ec0c37.png">

After: 

<img width="723" alt="Screen Shot 2019-07-09 at 11 45 54 AM" src="https://user-images.githubusercontent.com/24608948/60914798-27730700-a23f-11e9-9b23-0da9ba637962.png">

## Tests
- [x] I have included unit tests 
- [ ] I have included feature tests 
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [x] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

