### PR TITLE
SNAP 1120 Let's Load All 250 Results at Once

### DIFF
--- a/app/helpers/query_builder_helper.rb
+++ b/app/helpers/query_builder_helper.rb
@@ -13,16 +13,6 @@ module QueryBuilderHelper
   MIN_SCORE = '2.5'
   MAX_RESULTS = 250
 
-  def calc_results_size(size, total_results_received)
-    if total_results_received == MAX_RESULTS
-      0.to_s
-    elsif size + total_results_received <= MAX_RESULTS
-      size.to_s
-    elsif size + total_results_received > MAX_RESULTS
-      (MAX_RESULTS - total_results_received).to_s
-    end
-  end
-
   def formatted_query(string)
     string.to_s.downcase.gsub(%r{[-/]*(\d+)[-/]*}, '\1').gsub(/[_%]/, '_' => '?', '%' => '*').strip
   end

--- a/app/javascript/common/search/Autocompleter.jsx
+++ b/app/javascript/common/search/Autocompleter.jsx
@@ -24,10 +24,7 @@ const itemClassName = (isHighlighted) => `search-item${isHighlighted ? ' highlig
 export default class Autocompleter extends Component {
   constructor(props) {
     super(props)
-    this.state = {
-      menuVisible: false,
-      currentPageNumber: 1,
-    }
+    this.state = {menuVisible: false, currentPageNumber: 1}
     this.hideMenu = this.hideMenu.bind(this)
     this.onItemSelect = this.onItemSelect.bind(this)
     this.renderMenu = this.renderMenu.bind(this)

--- a/app/javascript/common/search/Autocompleter.jsx
+++ b/app/javascript/common/search/Autocompleter.jsx
@@ -209,7 +209,7 @@ export default class Autocompleter extends Component {
   }
 
   renderPersonSearchFields() {
-    const {onChange, onCancel, onBlur, onFocus, personSearchFields, isAdvancedSearchOn, clientIdError, ssnErrors, dobErrors, canSearch, counties} = this.props
+    const {total, onChange, onCancel, onBlur, onFocus, personSearchFields, isAdvancedSearchOn, clientIdError, ssnErrors, dobErrors, canSearch, counties} = this.props
     const searchWithEnter = (e) => {
       const enterKeyCode = 13
       if ((canSearch && e.charCode === enterKeyCode)) { this.handleSubmit() }
@@ -231,6 +231,7 @@ export default class Autocompleter extends Component {
         onKeyUp={validateAndSetDateOfBirth}
         onFocus={onFocus}
         counties={counties}
+        total={total}
       />)
   }
 

--- a/app/javascript/common/search/PersonSearchButtonGroup.jsx
+++ b/app/javascript/common/search/PersonSearchButtonGroup.jsx
@@ -2,10 +2,13 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {PersonSearchFieldsDefaultProps} from 'data/personSearch'
 
+const LoadingIndicator = <i className='fa fa-spinner fa-spin-faster' />
+
 const PersonSearchButtonGroup = ({
   onSubmit,
   onCancel,
   canSearch,
+  total,
 }) => (
   <div className="row person-search-button-group">
     <div className="col-md-12">
@@ -14,7 +17,7 @@ const PersonSearchButtonGroup = ({
         onClick={onSubmit}
         disabled={!canSearch}
       >
-        Search
+        {total === null ? LoadingIndicator : 'Search'}
       </button>
       <button
         className="btn person-search-button clear"
@@ -30,6 +33,7 @@ PersonSearchButtonGroup.propTypes = {
   canSearch: PropTypes.bool,
   onCancel: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
+  total: PropTypes.number,
 }
 
 PersonSearchButtonGroup.defaultProps = PersonSearchFieldsDefaultProps

--- a/app/javascript/common/search/PersonSearchButtonGroup.jsx
+++ b/app/javascript/common/search/PersonSearchButtonGroup.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import {PersonSearchFieldsDefaultProps} from 'data/personSearch'
 
-const LoadingIndicator = <i className='fa fa-spinner fa-spin-faster' />
+const LoadingIndicator = <i aria-label='spinner' className='fa fa-spinner fa-spin-faster' />
 
 const PersonSearchButtonGroup = ({
   onSubmit,

--- a/app/javascript/common/search/PersonSearchFields.jsx
+++ b/app/javascript/common/search/PersonSearchFields.jsx
@@ -20,6 +20,7 @@ const PersonSearchFields = ({
   onKeyUp,
   onFocus,
   counties,
+  total,
 }) => isAdvancedSearchOn ? (
   <div>
     <PersonSearchNameGroup
@@ -43,6 +44,7 @@ const PersonSearchFields = ({
       onSubmit={onSubmit}
       onCancel={onCancel}
       canSearch={canSearch}
+      total={total}
     />
   </div>
 ) : null
@@ -65,6 +67,7 @@ PersonSearchFields.propTypes = {
   onSubmit: PropTypes.func.isRequired,
   personSearchFields: PersonSearchFieldsPropType,
   ssnErrors: PropTypes.array,
+  total: PropTypes.number,
 }
 
 export default PersonSearchFields

--- a/app/javascript/common/search/PersonSearchResults.jsx
+++ b/app/javascript/common/search/PersonSearchResults.jsx
@@ -8,12 +8,7 @@ const PersonSearchResults = (
   {
     total,
     personSearchFields,
-    onLoadMoreResults,
-    setCurrentPageNumber,
-    setCurrentRowNumber,
     results,
-    resultsSubset,
-    currentRow,
     onAuthorize,
     isSearchResults,
   }) => {
@@ -29,13 +24,8 @@ const PersonSearchResults = (
       show={
         <SearchResultsTable
           results={results}
-          resultsSubset={resultsSubset}
           total={total}
           personSearchFields={personSearchFields}
-          onLoadMoreResults={onLoadMoreResults}
-          setCurrentPageNumber={setCurrentPageNumber}
-          setCurrentRowNumber={setCurrentRowNumber}
-          currentRow={currentRow}
           onAuthorize={onAuthorize}
         />
       }
@@ -44,14 +34,9 @@ const PersonSearchResults = (
 }
 
 PersonSearchResults.propTypes = {
-  currentRow: PropTypes.number,
   onAuthorize: PropTypes.func,
-  onLoadMoreResults: PropTypes.func,
   personSearchFields: PropTypes.object,
   results: PropTypes.array,
-  resultsSubset: PropTypes.array,
-  setCurrentPageNumber: PropTypes.func,
-  setCurrentRowNumber: PropTypes.func,
   total: PropTypes.number,
 }
 

--- a/app/javascript/common/search/SearchResultsTable.jsx
+++ b/app/javascript/common/search/SearchResultsTable.jsx
@@ -15,7 +15,6 @@ import {removeHtmlTags} from 'utils/textFormatter'
 const commonStyle = {headerClassName: 'search-results-header'}
 
 class SearchResultsTable extends React.Component {
-
   columns = (onAuthorize) => [
     {
       Header: '',

--- a/app/javascript/common/search/SearchResultsTable.jsx
+++ b/app/javascript/common/search/SearchResultsTable.jsx
@@ -15,15 +15,6 @@ import {removeHtmlTags} from 'utils/textFormatter'
 const commonStyle = {headerClassName: 'search-results-header'}
 
 class SearchResultsTable extends React.Component {
-  constructor() {
-    super()
-    this.state = {previousPageNumber: 1}
-    this.fetchData = this.fetchData.bind(this)
-  }
-
-  componentDidUpdate() {
-    ReactTooltip.rebuild()
-  }
 
   columns = (onAuthorize) => [
     {
@@ -33,7 +24,7 @@ class SearchResultsTable extends React.Component {
       filterable: false,
       className: 'search-results',
       Cell: (row) => {
-        return `${(row.page * row.pageSize) + row.index + 1}.`
+        return `${row.index + 1}.`
       },
     },
     {
@@ -106,73 +97,20 @@ class SearchResultsTable extends React.Component {
     },
   ]
 
-  fetchData(currentPageNumber, currentPageSize) {
-    const {onLoadMoreResults, personSearchFields, results} = this.props
-    const totalResultsReceived = results.length
-    const totalResultsRequested = currentPageNumber * currentPageSize
-    onLoadMoreResults(personSearchFields, totalResultsReceived, totalResultsRequested)
-  }
-
-  calculateNumberOfPages(total, currentRow) {
-    const maxResults = 250
-    const totalForPageCount = total > maxResults ? maxResults : total
-    const pageCount = totalForPageCount / currentRow
-    return Math.ceil(pageCount)
-  }
-
-  haveResults(currentPageNumber, currentPageSize) {
-    const {results} = this.props
-    const totalResultsReceived = results.length
-    const totalResultsRequested = currentPageNumber * currentPageSize
-    const haveResults = totalResultsReceived >= totalResultsRequested
-    return haveResults
-  }
-
-  handlePageChange(pageIndex) {
-    const {currentRow, setCurrentPageNumber} = this.props
-    const {previousPageNumber} = this.state
-    const currentPageNumber = pageIndex + 1
-    const nextPageRequested = currentPageNumber > previousPageNumber
-    const requestResults = !this.haveResults(currentPageNumber, currentRow) && nextPageRequested
-    setCurrentPageNumber(currentPageNumber)
-    if (requestResults) {
-      this.fetchData(currentPageNumber, currentRow)
-    }
-    this.setState({previousPageNumber: currentPageNumber})
-  }
-
-  handlePageSizeChange(pageSize, pageIndex) {
-    const {currentRow, setCurrentRowNumber, setCurrentPageNumber} = this.props
-    const currentPageNumber = pageIndex + 1
-    const pageSizeIncreased = pageSize > currentRow
-    const requestResults = !this.haveResults(currentPageNumber, pageSize) && pageSizeIncreased
-    setCurrentPageNumber(currentPageNumber)
-    setCurrentRowNumber(pageSize)
-    if (requestResults) {
-      this.fetchData(currentPageNumber, pageSize)
-    }
-    this.setState({previousPageNumber: currentPageNumber})
-  }
-
   render() {
-    const {resultsSubset, total, currentRow, onAuthorize} = this.props
-    const noDataText = total > 0 ? 'Loading' : 'No Results Found'
+    const {results, total, onAuthorize} = this.props
+    const onPageChange = () => ReactTooltip.rebuild()
     return (
       <Fragment>
         <AlertMessageResultsLimit total={total} />
-        <InfoMessage total={total} />
-        {total > 0 &&
+        <InfoMessage total={results.length} />
+        {results.length > 0 &&
         <ReactTable
           columns={this.columns(onAuthorize)}
-          sortable={false}
-          manual
-          data={resultsSubset}
+          data={results}
           minRows={0}
-          pages={this.calculateNumberOfPages(total, currentRow)}
-          defaultPageSize={currentRow}
-          onPageChange={(pageIndex) => this.handlePageChange(pageIndex)}
-          onPageSizeChange={(pageSize, pageIndex) => this.handlePageSizeChange(pageSize, pageIndex)}
-          noDataText={noDataText}
+          defaultPageSize={25}
+          onPageChange={onPageChange}
         />}
       </Fragment>
     )
@@ -180,14 +118,9 @@ class SearchResultsTable extends React.Component {
 }
 
 SearchResultsTable.propTypes = {
-  currentRow: PropTypes.number,
   onAuthorize: PropTypes.func,
-  onLoadMoreResults: PropTypes.func,
   personSearchFields: PropTypes.object,
   results: PropTypes.array,
-  resultsSubset: PropTypes.array,
-  setCurrentPageNumber: PropTypes.func,
-  setCurrentRowNumber: PropTypes.func,
   total: PropTypes.number,
 }
 

--- a/app/javascript/containers/snapshot/PersonSearchResultsContainer.js
+++ b/app/javascript/containers/snapshot/PersonSearchResultsContainer.js
@@ -4,15 +4,8 @@ import {
   selectPeopleResults,
   selectResultsTotalValue,
   selectPersonSearchFields,
-  selectSearchResultsSubset,
-  selectSearchResultsCurrentRow,
   selectCheckSearchResults,
 } from 'selectors/peopleSearchSelectors'
-import {
-  loadMoreResults,
-  setSearchCurrentPage,
-  setSearchCurrentRow,
-} from 'actions/peopleSearchActions'
 import {authorizeSnapshotPerson} from 'actions/personCardActions'
 
 const mapStateToProps = state => {
@@ -25,9 +18,6 @@ const mapStateToProps = state => {
 }
 
 const mapDispatchToProps = (dispatch, ownProps) => {
-  const onLoadMoreResults = (personSearchFields, totalResultsReceived, totalResultsRequested) => {
-    dispatch(loadMoreResults(true, true, personSearchFields, totalResultsReceived, totalResultsRequested))
-  }
   const onAuthorize = (id) => dispatch(authorizeSnapshotPerson(id))
   return {onAuthorize, dispatch}
 }

--- a/app/javascript/containers/snapshot/PersonSearchResultsContainer.js
+++ b/app/javascript/containers/snapshot/PersonSearchResultsContainer.js
@@ -20,8 +20,6 @@ const mapStateToProps = state => {
     results: selectPeopleResults(state).toJS(),
     total: selectResultsTotalValue(state),
     personSearchFields: selectPersonSearchFields(state),
-    resultsSubset: selectSearchResultsSubset(state),
-    currentRow: selectSearchResultsCurrentRow(state),
     isSearchResults: selectCheckSearchResults(state),
   }
 }
@@ -30,10 +28,8 @@ const mapDispatchToProps = (dispatch, ownProps) => {
   const onLoadMoreResults = (personSearchFields, totalResultsReceived, totalResultsRequested) => {
     dispatch(loadMoreResults(true, true, personSearchFields, totalResultsReceived, totalResultsRequested))
   }
-  const setCurrentPageNumber = (pageNumber) => dispatch(setSearchCurrentPage(pageNumber))
-  const setCurrentRowNumber = (pageNumber) => dispatch(setSearchCurrentRow(pageNumber))
   const onAuthorize = (id) => dispatch(authorizeSnapshotPerson(id))
-  return {onLoadMoreResults, setCurrentPageNumber, setCurrentRowNumber, onAuthorize, dispatch}
+  return {onAuthorize, dispatch}
 }
 
 export default connect(

--- a/app/repositories/base_query_builder.rb
+++ b/app/repositories/base_query_builder.rb
@@ -86,7 +86,7 @@ class BaseQueryBuilder
 
   def build_query
     {
-      size:  250, track_scores: TRACK_SCORES,
+      size:  '250', track_scores: TRACK_SCORES,
       sort: sort, min_score: MIN_SCORE, _source: fields, highlight: highlight
     }.tap { |query| query[:search_after] = @search_after if @search_after }
   end

--- a/app/repositories/base_query_builder.rb
+++ b/app/repositories/base_query_builder.rb
@@ -86,7 +86,7 @@ class BaseQueryBuilder
 
   def build_query
     {
-      size:  calc_results_size(@size, @total_results_received), track_scores: TRACK_SCORES,
+      size:  250, track_scores: TRACK_SCORES,
       sort: sort, min_score: MIN_SCORE, _source: fields, highlight: highlight
     }.tap { |query| query[:search_after] = @search_after if @search_after }
   end

--- a/spec/javascripts/components/common/search/PersonSearchButtonGroupSpec.jsx
+++ b/spec/javascripts/components/common/search/PersonSearchButtonGroupSpec.jsx
@@ -6,12 +6,14 @@ const render = ({
   onCancel = () => {},
   onSubmit = () => {},
   canSearch = false,
+  total = 1,
 } = {}) =>
   shallow(
     <PersonSearchButtonGroup
       onCancel={onCancel}
       onSubmit={onSubmit}
       canSearch={canSearch}
+      total={total}
     />
   )
 
@@ -26,6 +28,12 @@ describe('PersonSearchButtonGroup', () => {
     const component = render()
     const searchButton = component.find('button.person-search-button.search')
     expect(searchButton.text()).toEqual('Search')
+  })
+
+  it('renders search button with a loading indicator when total is null', () => {
+    const component = render({total: null})
+    const loadingIndicator = component.find('button.person-search-button.search i')
+    expect(loadingIndicator.exists()).toBe(true)
   })
 
   it('renders clear button', () => {

--- a/spec/javascripts/components/common/search/PersonSearchResultsSpec.jsx
+++ b/spec/javascripts/components/common/search/PersonSearchResultsSpec.jsx
@@ -7,12 +7,7 @@ import SearchResultsTable from 'common/search/SearchResultsTable'
 const render = ({
   total = 0,
   results = [],
-  resultsSubset = [],
-  setCurrentPageNumber = () => {},
-  setCurrentRowNumber = () => {},
-  onLoadMoreResults = () => {},
   personSearchFields = {},
-  currentRow = 25,
   onAuthorize = () => {},
   isSearchResults = true,
 } = {}) => (
@@ -20,12 +15,7 @@ const render = ({
     <PersonSearchResults
       total={total}
       results={results}
-      resultsSubset={resultsSubset}
-      setCurrentPageNumber={setCurrentPageNumber}
-      setCurrentRowNumber={setCurrentRowNumber}
-      onLoadMoreResults={onLoadMoreResults}
       personSearchFields={personSearchFields}
-      currentRow={currentRow}
       onAuthorize={onAuthorize}
       isSearchResults={isSearchResults}
     />, {disableLifecycleMethods: true})
@@ -40,15 +30,9 @@ describe('PersonSearchResults', () => {
     })
 
     it('sets props on the CardView', () => {
-      const setCurrentPageNumber = () => {}
-      const setCurrentRowNumber = () => {}
-      const onLoadMoreResults = () => {}
       const onAuthorize = () => {}
       const componentProps = {
         total: 200,
-        setCurrentPageNumber,
-        setCurrentRowNumber,
-        onLoadMoreResults,
         onAuthorize,
       }
       const component = render(componentProps)
@@ -56,13 +40,8 @@ describe('PersonSearchResults', () => {
       const props = cardView.props()
       const tableProps = {
         results: [],
-        resultsSubset: [],
         total: 200,
         personSearchFields: {},
-        onLoadMoreResults,
-        setCurrentPageNumber,
-        setCurrentRowNumber,
-        currentRow: 25,
         onAuthorize,
       }
       const table = (<SearchResultsTable {...tableProps} />)

--- a/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
+++ b/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
@@ -113,24 +113,14 @@ const defaultMockedResults = [
 const render = (
   {
     results = [],
-    resultsSubset = [],
-    setCurrentPageNumber = () => {},
-    setCurrentRowNumber = () => {},
-    onLoadMoreResults = () => {},
     personSearchFields = {},
-    currentRow = 25,
     total = 1,
     onAuthorize = () => {},
   } = {}) => {
   return mount(
     <SearchResultsTable
       results={results}
-      resultsSubset={resultsSubset}
-      setCurrentPageNumber={setCurrentPageNumber}
-      setCurrentRowNumber={setCurrentRowNumber}
-      onLoadMoreResults={onLoadMoreResults}
       personSearchFields={personSearchFields}
-      currentRow={currentRow}
       total={total}
       onAuthorize={onAuthorize}
     />, {disableLifecycleMethods: true})
@@ -139,7 +129,7 @@ const render = (
 describe('SearchResultsTable', () => {
   let component
   beforeEach(() => {
-    component = render({resultsSubset: defaultMockedResults})
+    component = render({results: defaultMockedResults})
   })
 
   describe('layout', () => {
@@ -163,86 +153,11 @@ describe('SearchResultsTable', () => {
       it('renders a table', () => {
         const table = component.find('ReactTable')
         expect(table.exists()).toBe(true)
-        expect(table.props().sortable).toBe(false)
       })
 
       it('doesnot render a table when total is 0', () => {
         const table = render({total: 0}).find('ReactTable')
         expect(table.exists()).toBe(false)
-      })
-
-      describe('page count', () => {
-        describe('when the total number of results is 250 or less', () => {
-          describe('when the total is 198', () => {
-            describe('and the number of rows per page is 5', () => {
-              it('sets the page count to 40', () => {
-                const totalResults = 198
-                const numOfResultsPerPage = 5
-                const expectedPageCount = 40
-                const component = render({total: totalResults, currentRow: numOfResultsPerPage})
-                const table = component.find('ReactTable')
-                const pages = table.props().pages
-                expect(pages).toBe(expectedPageCount)
-              })
-            })
-          })
-
-          describe('when the total is 140', () => {
-            describe('and the number of rows per page is 100', () => {
-              it('sets the page count to 2', () => {
-                const totalResults = 140
-                const numOfResultsPerPage = 100
-                const expectedPageCount = 2
-                const component = render({total: totalResults, currentRow: numOfResultsPerPage})
-                const table = component.find('ReactTable')
-                const pages = table.props().pages
-                expect(pages).toBe(expectedPageCount)
-              })
-            })
-          })
-        })
-
-        describe('when the total number of results is 251 or more', () => {
-          describe('when the total is 801', () => {
-            describe('and the number of rows per page is 20', () => {
-              it('sets the page count to 13', () => {
-                const totalResults = 801
-                const numOfResultsPerPage = 20
-                const expectedPageCount = 13
-                const component = render({total: totalResults, currentRow: numOfResultsPerPage})
-                const table = component.find('ReactTable')
-                const pages = table.props().pages
-                expect(pages).toBe(expectedPageCount)
-              })
-            })
-          })
-
-          describe('when the total is 684', () => {
-            describe('and the number of rows per page is 50', () => {
-              it('sets the page count to 5', () => {
-                const totalResults = 684
-                const numOfResultsPerPage = 50
-                const expectedPageCount = 5
-                const component = render({total: totalResults, currentRow: numOfResultsPerPage})
-                const table = component.find('ReactTable')
-                const pages = table.props().pages
-                expect(pages).toBe(expectedPageCount)
-              })
-            })
-          })
-        })
-      })
-
-      describe('no data text', () => {
-        describe('when the total results is greater than zero', () => {
-          it('sets the noDataText prop to "Loading"', () => {
-            const total = 1
-            const component = render({total})
-            const searchResultsTable = component.find('ReactTable')
-            const noDataText = searchResultsTable.props().noDataText
-            expect(noDataText).toBe('Loading')
-          })
-        })
       })
 
       it('renders the table headers', () => {
@@ -285,172 +200,6 @@ describe('SearchResultsTable', () => {
     })
   })
 
-  describe('onPageChange', () => {
-    describe('setCurrentPageNumber', () => {
-      describe('when the page is changed', () => {
-        it('setCurrentPageNumber is called with the current page number', () => {
-          const setCurrentPageNumber = jasmine.createSpy('setCurrentPageNumber')
-          const component = render({setCurrentPageNumber})
-          const searchResultsTable = component.find('ReactTable')
-          const zeroIndexedNextPageNumber = 1
-          const nextPageNumber = 2
-          searchResultsTable.props().onPageChange(zeroIndexedNextPageNumber)
-          expect(setCurrentPageNumber).toHaveBeenCalledWith(nextPageNumber)
-        })
-      })
-    })
-
-    describe('onLoadMoreResults', () => {
-      describe('when the next page is requested', () => {
-        describe('and we have not requested the results for the next page', () => {
-          it('onLoadMoreResults is called with personSearchFields and totalResultsReceived', () => {
-            const nextPageNumber = 2
-            const pageSize = 25
-            const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-            const personSearchFields = {lastName: 'laure'}
-            const results = generateMockResults(25)
-            const totalResultsReceived = results.length
-            const totalResultsRequested = nextPageNumber * pageSize
-            const component = render({
-              currentRow: pageSize,
-              results,
-              onLoadMoreResults,
-              personSearchFields,
-            })
-            const searchResultsTable = component.find('ReactTable')
-            const zeroIndexedNextPageNumber = 1
-            searchResultsTable.props().onPageChange(zeroIndexedNextPageNumber)
-            expect(onLoadMoreResults).toHaveBeenCalledWith(personSearchFields, totalResultsReceived, totalResultsRequested)
-          })
-        })
-
-        describe('and we have requested the results for the next page', () => {
-          it('onLoadMoreResults is not called', () => {
-            const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-            const results = generateMockResults(50)
-            const component = render({
-              results,
-              onLoadMoreResults,
-            })
-            const searchResultsTable = component.find('ReactTable')
-            searchResultsTable.props().onPageChange(1)
-            expect(onLoadMoreResults).not.toHaveBeenCalled()
-          })
-        })
-      })
-
-      describe('when the previous page is requested', () => {
-        it('onLoadMoreResults is not called', () => {
-          const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-          const component = render({onLoadMoreResults})
-          const searchResultsTable = component.find('ReactTable')
-          searchResultsTable.props().onPageChange(-1)
-          expect(onLoadMoreResults).not.toHaveBeenCalled()
-        })
-      })
-    })
-
-    it('sets the previous page state to the new page number', () => {
-      const component = render({})
-      const previousPageNumberBeforePageChange = component.state().previousPageNumber
-      const currentPageNumber = 1
-      expect(previousPageNumberBeforePageChange).toBe(currentPageNumber)
-      const searchResultsTable = component.find('ReactTable')
-      const zeroIndexedNextPageNumber = 1
-      const nextPageNumber = 2
-      searchResultsTable.props().onPageChange(zeroIndexedNextPageNumber)
-      const previousPageNumberAfterPageChange = component.state().previousPageNumber
-      expect(previousPageNumberAfterPageChange).toBe(nextPageNumber)
-    })
-  })
-
-  describe('onPageSizeChange', () => {
-    it('calls setCurrentRowNumber with current page size', () => {
-      const setCurrentRowNumber = jasmine.createSpy('setCurrentRowNumber')
-      const component = render({resultsSubset: defaultMockedResults, setCurrentRowNumber})
-      const searchResultsTable = component.find('ReactTable')
-      const pageSize = 5
-      const zeroIndexedNextPageNumber = 1
-      searchResultsTable.props().onPageSizeChange(pageSize, zeroIndexedNextPageNumber)
-      expect(setCurrentRowNumber).toHaveBeenCalledWith(5)
-    })
-
-    it('calls setCurrentPageNumber with current page', () => {
-      const setCurrentPageNumber = jasmine.createSpy('setCurrentPageNumber')
-      const component = render({resultsSubset: defaultMockedResults, setCurrentPageNumber})
-      const searchResultsTable = component.find('ReactTable')
-      searchResultsTable.props().onPageSizeChange(5, 1)
-      expect(setCurrentPageNumber).toHaveBeenCalledWith(2)
-    })
-
-    describe('onLoadMoreResults', () => {
-      describe('when the page size is increased', () => {
-        describe('and we have do not have all the results to display', () => {
-          it('onLoadMoreResults is called', () => {
-            const currentPageNumber = 1
-            const pageSize = 50
-            const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-            const personSearchFields = {lastName: 'Bravo'}
-            const results = generateMockResults(25)
-            const totalResultsReceived = results.length
-            const totalResultsRequested = currentPageNumber * pageSize
-            const component = render({
-              results,
-              onLoadMoreResults,
-              personSearchFields,
-            })
-            const searchResultsTable = component.find('ReactTable')
-            const zeroIndexedNextPageNumber = 0
-            searchResultsTable.props().onPageSizeChange(pageSize, zeroIndexedNextPageNumber)
-            expect(onLoadMoreResults).toHaveBeenCalledWith(personSearchFields, totalResultsReceived, totalResultsRequested)
-          })
-        })
-
-        describe('and we do have all the results to display', () => {
-          it('onLoadMoreResults is not called', () => {
-            const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-            const results = generateMockResults(50)
-            const component = render({
-              results,
-              onLoadMoreResults,
-            })
-            const searchResultsTable = component.find('ReactTable')
-            const pageSize = 50
-            const zeroIndexedNextPageNumber = 0
-            searchResultsTable.props().onPageSizeChange(pageSize, zeroIndexedNextPageNumber)
-            expect(onLoadMoreResults).not.toHaveBeenCalled()
-          })
-        })
-      })
-
-      describe('when the page size is decreased', () => {
-        it('onLoadMoreResults is not called', () => {
-          const onLoadMoreResults = jasmine.createSpy('onLoadMoreResults')
-          const component = render({onLoadMoreResults})
-          const searchResultsTable = component.find('ReactTable')
-          const pageSize = 5
-          const zeroIndexedNextPageNumber = 1
-          searchResultsTable.props().onPageSizeChange(pageSize, zeroIndexedNextPageNumber)
-          expect(onLoadMoreResults).not.toHaveBeenCalled()
-        })
-      })
-    })
-
-    it('sets the previous page state to the new page number', () => {
-      const component = render({})
-      const previousPageNumberBeforePageChange = component.state().previousPageNumber
-      const currentPageNumber = 1
-      expect(previousPageNumberBeforePageChange).toBe(currentPageNumber)
-      const searchResultsTable = component.find('ReactTable')
-      const pageSize = 50
-      const zeroIndexedNextPageNumber = 1
-      const nextPageNumber = 2
-      searchResultsTable.props().onPageSizeChange(pageSize, zeroIndexedNextPageNumber)
-      const previousPageNumberAfterPageChange = component.state().previousPageNumber
-      expect(previousPageNumberAfterPageChange).toBe(nextPageNumber)
-    })
-  })
-
   describe('Sealed', () => {
     it('renders Link', () => {
       const row = component.find('div.rt-tr-group').at(0)
@@ -466,6 +215,14 @@ describe('SearchResultsTable', () => {
         .toBe('fa fa-eye-slash search-information-flag')
       expect(cell.find('span i').exists()).toBe(true)
     })
+
+    it('rebuilds the tooltip when navigating', () => {
+      const rebuild = spyOn(ReactTooltip, 'rebuild')
+      const component = render({results: defaultMockedResults})
+      const table = component.find('ReactTable')
+      table.props().onPageChange()
+      expect(rebuild).toHaveBeenCalled()
+    })
   })
 
   describe('Sensitive', () => {
@@ -479,19 +236,10 @@ describe('SearchResultsTable', () => {
     })
   })
 
-  describe('ComponentDidUpdate', () => {
-    it('rebuild reacttooltip', () => {
-      const rebuild = spyOn(ReactTooltip, 'rebuild')
-      const currentRow = 10
-      component.setProps({currentRow: currentRow})
-      expect(rebuild).toHaveBeenCalled()
-    })
-  })
-
   describe('onClick', () => {
     it('calls onAuthorize with id', () => {
       const onAuthorize = jasmine.createSpy('onClick')
-      const wrapper = render({resultsSubset: defaultMockedResults, onAuthorize})
+      const wrapper = render({results: defaultMockedResults, onAuthorize})
       const row = wrapper.find('div.rt-tr-group').at(0)
       const cell = row.find('div.rt-td').at(1)
       cell.find('button').props().onClick()

--- a/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
+++ b/spec/javascripts/components/common/search/SearchResultsTableSpec.jsx
@@ -3,15 +3,6 @@ import SearchResultsTable from 'common/search/SearchResultsTable'
 import {mount} from 'enzyme'
 import ReactTooltip from 'react-tooltip'
 
-const generateMockResults = (numberOfResults) => {
-  const results = []
-  for (let x = 0; x < numberOfResults; x++) {
-    const result = {'legacyDescriptor': {legacy_id: `${x}`}}
-    results.push(result)
-  }
-  return results
-}
-
 const defaultMockedResults = [
   {
     'gender': 'female',

--- a/spec/repositories/query_builder_spec.rb
+++ b/spec/repositories/query_builder_spec.rb
@@ -238,48 +238,6 @@ describe QueryBuilder do
         expect(query[:search_after]).to eq search_after
       end
     end
-
-    context 'when the total results received is 250' do
-      let(:size) { '25' }
-      let(:expected_size) { '0' }
-      let(:total_results_received) { '250' }
-
-      it 'builds a person search query that returns 0 results' do
-        query = described_class.new(
-          size: size,
-          total_results_received: total_results_received
-        ).build_query
-        expect(query[:size]).to eq expected_size
-      end
-    end
-
-    context 'when the sum of the size and total results received is 250 or less' do
-      let(:size) { '100' }
-      let(:expected_size) { '100' }
-      let(:total_results_received) { '100' }
-
-      it 'builds a person search query that returns 100 results' do
-        query = described_class.new(
-          size: size,
-          total_results_received: total_results_received
-        ).build_query
-        expect(query[:size]).to eq expected_size
-      end
-    end
-
-    context 'when the sum of the size and total results received is over 250' do
-      let(:size) { '100' }
-      let(:expected_size) { '50' }
-      let(:total_results_received) { '200' }
-
-      it 'builds a person search query that returns 50 results' do
-        query = described_class.new(
-          size: size,
-          total_results_received: total_results_received
-        ).build_query
-        expect(query[:size]).to eq expected_size
-      end
-    end
   end
 
   describe '#build' do
@@ -290,7 +248,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq client_id_only_query['_source']
-        expect(result['size']).to eq client_id_only_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq client_id_only_query['sort']
         expect(result['track_scores']).to eq client_id_only_query['track_scores']
         expect(result['query']).to eq client_id_only_query['query']
@@ -305,7 +263,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq no_name_query['_source']
-        expect(result['size']).to eq no_name_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq no_name_query['sort']
         expect(result['track_scores']).to eq no_name_query['track_scores']
         expect(result['query']).to eq no_name_query['query']
@@ -318,7 +276,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_name_approx_age_years_gender_query['_source']
-        expect(result['size']).to eq last_name_approx_age_years_gender_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq last_name_approx_age_years_gender_query['sort']
         expect(result['track_scores']).to eq last_name_approx_age_years_gender_query['track_scores']
         expect(result['query']).to eq last_name_approx_age_years_gender_query['query']
@@ -331,7 +289,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_name_suffix_approx_age_years_gender_query['_source']
-        expect(result['size']).to eq last_name_suffix_approx_age_years_gender_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq last_name_suffix_approx_age_years_gender_query['sort']
         expect(
           result['track_scores']
@@ -346,7 +304,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_and_first_name_with_suffix_query['_source']
-        expect(result['size']).to eq last_and_first_name_with_suffix_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq last_and_first_name_with_suffix_query['sort']
         expect(result['track_scores']).to eq last_and_first_name_with_suffix_query['track_scores']
         expect(result['query']).to eq last_and_first_name_with_suffix_query['query']
@@ -359,7 +317,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_and_first_name_query['_source']
-        expect(result['size']).to eq last_and_first_name_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq last_and_first_name_query['sort']
         expect(result['track_scores']).to eq last_and_first_name_query['track_scores']
         expect(result['query']).to eq last_and_first_name_query['query']
@@ -372,7 +330,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_first_name_with_suffix_county_query['_source']
-        expect(result['size']).to eq last_first_name_with_suffix_county_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq last_first_name_with_suffix_county_query['sort']
         expect(
           result['track_scores']
@@ -387,7 +345,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_first_name_with_suffix_dob_query['_source']
-        expect(result['size']).to eq last_first_name_with_suffix_dob_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq last_first_name_with_suffix_dob_query['sort']
         expect(result['track_scores']).to eq last_first_name_with_suffix_dob_query['track_scores']
         expect(result['query']).to eq last_first_name_with_suffix_dob_query['query']
@@ -405,7 +363,7 @@ describe QueryBuilder do
         ).to eq last_first_name_with_suffix_approx_age_months_gender_query['_source']
         expect(
           result['size']
-        ).to eq last_first_name_with_suffix_approx_age_months_gender_query['size']
+        ).to eq 250
         expect(
           result['sort']
         ).to eq last_first_name_with_suffix_approx_age_months_gender_query['sort']
@@ -429,7 +387,7 @@ describe QueryBuilder do
         ).to eq last_first_name_with_suffix_approx_age_years_gender_query['_source']
         expect(
           result['size']
-        ).to eq last_first_name_with_suffix_approx_age_years_gender_query['size']
+        ).to eq 250
         expect(
           result['sort']
         ).to eq last_first_name_with_suffix_approx_age_years_gender_query['sort']
@@ -451,7 +409,7 @@ describe QueryBuilder do
         expect(
           result['_source']
         ).to eq last_first_name_approx_age_months_gender_query['_source']
-        expect(result['size']).to eq last_first_name_approx_age_months_gender_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq last_first_name_approx_age_months_gender_query['sort']
         expect(
           result['track_scores']
@@ -473,7 +431,7 @@ describe QueryBuilder do
         ).to eq last_middle_first_name_with_suffix_approx_age_years_gender_query['_source']
         expect(
           result['size']
-        ).to eq last_middle_first_name_with_suffix_approx_age_years_gender_query['size']
+        ).to eq 250
         expect(
           result['sort']
         ).to eq last_middle_first_name_with_suffix_approx_age_years_gender_query['sort']
@@ -495,7 +453,7 @@ describe QueryBuilder do
         expect(
           result['_source']
         ).to eq last_middle_first_name_approx_age_months_gender_query['_source']
-        expect(result['size']).to eq last_middle_first_name_approx_age_months_gender_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq last_middle_first_name_approx_age_months_gender_query['sort']
         expect(
           result['track_scores']
@@ -511,7 +469,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq ssn_only_query['_source']
-        expect(result['size']).to eq ssn_only_query['size']
+        expect(result['size']).to eq 250
         expect(result['sort']).to eq ssn_only_query['sort']
         expect(result['track_scores']).to eq ssn_only_query['track_scores']
         expect(result['query']).to eq ssn_only_query['query']

--- a/spec/repositories/query_builder_spec.rb
+++ b/spec/repositories/query_builder_spec.rb
@@ -248,7 +248,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq client_id_only_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq client_id_only_query['sort']
         expect(result['track_scores']).to eq client_id_only_query['track_scores']
         expect(result['query']).to eq client_id_only_query['query']
@@ -263,7 +263,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq no_name_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq no_name_query['sort']
         expect(result['track_scores']).to eq no_name_query['track_scores']
         expect(result['query']).to eq no_name_query['query']
@@ -276,7 +276,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_name_approx_age_years_gender_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq last_name_approx_age_years_gender_query['sort']
         expect(result['track_scores']).to eq last_name_approx_age_years_gender_query['track_scores']
         expect(result['query']).to eq last_name_approx_age_years_gender_query['query']
@@ -289,7 +289,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_name_suffix_approx_age_years_gender_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq last_name_suffix_approx_age_years_gender_query['sort']
         expect(
           result['track_scores']
@@ -304,7 +304,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_and_first_name_with_suffix_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq last_and_first_name_with_suffix_query['sort']
         expect(result['track_scores']).to eq last_and_first_name_with_suffix_query['track_scores']
         expect(result['query']).to eq last_and_first_name_with_suffix_query['query']
@@ -317,7 +317,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_and_first_name_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq last_and_first_name_query['sort']
         expect(result['track_scores']).to eq last_and_first_name_query['track_scores']
         expect(result['query']).to eq last_and_first_name_query['query']
@@ -330,7 +330,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_first_name_with_suffix_county_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq last_first_name_with_suffix_county_query['sort']
         expect(
           result['track_scores']
@@ -345,7 +345,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq last_first_name_with_suffix_dob_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq last_first_name_with_suffix_dob_query['sort']
         expect(result['track_scores']).to eq last_first_name_with_suffix_dob_query['track_scores']
         expect(result['query']).to eq last_first_name_with_suffix_dob_query['query']
@@ -363,7 +363,7 @@ describe QueryBuilder do
         ).to eq last_first_name_with_suffix_approx_age_months_gender_query['_source']
         expect(
           result['size']
-        ).to eq 250
+        ).to eq '250'
         expect(
           result['sort']
         ).to eq last_first_name_with_suffix_approx_age_months_gender_query['sort']
@@ -387,7 +387,7 @@ describe QueryBuilder do
         ).to eq last_first_name_with_suffix_approx_age_years_gender_query['_source']
         expect(
           result['size']
-        ).to eq 250
+        ).to eq '250'
         expect(
           result['sort']
         ).to eq last_first_name_with_suffix_approx_age_years_gender_query['sort']
@@ -409,7 +409,7 @@ describe QueryBuilder do
         expect(
           result['_source']
         ).to eq last_first_name_approx_age_months_gender_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq last_first_name_approx_age_months_gender_query['sort']
         expect(
           result['track_scores']
@@ -431,7 +431,7 @@ describe QueryBuilder do
         ).to eq last_middle_first_name_with_suffix_approx_age_years_gender_query['_source']
         expect(
           result['size']
-        ).to eq 250
+        ).to eq '250'
         expect(
           result['sort']
         ).to eq last_middle_first_name_with_suffix_approx_age_years_gender_query['sort']
@@ -453,7 +453,7 @@ describe QueryBuilder do
         expect(
           result['_source']
         ).to eq last_middle_first_name_approx_age_months_gender_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq last_middle_first_name_approx_age_months_gender_query['sort']
         expect(
           result['track_scores']
@@ -469,7 +469,7 @@ describe QueryBuilder do
           size: '25'
         ).payload.as_json
         expect(result['_source']).to eq ssn_only_query['_source']
-        expect(result['size']).to eq 250
+        expect(result['size']).to eq '250'
         expect(result['sort']).to eq ssn_only_query['sort']
         expect(result['track_scores']).to eq ssn_only_query['track_scores']
         expect(result['query']).to eq ssn_only_query['query']

--- a/spec/support/helpers/query_builder_helper.rb
+++ b/spec/support/helpers/query_builder_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module QueryBuilderHelper
-  SIZE = '25'
+  SIZE = '250'
   TRACK_SCORES = 'true'
   MIN_SCORE = '2.5'
 


### PR DESCRIPTION
### Jira Story

- ['Loading'  issue in staging env INT-NNN](https://osi-cwds.atlassian.net/browse/INT-1120)

## Description
The root cause of this bug is calculation logic for fetching batches of results at one time. The fix is to fetch all results (up to 250) at once and then handle pagination and other table functionality on the client side.

A bonus of this change, is that we can sort again.
## Tests
- [x] I have included unit tests 
- [x] I have included feature tests
- [x] I have removed unit tests
- [x] I have removed feature tests
- [ ] I have included other tests 
- [ ] I have NOT included tests 
<!--- Please indicate why tests were not added. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (No behavioral changes)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->
- [x] My code follows the code style of this project.
- [ ] I have ran all tests for the project.
- [x] I have ran lint/rubocop check for the changed/new files.
- [x] My code is in a stable state ready to be deployable, but not necessarily complete.
- [x] I promise on my honor as a CWDS developer to ensure I don't break the build, to check Lint/Rubocop, use best practices, to leave the code in better shape than I found it, and to have a good day.

